### PR TITLE
Only show plan languages when editing indicators; update i18n tabs logic

### DIFF
--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -74,7 +74,16 @@ def insert_model_translation_panels(model, panels, request, plan=None) -> List:
 
 
 def get_translation_tabs(instance, request, include_all_languages: bool = False, extra_panels=None):
-    # extra_panels maps a language code to a list of panels that should be put on the tab of that language
+    """Get tabs for entering translated strings.
+
+    If `include_all_languages` is true, a tab is shown for each language that is not the default for the given instance.
+    This default language is determined by the `default_language` argument of the model's i18n field. If there is no
+    such argument, the global default language from `settings.LANGUAGE_CODE` is used.
+    If `include_all_languages` is false, a tab is shown for each language supported by the currently active plan except,
+    just like before, the default language of the instance.
+
+    `extra_panels` maps a language code to a list of panels that should be put on the tab of that language.
+    """
     if extra_panels is None:
         extra_panels = {}
 
@@ -89,16 +98,19 @@ def get_translation_tabs(instance, request, include_all_languages: bool = False,
 
     languages_by_code = {x[0].lower(): x[1] for x in settings.LANGUAGES}
     if include_all_languages:
-        # Omit default language because it's stored in the model field without a modeltrans language suffix
-        if i18n_field.default_language_field:
-            default_language = get_instance_field_value(instance, i18n_field.default_language_field)
-        else:
-            default_language = settings.LANGUAGE_CODE
-        if default_language:
-            default_language = default_language.lower()
-        languages = [lang for lang in languages_by_code.keys() if lang != default_language]
+        languages = [lang for lang in languages_by_code.keys()]
     else:
-        languages = [lang.lower() for lang in plan.other_languages]
+        languages = [plan.primary_language.lower()] + [lang.lower() for lang in plan.other_languages]
+
+    # Omit default language because it's stored in the model field without a modeltrans language suffix
+    if i18n_field.default_language_field:
+        default_language = get_instance_field_value(instance, i18n_field.default_language_field)
+    else:
+        default_language = settings.LANGUAGE_CODE
+    if default_language:
+        default_language = default_language.lower()
+        languages = [lang for lang in languages if lang != default_language]
+
     for lang_code in languages:
         assert lang_code == lang_code.lower()
         panels = []

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -478,7 +478,7 @@ class IndicatorAdmin(AplansModelAdmin):
             ], heading=_('Contact persons')),
         ]
 
-        i18n_tabs = get_translation_tabs(instance, request, include_all_languages=True)
+        i18n_tabs = get_translation_tabs(instance, request)
         tabs += i18n_tabs
 
         return IndicatorEditHandler(tabs)


### PR DESCRIPTION
See this task and my comment there:
https://app.asana.com/0/home/1202868319424336/1205262279214952

@juyrjola I think you should review this. We talked about this already in the past and it's kind of a tricky thing.