### PR TITLE
Read XSLX report field labels for category blocks from actual block

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -14,6 +14,7 @@ from modelcluster.fields import ParentalManyToManyDescriptor
 from reversion.models import Version
 from reversion.revisions import _current_frame, add_to_revision, create_revision
 from wagtail.fields import StreamField
+from wagtail.blocks.stream_block import StreamValue
 
 from actions.models.action import Action
 from aplans.utils import PlanRelatedModel
@@ -43,6 +44,14 @@ class ReportType(models.Model, PlanRelatedModel):
     class Meta:
         verbose_name = _('report type')
         verbose_name_plural = _('report types')
+
+    def get_fields_for_type(self, block_type: str) -> list[StreamValue.StreamChild]:
+        return [f for f in self.fields if f.block_type == block_type]
+
+    def get_field_labels_for_type(self, block_type: str) -> list[list[str]]:
+        fields = self.get_fields_for_type(block_type)
+        labels = [field.block.xlsx_column_labels(field.value) for field in fields]
+        return labels
 
     def __str__(self):
         return f'{self.name} ({self.plan.identifier})'

--- a/reports/spreadsheets.py
+++ b/reports/spreadsheets.py
@@ -402,10 +402,12 @@ class ExcelReport:
 
     def post_process(self, action_df: polars.DataFrame):
         pivot_specs = [
+            # Pivot sheet: Implementation phase
             {
                 'group': (_('implementation phase').capitalize(),),
                 'type': 'pie'
             },
+            # Pivot sheet: Organization parent x Implementation phase
             {
                 'group': (
                     _('Parent'),
@@ -413,12 +415,18 @@ class ExcelReport:
                 'type': 'column'
             }
         ]
-        for ct in self.plan_current_related_objects.category_types.values():
-            pivot_specs.append({
-                'group': (ct.name, _('implementation phase').capitalize()),
-                'type': 'column',
-                'subtype': 'stacked'
-            })
+
+        # Pivot sheet: Category (level) x Implementation phase
+        category_labels = self.report.type.get_field_labels_for_type('category')
+        implementation_phase_fields = self.report.type.get_fields_for_type('implementation_phase')
+        if len(implementation_phase_fields) > 0:
+            for label in category_labels:
+                assert len(label) == 1
+                pivot_specs.append({
+                    'group': (label[0], _('implementation phase').capitalize()),
+                    'type': 'column',
+                    'subtype': 'stacked'
+                })
         sheet_number = 1
         for spec in pivot_specs:
             grouping = spec['group']


### PR DESCRIPTION
Fixes a problem where level labels are used as column labels but
aggregation logic tried to use category type name.