### PR TITLE
Distinguish between approval and publishing rights in moderation

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1320,10 +1320,10 @@ class ImpactGroupAction(models.Model):
 
 class ActionModeratorApprovalTask(Task):
     def locked_for_user(self, obj: Action, user: User):
-        return not user.can_publish_action(obj)
+        return not user.can_approve_action(obj)
 
     def get_actions(self, obj: Action, user: User):
-        if user.can_publish_action(obj):
+        if user.can_approve_action(obj):
             return [
                 ("approve", _("Approve"), False),
                 # ("approve", _("Approve with comment"), True),

--- a/actions/tests/factories.py
+++ b/actions/tests/factories.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_save
 from django.utils.timezone import make_aware
 from factory import LazyAttribute, RelatedFactory, SelfAttribute, Sequence, SubFactory, post_generation
+from wagtail.models import Workflow, WorkflowTask, Task as WagtailTask
 from wagtail.models.i18n import Locale
 from wagtail.rich_text import RichText
 from wagtail.test.utils.wagtail_factories import StructBlockFactory
@@ -354,3 +355,28 @@ class CategoryListBlockFactory(StructBlockFactory):
     heading = "Category list heading"
     lead = RichText("<p>Category list lead</p>")
     style = 'cards'
+
+
+class WagtailTaskFactory(ModelFactory[WagtailTask]):
+    class Meta:
+        model = WagtailTask
+
+    name = Sequence(lambda i: f'WorkflowTask {i}')
+    active = True
+    content_type = LazyAttribute(lambda _: ContentType.objects.get(app_label='actions', model='action'))
+
+
+class WorkflowFactory(ModelFactory[Workflow]):
+    class Meta:
+        model = Workflow
+
+    name = Sequence(lambda i: f'Workflow {i}')
+    active = True
+
+
+class WorkflowTaskFactory(ModelFactory[WorkflowTask]):
+    class Meta:
+        model = WorkflowTask
+
+    workflow = SubFactory(WorkflowFactory)
+    task = SubFactory(WagtailTaskFactory)

--- a/actions/tests/test_moderation_permissions.py
+++ b/actions/tests/test_moderation_permissions.py
@@ -1,0 +1,107 @@
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def plan_with_single_task_moderation(plan_factory, workflow_factory, workflow_task_factory, action_factory):
+    plan = plan_factory()
+    workflow = workflow_factory()
+    workflow_task_factory(workflow=workflow)
+    plan.features.moderation_workflow = workflow
+    action_factory(plan=plan)
+    return plan
+
+
+@pytest.fixture
+def plan_with_double_task_moderation(plan_factory, workflow_task_factory, workflow_factory, action_factory):
+    plan = plan_factory()
+    workflow = workflow_factory()
+    workflow_task_factory(workflow=workflow)
+    workflow_task_factory(workflow=workflow)
+    plan.features.moderation_workflow = workflow
+    action_factory(plan=plan)
+    return plan
+
+
+@pytest.fixture
+def action_contact_person_user_maker(action_contact_factory):
+    def make_action_contact_person_with_role(plan, role):
+        action = plan.actions.get()
+        acp = action_contact_factory(action=action, role=role)
+        return acp.person.user
+    return make_action_contact_person_with_role
+
+
+@pytest.fixture
+def moderator_user_without_publishing_rights(plan_with_double_task_moderation, action_contact_person_user_maker):
+    return action_contact_person_user_maker(plan_with_double_task_moderation, 'moderator')
+
+
+@pytest.fixture
+def moderator_user_with_publishing_rights(plan_with_single_task_moderation, action_contact_person_user_maker):
+    return action_contact_person_user_maker(plan_with_single_task_moderation, 'moderator')
+
+
+@pytest.fixture
+def editor_user_without_publishing_rights_double(plan_with_double_task_moderation, action_contact_person_user_maker):
+    return action_contact_person_user_maker(plan_with_double_task_moderation, 'editor')
+
+
+@pytest.fixture
+def editor_user_without_publishing_rights_single(plan_with_single_task_moderation, action_contact_person_user_maker):
+    return action_contact_person_user_maker(plan_with_single_task_moderation, 'editor')
+
+
+def test_action_moderator_has_publishing_rights(moderator_user_with_publishing_rights, plan_with_single_task_moderation):
+    assert moderator_user_with_publishing_rights.can_publish_action(
+        plan_with_single_task_moderation.actions.first()
+    )
+
+
+def test_action_moderator_has_no_publishing_rights(moderator_user_without_publishing_rights, plan_with_double_task_moderation):
+    assert not moderator_user_without_publishing_rights.can_publish_action(
+        plan_with_double_task_moderation.actions.first()
+    )
+
+
+def test_action_editor_has_no_publishing_rights(
+        editor_user_without_publishing_rights_single,
+        editor_user_without_publishing_rights_double,
+        plan_with_single_task_moderation,
+        plan_with_double_task_moderation
+):
+    assert not editor_user_without_publishing_rights_single.can_publish_action(
+        plan_with_single_task_moderation.actions.first()
+    )
+    assert not editor_user_without_publishing_rights_double.can_publish_action(
+        plan_with_double_task_moderation.actions.first()
+    )
+
+
+def test_action_editor_has_no_approval_rights(
+        editor_user_without_publishing_rights_single,
+        editor_user_without_publishing_rights_double,
+        plan_with_single_task_moderation,
+        plan_with_double_task_moderation
+):
+    assert not editor_user_without_publishing_rights_single.can_approve_action(
+        plan_with_single_task_moderation.actions.first()
+    )
+    assert not editor_user_without_publishing_rights_double.can_approve_action(
+        plan_with_double_task_moderation.actions.first()
+    )
+
+
+def test_action_moderator_has_approval_rights(
+        moderator_user_with_publishing_rights,
+        moderator_user_without_publishing_rights,
+        plan_with_single_task_moderation,
+        plan_with_double_task_moderation
+):
+    assert moderator_user_with_publishing_rights.can_approve_action(
+        plan_with_single_task_moderation.actions.first()
+    )
+    assert moderator_user_without_publishing_rights.can_approve_action(
+        plan_with_double_task_moderation.actions.first()
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -68,6 +68,11 @@ register(actions_factories.AttributeChoiceWithTextFactory)
 register(actions_factories.AttributeNumericValueFactory)
 register(actions_factories.AttributeCategoryChoiceFactory)
 register(actions_factories.AttributeTypeFactory)
+
+register(actions_factories.WagtailTaskFactory)
+register(actions_factories.WorkflowFactory)
+register(actions_factories.WorkflowTaskFactory)
+
 register(
     actions_factories.AttributeTypeFactory,
     'action_attribute_type',


### PR DESCRIPTION
We currently support two kinds of moderation workflows: those with 1 task, where the moderators can directly publish, and those with 2 tasks where the moderators can only approve, pushing the content to the final task of the 2 moderation tasks, publication (available to a smaller set of users, currently plan admins)

For those with 2 tasks, we need to make sure the moderators don't have the publishing rights.