### PR TITLE
Let plan admins see indicators also from adminable plans

### DIFF
--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -500,7 +500,9 @@ class IndicatorAdmin(AplansModelAdmin):
         if request.user.is_superuser:
             qs = qs.filter(organization__in=Organization.objects.available_for_plan(plan))
         else:
-            qs = qs.filter(organization=plan.organization)
+            orgs = [plan.organization.id]
+            orgs.extend(Organization.objects.user_is_plan_admin_for(request.user, plan).values_list("id", flat=True))
+            qs = qs.filter(organization_id__in=orgs)
         return qs.select_related('unit', 'quantity')
 
 


### PR DESCRIPTION
Show plan admins indicators not only from parent plan but also from adminable plans.

https://app.asana.com/0/1206017643443542/1206670849313396