### PR TITLE
Create formset class to work around modelcluster ordering issues

### DIFF
--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -14,6 +14,8 @@ from wagtail_modeladmin.options import modeladmin_register
 from wagtail_modeladmin.views import IndexView, DeleteView
 from wagtailorderable.modeladmin.mixins import OrderableMixin
 
+from aplans.utils import OrderedModelChildFormSet
+
 from .attributes import AttributeType as AttributeTypeWrapper
 from .models import Action, AttributeType, AttributeTypeChoiceOption, Category
 from actions.chooser import CategoryTypeChooser
@@ -204,6 +206,13 @@ class ActionAttributeTypeForm(ActionListPageBlockFormMixin, AttributeTypeForm):
     pass
 
 
+class AttributeTypeEditHandler(AplansTabbedInterface):
+    def get_form_options(self):
+        options = super().get_form_options()
+        options['formsets']['choice_options']['formset'] = OrderedModelChildFormSet
+        return options
+
+
 @modeladmin_register
 class AttributeTypeAdmin(OrderableMixin, AplansModelAdmin):
     model = AttributeType
@@ -278,7 +287,7 @@ class AttributeTypeAdmin(OrderableMixin, AplansModelAdmin):
 
         tabs = [ObjectList(panels, heading=_('General'))]
 
-        handler = AplansTabbedInterface(tabs, base_form_class=base_form_class)
+        handler = AttributeTypeEditHandler(tabs, base_form_class=base_form_class)
         return handler
 
     def get_menu_item(self, order=None):

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -218,8 +218,6 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):  # type: ignore
 
     public_fields: ClassVar = ['id', 'identifier', 'name']
 
-    override_order = False  # see OrderedModel
-
     class Meta:
         constraints = [
             models.UniqueConstraint(

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -22,7 +22,7 @@ from aplans.utils import (
 )
 from indicators.models import Unit
 
-from typing import ClassVar, Any
+from typing import Any, ClassVar, Self
 if typing.TYPE_CHECKING:
     from django.db.models.manager import RelatedManager
     from .plan import Plan
@@ -218,6 +218,8 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):  # type: ignore
 
     public_fields: ClassVar = ['id', 'identifier', 'name']
 
+    override_order = False  # see OrderedModel
+
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -236,6 +238,10 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):  # type: ignore
 
     def __str__(self):
         return self.name
+
+    def filter_siblings(self, qs: models.QuerySet[Self]) -> models.QuerySet[Self]:
+        # Used by OrderedModel to make sure order starts at 0 for each attribute type
+        return qs.filter(type=self.type)
 
 
 @reversion.register(follow=['categories'])

--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -47,16 +47,6 @@ def mp_node_get_ancestors(qs, include_self=False):
     return qs.model.objects.filter(path__in=paths)
 
 
-class OrderableModelMixin:
-    order = graphene.Int()
-
-    @gql_optimizer.resolver_hints(
-        model_field='sort_order',
-    )
-    def resolve_order(self, **kwargs):
-        return self.sort_order
-
-
 class SiteGeneralContentNode(DjangoNode):
     class Meta:
         model = SiteGeneralContent


### PR DESCRIPTION
This should fix the following ordering problems with models that are used in inline panels:
- Modelcluster may leave holes in the order values when deleting instances. That is, the orders `[0, 1, 2]` may become `[0, 2]`.
- As Modelcluster only saves instances whose fields (not taking the order field into account) have changed, adding a new instance before an existing one may lead to integrity constraint violations due to duplicate order values.

So far, this PR only takes the fix into use for `AttributeTypeChoiceOption`, where Bremen ran into problems, but it should probably be applied to a lot of other models as well once it has proven to be fine.

For some context about what this is supposed to fix, you can have a look at [my Slack message](https://kausaltech.slack.com/archives/C01AZ2V3656/p1713255729986919).