### PR TITLE
Optionally add locale to action.viewUrl in GQL API

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -645,7 +645,7 @@ class Action(  # type: ignore[django-manager-missing]
     def get_view_url(self, plan: Optional[Plan] = None, client_url: Optional[str] = None) -> str:
         if plan is None:
             plan = self.plan
-        return '%s/actions/%s' % (plan.get_view_url(client_url=client_url), self.identifier)
+        return '%s/actions/%s' % (plan.get_view_url(client_url=client_url, active_locale=translation.get_language()), self.identifier)
 
     @classmethod
     def get_indexed_objects(cls):

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -498,7 +498,12 @@ class Plan(ClusterableModel):
     def is_live(self):
         return self.published_at is not None and self.archived_at is None
 
-    def get_view_url(self, client_url: Optional[str] = None) -> str:
+    def get_optional_locale_prefix(self, locale: str):
+        if locale.lower() != self.primary_language.lower():
+            return f'/{locale}'
+        return ''
+
+    def get_view_url(self, client_url: Optional[str] = None, active_locale: str | None = None) -> str:
         """Return an URL for the homepage of the plan.
 
         If `client_url` is given, try to return the URL that matches the supplied
@@ -541,6 +546,10 @@ class Plan(ClusterableModel):
                 else:
                     hostname = None
 
+        locale_prefix = ''
+        if active_locale:
+            locale_prefix = self.get_optional_locale_prefix(active_locale)
+
         if hostname:
             if not scheme:
                 scheme = 'https'
@@ -552,14 +561,14 @@ class Plan(ClusterableModel):
                 port_str = ':%s' % port
             else:
                 port_str = ''
-            return '%s://%s%s%s' % (scheme, hostname, port_str, base_path)
+            return '%s://%s%s%s%s' % (scheme, hostname, port_str, base_path, locale_prefix)
         else:
             assert self.site_url is not None
             if self.site_url.startswith('http'):
                 url = self.site_url.rstrip('/')
             else:
                 url = 'https://%s' % self.site_url
-            return url
+            return f'{url}{locale_prefix}'
 
     @classmethod
     def create_with_defaults(

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -499,9 +499,9 @@ class Plan(ClusterableModel):
         return self.published_at is not None and self.archived_at is None
 
     def get_optional_locale_prefix(self, locale: str):
-        if locale.lower() != self.primary_language.lower():
-            return f'/{locale}'
-        return ''
+        if locale.lower() == self.primary_language.lower():
+            return ''
+        return next((f'/{lang}' for lang in self.other_languages if lang.lower() == locale.lower()), '')
 
     def get_view_url(self, client_url: Optional[str] = None, active_locale: str | None = None) -> str:
         """Return an URL for the homepage of the plan.


### PR DESCRIPTION
This is required especially to make cross-plan action links work in a multilingual multiplan context.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205697375570220