### PR TITLE
Action visibility and visibility_display in api

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1005,7 +1005,7 @@ class ActionSerializer(
         fields = public_fields(
             Action,
             add_fields=[
-                'internal_notes', 'internal_admin_notes',
+                'internal_notes', 'internal_admin_notes', 'visibility', 'visibility_display'
             ],
             remove_fields=[
                 'impact', 'status_updates', 'monitoring_quality_points', 'image', 'tasks', 'links',

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -463,6 +463,11 @@ class Action(  # type: ignore[django-manager-missing]
             .first()
         )
 
+    @property
+    def visibility_display(self):
+        return self.get_visibility_display()
+
+
     def _calculate_status_from_indicators(self):
         progress_indicators = self.related_indicators.filter(indicates_action_progress=True)
         total_completion = 0.0


### PR DESCRIPTION
Expose visibility and visibility_display in api so that they can be used in spreadsheet editor

Related extensions PR: https://github.com/kausaltech/kausal-extensions/pull/13

Asana: https://app.asana.com/0/1206017643443542/1206773871156896

