### PR TITLE
Add ADFS OIDC backend

### DIFF
--- a/admin_site/models.py
+++ b/admin_site/models.py
@@ -21,6 +21,7 @@ class Client(WorkflowMixin, DraftStateMixin, LockableMixin, RevisionMixin, Clust
         GOOGLE = 'google-openidconnect', _('Google')
         TUNNISTAMO = 'tunnistamo', _('Tunnistamo')
         OKTA = 'okta-openidconnect', _('OKTA')
+        ADFS = 'adfs-openidconnect', _('ADFS OpenID Connect')
 
     name = models.CharField(
         max_length=100,

--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -51,6 +51,9 @@ env = environ.FileAwareEnv(
     OKTA_CLIENT_ID=(str, ''),
     OKTA_CLIENT_SECRET=(str, ''),
     OKTA_API_URL=(str, ''),
+    ADFS_CLIENT_ID=(str, ''),
+    ADFS_CLIENT_SECRET=(str, ''),
+    ADFS_API_URL=(str, ''),
     MAILGUN_API_KEY=(str, ''),
     MAILGUN_SENDER_DOMAIN=(str, ''),
     MAILGUN_REGION=(str, ''),
@@ -270,9 +273,10 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTHENTICATION_BACKENDS = (
     'helusers.tunnistamo_oidc.TunnistamoOIDCAuth',
     'admin_site.backends.AzureADAuth',
+    'admin_site.backends.ADFSOpenIDConnectAuth',
     'django.contrib.auth.backends.ModelBackend',
     'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
-    'social_core.backends.okta_openidconnect.OktaOpenIdConnect'
+    'social_core.backends.okta_openidconnect.OktaOpenIdConnect',
 )
 
 AUTH_USER_MODEL = 'users.User'
@@ -297,6 +301,10 @@ SOCIAL_AUTH_GOOGLE_OPENIDCONNECT_SECRET = env.str('GOOGLE_CLIENT_SECRET')
 SOCIAL_AUTH_OKTA_OPENIDCONNECT_KEY = env.str('OKTA_CLIENT_ID')
 SOCIAL_AUTH_OKTA_OPENIDCONNECT_SECRET = env.str('OKTA_CLIENT_SECRET')
 SOCIAL_AUTH_OKTA_OPENIDCONNECT_API_URL = env.str('OKTA_API_URL')
+
+SOCIAL_AUTH_ADFS_OPENIDCONNECT_KEY = env.str('ADFS_CLIENT_ID')
+SOCIAL_AUTH_ADFS_OPENIDCONNECT_SECRET = env.str('ADFS_CLIENT_SECRET')
+SOCIAL_AUTH_ADFS_OPENIDCONNECT_API_URL = env.str('ADFS_API_URL')
 
 SOCIAL_AUTH_PIPELINE = (
     'users.pipeline.log_login_attempt',

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -64,7 +64,7 @@ def find_user_by_email(backend, details, user=None, social=None, *args, **kwargs
 
 def create_or_update_user(backend, details, user, *args, **kwargs):
     if user is None:
-        if backend.name == 'google-openidconnect':
+        if backend.name != 'azure_ad':
             uuid = uuid4()
         else:
             uuid = details.get('uuid') or kwargs.get('uid')

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -64,10 +64,10 @@ def find_user_by_email(backend, details, user=None, social=None, *args, **kwargs
 
 def create_or_update_user(backend, details, user, *args, **kwargs):
     if user is None:
-        if backend.name != 'azure_ad':
-            uuid = uuid4()
+        if 'uuid' in details:
+            uuid = details.get('uuid')
         else:
-            uuid = details.get('uuid') or kwargs.get('uid')
+            uuid = uuid4()
         user = User(uuid=uuid)
         msg = 'Created new user'
     else:

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -146,10 +146,7 @@ def get_username(details, backend, response, *args, **kwargs):
     `helusers.utils.uuid_to_username` function.
     """
 
-    if backend.name == 'google-openidconnect':
-        return
-
-    if backend.name == 'okta-openidconnect':
+    if backend.name != 'azure_ad':
         return
 
     user = details.get('user')


### PR DESCRIPTION
This is meant for Winterthur but it is generically named.
The implementation only supports one endpoint, ie. one
customer as of now. I was thinking when the next customer
comes up with similar needs, we will need to make this
configurable in a multi-tenant way, same goes for the
recent OKTA integration.