### PR TITLE
Redact contact person information if plan is configured so

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -56,6 +56,7 @@ from ..action_status_summary import ActionStatusSummaryIdentifier, ActionTimelin
 from ..attributes import AttributeFieldPanel, AttributeType
 from ..monitoring_quality import determine_monitoring_quality
 from .attributes import AttributeType as AttributeTypeModel, ModelWithAttributes
+from .features import PlanFeatures
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -65,7 +66,7 @@ if typing.TYPE_CHECKING:
 
     from kausal_common.models.types import FK, M2M, GetDisplayMethod, RevMany
 
-    from aplans.cache import WatchObjectCache
+    from aplans.cache import PlanSpecificCache, WatchObjectCache
     from aplans.graphql_types import WorkflowStateEnum
     from aplans.types import UserOrAnon
 
@@ -896,6 +897,40 @@ class Action(
         # No plan context needed just to get the color
         summary = ActionStatusSummaryIdentifier.for_action(self)
         return summary.value.color
+
+    def get_redacted_contact_persons(
+        self,
+        user: UserOrAnon,
+        show_all_contact_persons: bool,  # TODO: clarify what this means
+        cache: PlanSpecificCache | None = None,
+    ):
+        """Get contact persons but redact data that should not be revealed according to plan features."""
+        if self.plan.features.contact_persons_public_data == PlanFeatures.ContactPersonsPublicData.NONE:
+            return self.contact_persons.none()
+
+        visible_contact_persons = []
+        for acp in self.contact_persons.all():
+            if cache is None:
+                person = acp.person
+            else:
+                person = cache.get_person(acp.person_id) or acp.person
+            if not person.visible_for_user(user=user, plan=self.plan):
+                continue
+            visible_contact_persons.append(acp)
+        if self.plan.features.contact_persons_hide_moderators and (
+            not show_all_contact_persons or not user.is_authenticated or not user.can_access_admin(self.plan)
+        ):
+            visible_contact_persons = [acp for acp in visible_contact_persons if not acp.is_moderator()]
+
+        if self.plan.features.contact_persons_public_data == PlanFeatures.ContactPersonsPublicData.ALL:
+            return visible_contact_persons
+
+        # Need to redact due to setting of self.plan.features.contact_persons_public_data
+        for cp in visible_contact_persons:
+            cp.person = cp.person.get_redacted_copy(self.plan)
+        return visible_contact_persons
+
+
 
     def get_workflow(self):
         return self.plan.features.moderation_workflow

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1005,6 +1005,17 @@ class Action(
         from .action_deps import ActionDependencyRelationship
         return ActionDependencyRelationship.objects.qs.all_for_action(self).visible_for_user(user, plan)
 
+    def has_contact_person_from_organization(
+        self,
+        organization: Organization,
+        include_suborganizations: bool = True,
+    ) -> bool:
+        if include_suborganizations:
+            filter_kwargs = {'organization__path__startswith': organization.path}
+        else:
+            filter_kwargs = {'organization': organization.path}
+        return self.contact_persons_unordered.filter(**filter_kwargs).exists()
+
 
 class ModelWithRole[ModelRole: 'ModelWithRole.Role']:  # pyright: ignore
     role: models.CharField[str | None, str | None]

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1273,10 +1273,16 @@ class ActionImplementationPhaseNode(DjangoNode):
 
 
 class ActionResponsiblePartyNode(DjangoNode):
+    has_contact_person = graphene.Boolean(required=True)
+
     @staticmethod
     def resolve_organization(root: ActionResponsibleParty, info) -> Organization:
         cache = info.context.watch_cache.for_plan_id(root.action.plan_id)
         return cache.get_organization(root.organization_id) or root.organization
+
+    @staticmethod
+    def resolve_has_contact_person(root: ActionResponsibleParty, info: GQLInfo) -> bool:
+        return root.action.has_contact_person_from_organization(root.organization, include_suborganizations=True)
 
     class Meta:
         model = ActionResponsibleParty

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1187,18 +1187,10 @@ class ActionNode(AdminButtonsMixin, AttributesMixin, DjangoNode):
     )
     def resolve_contact_persons(root: Action, info: GQLInfo, show_all_contact_persons: bool):
         plan: Plan = get_plan_from_context(info)
+        assert plan == root.plan
         user = info.context.user
-        acps = []
         cache = info.context.watch_cache.for_plan(plan)
-        for acp in root.contact_persons.all():
-            person = cache.get_person(acp.person_id) or acp.person
-            if not person.visible_for_user(user=user, plan=plan):
-                continue
-            acps.append(acp)
-        if plan.features.contact_persons_hide_moderators and (
-            not show_all_contact_persons or not user.is_authenticated or not user.can_access_admin(plan)):
-            acps = [acp for acp in acps if not acp.is_moderator()]
-        return acps
+        return root.get_redacted_contact_persons(user, show_all_contact_persons, cache)
 
     @staticmethod
     def resolve_similar_actions(root: Action, info):

--- a/actions/tests/test_schema.py
+++ b/actions/tests/test_schema.py
@@ -1,9 +1,8 @@
-from datetime import date
-from decimal import Decimal
+from __future__ import annotations
 
 import pytest
 
-from actions.models.features import OrderBy
+from actions.models.features import OrderBy, PlanFeatures
 from actions.tests.factories import (
     ActionContactFactory,
     ActionFactory,
@@ -25,8 +24,8 @@ from actions.tests.factories import (
 )
 from indicators.tests.factories import ActionIndicatorFactory, IndicatorFactory, IndicatorLevelFactory
 from pages.tests.factories import CategoryPageFactory
+
 from .fixtures import *
-from actions.models.features import PlanFeatures
 
 pytestmark = pytest.mark.django_db
 
@@ -1700,7 +1699,7 @@ def test_action_contact_persons_redacted(graphql_client_query_data, public_data)
     person = action_contact.person
     assert person.email
     data = graphql_client_query_data(
-        '''
+        """
         query($action: ID!) {
           action(id: $action) {
             contactPersons {
@@ -1716,8 +1715,8 @@ def test_action_contact_persons_redacted(graphql_client_query_data, public_data)
             }
           }
         }
-        ''',
-        variables={'action': action.id}
+        """,
+        variables={'action': action.id},
     )
     if public_data == PlanFeatures.ContactPersonsPublicData.NONE:
         expected_contact_persons = []
@@ -1727,7 +1726,7 @@ def test_action_contact_persons_redacted(graphql_client_query_data, public_data)
         elif public_data == PlanFeatures.ContactPersonsPublicData.ALL:
             expected_email = person.email
         else:
-            assert False
+            pytest.fail("invalid ContactPersonsPublicData value")
         expected_contact_persons = [{
             'person': {
                 'firstName': person.first_name,
@@ -1741,8 +1740,8 @@ def test_action_contact_persons_redacted(graphql_client_query_data, public_data)
         }]
     expected = {
         'action': {
-            'contactPersons': expected_contact_persons
-        }
+            'contactPersons': expected_contact_persons,
+        },
     }
     assert data == expected
 

--- a/actions/tests/test_schema.py
+++ b/actions/tests/test_schema.py
@@ -25,8 +25,8 @@ from actions.tests.factories import (
 )
 from indicators.tests.factories import ActionIndicatorFactory, IndicatorFactory, IndicatorLevelFactory
 from pages.tests.factories import CategoryPageFactory
-
 from .fixtures import *
+from actions.models.features import PlanFeatures
 
 pytestmark = pytest.mark.django_db
 
@@ -1684,6 +1684,65 @@ def test_action_contact_person_node(graphql_client_query_data):
                 'primaryContact': action_contact.primary_contact,
             }],
         },
+    }
+    assert data == expected
+
+
+@pytest.mark.parametrize('public_data', [
+    PlanFeatures.ContactPersonsPublicData.ALL,
+    PlanFeatures.ContactPersonsPublicData.NAME,
+    PlanFeatures.ContactPersonsPublicData.NONE,
+])
+def test_action_contact_persons_redacted(graphql_client_query_data, public_data):
+    plan = PlanFactory(features__contact_persons_public_data=public_data)
+    action = ActionFactory(plan=plan)
+    action_contact = ActionContactFactory(action=action, person__organization=plan.organization)
+    person = action_contact.person
+    assert person.email
+    data = graphql_client_query_data(
+        '''
+        query($action: ID!) {
+          action(id: $action) {
+            contactPersons {
+              person {
+                firstName
+                lastName
+                title
+                organization {
+                  id
+                }
+                email
+              }
+            }
+          }
+        }
+        ''',
+        variables={'action': action.id}
+    )
+    if public_data == PlanFeatures.ContactPersonsPublicData.NONE:
+        expected_contact_persons = []
+    else:
+        if public_data == PlanFeatures.ContactPersonsPublicData.NAME:
+            expected_email = ''
+        elif public_data == PlanFeatures.ContactPersonsPublicData.ALL:
+            expected_email = person.email
+        else:
+            assert False
+        expected_contact_persons = [{
+            'person': {
+                'firstName': person.first_name,
+                'lastName': person.last_name,
+                'title': person.title,
+                'organization': {
+                    'id': str(person.organization.id),
+                },
+                'email': expected_email,
+            },
+        }]
+    expected = {
+        'action': {
+            'contactPersons': expected_contact_persons
+        }
     }
     assert data == expected
 

--- a/people/models.py
+++ b/people/models.py
@@ -1,51 +1,48 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 import hashlib
 import io
 import logging
 import os
 import re
-import uuid
-from datetime import timedelta
-from typing import TYPE_CHECKING, ClassVar
-
+import requests
 import reversion
+import uuid
+import willow
+from datetime import timedelta
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
+from easy_thumbnails.files import get_thumbnailer
+from image_cropping import ImageRatioField
 from modelcluster.models import ClusterableModel
 from modeltrans.fields import TranslationField
 from modeltrans.manager import MultilingualQuerySet
+from sentry_sdk import capture_exception
+from typing import TYPE_CHECKING, ClassVar
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url as wagtail_avatar_url
 from wagtail.images.rect import Rect
 from wagtail.search import index
 
-import requests
-import willow
-from easy_thumbnails.files import get_thumbnailer  # type: ignore
-from image_cropping import ImageRatioField  # type: ignore
-from sentry_sdk import capture_exception
-
 from kausal_common.models.types import MLModelManager
 
-from aplans.utils import PlanDefaultsModel
-
-from actions.models import ActionContactPerson
+from actions.models import ActionContactPerson, PlanFeatures
 from admin_site.models import Client
+from aplans.utils import PlanDefaultsModel
 from orgs.models import Organization
 from users.models import User
 
 if TYPE_CHECKING:
     from kausal_common.models.types import FK, M2M, OneToOne, RevMany
 
+    from actions.models.action import Action
+    from actions.models.plan import Plan, PlanPublicSiteViewer
     from aplans.types import UserOrAnon, WatchRequest
-
-    from actions.models import Action, Plan
-    from actions.models.plan import PlanPublicSiteViewer
     from indicators.models import Indicator
     from orgs.models import OrganizationPlanAdmin
     from users.models import User as UserModel
@@ -464,6 +461,25 @@ class Person(index.Indexed, ClusterableModel, PlanDefaultsModel):
         if plan is None:
             return self.plans_with_public_site_access.exists()
         return plan.pk in self.plans_with_public_site_access.values_list('plan_id', flat=True)
+
+    def get_redacted_copy(self, plan: Plan):
+        """Return a copy of self with redacted information according to the configuration of the given plan.
+
+        You better not save the returned object.
+        """
+        if plan.features.contact_persons_public_data == PlanFeatures.ContactPersonsPublicData.ALL:
+            return copy.copy(self)
+        if plan.features.contact_persons_public_data == PlanFeatures.ContactPersonsPublicData.NAME:
+            return Person(
+                id=self.id,  # if we omit this, GraphQL will complain that we return null for nun-nullable `id` fields
+                first_name=self.first_name,
+                last_name=self.last_name,
+                title=self.title,
+                organization=self.organization,
+            )
+        if plan.features.contact_persons_public_data == PlanFeatures.ContactPersonsPublicData.NONE:
+            return Person(id=self.id)
+        assert False, "Unexpected value for PlanFeatures.contact_persons_public_data"
 
     def __str__(self):
         return "%s %s" % (self.first_name, self.last_name)

--- a/people/models.py
+++ b/people/models.py
@@ -7,42 +7,46 @@ import io
 import logging
 import os
 import re
-import requests
-import reversion
 import uuid
-import willow
 from datetime import timedelta
+from typing import TYPE_CHECKING, ClassVar
+
+import reversion
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
-from easy_thumbnails.files import get_thumbnailer
-from image_cropping import ImageRatioField
 from modelcluster.models import ClusterableModel
 from modeltrans.fields import TranslationField
 from modeltrans.manager import MultilingualQuerySet
-from sentry_sdk import capture_exception
-from typing import TYPE_CHECKING, ClassVar
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url as wagtail_avatar_url
 from wagtail.images.rect import Rect
 from wagtail.search import index
 
+import requests
+import willow
+from easy_thumbnails.files import get_thumbnailer
+from image_cropping import ImageRatioField
+from sentry_sdk import capture_exception
+
 from kausal_common.models.types import MLModelManager
+
+from aplans.utils import PlanDefaultsModel
 
 from actions.models import ActionContactPerson, PlanFeatures
 from admin_site.models import Client
-from aplans.utils import PlanDefaultsModel
 from orgs.models import Organization
 from users.models import User
 
 if TYPE_CHECKING:
     from kausal_common.models.types import FK, M2M, OneToOne, RevMany
 
+    from aplans.types import UserOrAnon, WatchRequest
+
     from actions.models.action import Action
     from actions.models.plan import Plan, PlanPublicSiteViewer
-    from aplans.types import UserOrAnon, WatchRequest
     from indicators.models import Indicator
     from orgs.models import OrganizationPlanAdmin
     from users.models import User as UserModel
@@ -463,7 +467,8 @@ class Person(index.Indexed, ClusterableModel, PlanDefaultsModel):
         return plan.pk in self.plans_with_public_site_access.values_list('plan_id', flat=True)
 
     def get_redacted_copy(self, plan: Plan):
-        """Return a copy of self with redacted information according to the configuration of the given plan.
+        """
+        Return a copy of self with redacted information according to the configuration of the given plan.
 
         You better not save the returned object.
         """
@@ -479,7 +484,7 @@ class Person(index.Indexed, ClusterableModel, PlanDefaultsModel):
             )
         if plan.features.contact_persons_public_data == PlanFeatures.ContactPersonsPublicData.NONE:
             return Person(id=self.id)
-        assert False, "Unexpected value for PlanFeatures.contact_persons_public_data"
+        raise AssertionError("Unexpected value for PlanFeatures.contact_persons_public_data")
 
     def __str__(self):
         return "%s %s" % (self.first_name, self.last_name)


### PR DESCRIPTION
This takes care of the Asana task: https://app.asana.com/0/1202880927552397/1205365901296872

The contact information is at the moment still exposed by the `person` endpoint. Didn't we want to remove that altogether at some point?