### PR TITLE
Return "not started" status summary for actions without status

### DIFF
--- a/actions/action_status_summary.py
+++ b/actions/action_status_summary.py
@@ -168,9 +168,10 @@ class ActionStatusSummaryIdentifier(MetadataEnum):
         if phase == 'completed':
             return cls.COMPLETED
         # phase: "begun"? "implementation?"
-        if phase == 'not_started' and status_identifier == 'on_time':
-            return cls.ON_TIME
-        return cls.for_status(action.status)
+        status_match = cls.for_status(action.status)
+        if status_match == cls.UNDEFINED and phase == 'not_started':
+            return cls.NOT_STARTED
+        return status_match
 
 
 Comparison = Enum('Comparison', names='LTE GT')


### PR DESCRIPTION
New interpretation is that not started is an "everything ok" state unless
some known status overrides the ok-ness. This is to higlight not
started as a separate sector in the status pie.