### PR TITLE
Fix bug with target ancestor depth

### DIFF
--- a/reports/blocks/action_content.py
+++ b/reports/blocks/action_content.py
@@ -392,14 +392,12 @@ class ActionResponsiblePartyReportFieldBlock(blocks.StructBlock, FieldBlockWithH
             return [None] * value_length
         if target_depth is None:
             return [organization.name]
-        ancestors = organization.get_ancestors()
-        depth = len(ancestors)
-        if depth == 0:
+        ancestors = organization.get_ancestors()  # does not contain organization itself
+        num_ancestors = len(ancestors)
+        if num_ancestors == 0:
             parent = None
-        elif depth == 1:
-            parent = organization
-        elif depth < target_depth:
-            parent = ancestors[depth-1]
+        elif target_depth > num_ancestors:
+            parent = ancestors[num_ancestors-1]
         else:
             parent = ancestors[target_depth-1]
         parent_name = parent.name if parent else None


### PR DESCRIPTION
I believe we had a bug in the code that displays the "containing organization" for a responsible party in a report based on the level in the hierarchy.

For example, with Bremen, who has a hierarchy with currently two levels, if you choose "1" as the target ancestor depth, then for a row whose responsible party is below the top level, you won't get its containing top-level organization but the organization itself.

I removed one of the conditional branches, namely the one handling `depth == 1` because I didn't see its use. It seemed to be based on the assumption that `ancestors` contains the organization itself, but it doesn't. Maybe I didn't see something.