### PR TITLE
Remove extra SQL queries of content types, related models with default languages, and action dependencies for plans not using the feature

### DIFF
--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -28,7 +28,6 @@ if typing.TYPE_CHECKING:
     from .plan import Plan
     from .category import CategoryType
     from actions.attributes import AttributeType as AttributeTypeWrapper, DraftAttributes
-    from actions.models import Action, Category
 
 
 class AttributeTypeQuerySet(models.QuerySet['AttributeType']):
@@ -190,13 +189,11 @@ class Attribute(models.Model):
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey()
 
-    def is_visible_for_user(self, user: UserOrAnon, plan: Plan, model_with_attribute: Action | Category) -> bool:
+    def is_visible_for_user(self, user: UserOrAnon, plan: Plan) -> bool:
         from actions.models.action import Action
         assert plan is not None
         if self.content_type_id == ContentType.objects.get_for_model(Action).id:
-            assert self.object_id == model_with_attribute.pk
-            action = model_with_attribute
-            assert type(action) == Action
+            action = self.content_object
         else:
             action = None
         return self.type.is_instance_visible_for(user, plan, action)

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -28,6 +28,7 @@ if typing.TYPE_CHECKING:
     from .plan import Plan
     from .category import CategoryType
     from actions.attributes import AttributeType as AttributeTypeWrapper, DraftAttributes
+    from actions.models import Action, Category
 
 
 class AttributeTypeQuerySet(models.QuerySet['AttributeType']):
@@ -189,11 +190,13 @@ class Attribute(models.Model):
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey()
 
-    def is_visible_for_user(self, user: UserOrAnon, plan: Plan) -> bool:
+    def is_visible_for_user(self, user: UserOrAnon, plan: Plan, model_with_attribute: Action | Category) -> bool:
         from actions.models.action import Action
         assert plan is not None
-        if self.content_type == ContentType.objects.get_for_model(Action):
-            action = self.content_object
+        if self.content_type_id == ContentType.objects.get_for_model(Action).id:
+            assert self.object_id == model_with_attribute.pk
+            action = model_with_attribute
+            assert type(action) == Action
         else:
             action = None
         return self.type.is_instance_visible_for(user, plan, action)

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -635,7 +635,8 @@ class AttributesMixin:
     @gql_optimizer.resolver_hints(
         prefetch_related=[
             *chain(*[('%s' % rel, '%s__type' % rel) for rel in ModelWithAttributes.ATTRIBUTE_RELATIONS]),
-            *['choice_attributes__choice', 'choice_with_text_attributes__choice']
+            *['choice_attributes__choice', 'choice_with_text_attributes__choice'],
+            *['choice_attributes__choice__type', 'choice_with_text_attributes__choice__type'],
         ]
     )
     def resolve_attributes(root: Category | Action, info: GQLInfo, id: str | None = None):

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -646,7 +646,7 @@ class AttributesMixin:
             result = []
             for attribute in attributes:
                 id_mismatch = id is not None and attribute.type.identifier != id
-                if not id_mismatch and attribute.is_visible_for_user(request.user, plan):
+                if not id_mismatch and attribute.is_visible_for_user(request.user, plan, root):
                     result.append(attribute)
             return result
 

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -634,8 +634,7 @@ class AttributesMixin:
     @staticmethod
     @gql_optimizer.resolver_hints(
         prefetch_related=[
-            *chain(*[('%s' % rel, '%s__type' % rel) for rel in ModelWithAttributes.ATTRIBUTE_RELATIONS]),
-            *['choice_attributes__choice', 'choice_with_text_attributes__choice'],
+            *chain(*[(f'{rel}__type', f'{rel}__content_object') for rel in ModelWithAttributes.ATTRIBUTE_RELATIONS]),
             *['choice_attributes__choice__type', 'choice_with_text_attributes__choice__type'],
         ]
     )
@@ -647,7 +646,7 @@ class AttributesMixin:
             result = []
             for attribute in attributes:
                 id_mismatch = id is not None and attribute.type.identifier != id
-                if not id_mismatch and attribute.is_visible_for_user(request.user, plan, root):
+                if not id_mismatch and attribute.is_visible_for_user(request.user, plan):
                     result.append(attribute)
             return result
 

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1108,6 +1108,9 @@ class ActionNode(AdminButtonsMixin, AttributesMixin, DjangoNode):
 
     @staticmethod
     def resolve_all_dependency_relationships(root: Action, info: GQLInfo):
+        cache = info.context.watch_cache.for_plan_id(root.plan_id)
+        if not cache.plan_has_action_dependency_roles:
+            return []
         return root.get_dependency_relationships(info.context.user, root.plan)
 
     @staticmethod

--- a/actions/tests/test_models.py
+++ b/actions/tests/test_models.py
@@ -397,10 +397,10 @@ def test_attribute_type_visibility_contact_person_particular_action(plan, action
         type=at,
         content_object=action,
     )
-    assert visible_attr.is_visible_for_user(person.user, plan, ac.action)
+    assert visible_attr.is_visible_for_user(person.user, plan)
     # For InstancesVisibleForMixin.VisibleFor.CONTACT_PERSONS, it should not enough to be a contact person for *any*
     # action; you need to be a contact person of that particular action.
-    assert not invisible_attr.is_visible_for_user(person.user, plan, action)
+    assert not invisible_attr.is_visible_for_user(person.user, plan)
 
 
 LANGUAGES_TO_TEST = [l[0] for l in settings.LANGUAGES]

--- a/actions/tests/test_models.py
+++ b/actions/tests/test_models.py
@@ -397,10 +397,10 @@ def test_attribute_type_visibility_contact_person_particular_action(plan, action
         type=at,
         content_object=action,
     )
-    assert visible_attr.is_visible_for_user(person.user, plan)
+    assert visible_attr.is_visible_for_user(person.user, plan, ac.action)
     # For InstancesVisibleForMixin.VisibleFor.CONTACT_PERSONS, it should not enough to be a contact person for *any*
     # action; you need to be a contact person of that particular action.
-    assert not invisible_attr.is_visible_for_user(person.user, plan)
+    assert not invisible_attr.is_visible_for_user(person.user, plan, action)
 
 
 LANGUAGES_TO_TEST = [l[0] for l in settings.LANGUAGES]

--- a/aplans/cache.py
+++ b/aplans/cache.py
@@ -17,6 +17,10 @@ class PlanSpecificCache:
         return list(self.plan.action_statuses.all())
 
     @cached_property
+    def plan_has_action_dependency_roles(self):
+        return self.plan.action_dependency_roles.count() > 0
+
+    @cached_property
     def implementation_phases(self) -> list[ActionImplementationPhase]:
         return list(self.plan.action_implementation_phases.all())
 

--- a/aplans/cache.py
+++ b/aplans/cache.py
@@ -18,7 +18,7 @@ class PlanSpecificCache:
 
     @cached_property
     def plan_has_action_dependency_roles(self):
-        return self.plan.action_dependency_roles.count() > 0
+        return self.plan.action_dependency_roles.exists()
 
     @cached_property
     def implementation_phases(self) -> list[ActionImplementationPhase]:


### PR DESCRIPTION
Reduces the amount of queries from >9000 to ~599~  79 for that _one_ customer. All of the perf fixes for the action list page query are not done yet, but we should merge this ASAP and then work on the action dependencies.
