### PR TITLE
Add missing i18n panels to InlinePanel for CategoryLevel instances

### DIFF
--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -24,11 +24,6 @@ from wagtail_modeladmin.options import modeladmin_register
 from wagtail_modeladmin.views import DeleteView
 from wagtailorderable.modeladmin.mixins import OrderableMixin
 
-from .models import Category, CategoryLevel, CategoryType, CommonCategory, CommonCategoryType
-from admin_site.wagtail import (
-    CondensedInlinePanel, InitializeFormWithPlanMixin,  PlanFilteredFieldPanel, AplansTabbedInterface,
-    get_translation_tabs, insert_model_translation_panels
-)
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import append_query_parameter
 
@@ -45,9 +40,10 @@ from admin_site.wagtail import (
     InitializeFormWithPlanMixin,
     PlanFilteredFieldPanel,
     get_translation_tabs,
+    insert_model_translation_panels,
 )
 
-from .models import Category, CategoryType, CommonCategory, CommonCategoryType
+from .models import Category, CategoryLevel, CategoryType, CommonCategory, CommonCategoryType
 
 if TYPE_CHECKING:
     from django.http.request import HttpRequest

--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -24,6 +24,11 @@ from wagtail_modeladmin.options import modeladmin_register
 from wagtail_modeladmin.views import DeleteView
 from wagtailorderable.modeladmin.mixins import OrderableMixin
 
+from .models import Category, CategoryLevel, CategoryType, CommonCategory, CommonCategoryType
+from admin_site.wagtail import (
+    CondensedInlinePanel, InitializeFormWithPlanMixin,  PlanFilteredFieldPanel, AplansTabbedInterface,
+    get_translation_tabs, insert_model_translation_panels
+)
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import append_query_parameter
 
@@ -149,14 +154,15 @@ class CategoryTypeAdmin(AplansModelAdmin):
                 FieldPanel('editable_for_indicators'),
             ]),
         ], heading=_('Action and indicator categorization'), classname='collapsible'),
-        CondensedInlinePanel('levels', panels=[
-            FieldPanel('name'),
-            FieldPanel('name_plural'),
-        ], heading=_("Category levels")),
         FieldPanel('synchronize_with_pages'),
         FieldPanel('instances_editable_by'),
         FieldPanel('action_list_filter_section'),
         FieldPanel('action_detail_content_section'),
+    ]
+
+    levels_panels = [
+        FieldPanel('name'),
+        FieldPanel('name_plural'),
     ]
 
     def get_form_fields_exclude(self, request):
@@ -173,9 +179,18 @@ class CategoryTypeAdmin(AplansModelAdmin):
     def get_edit_handler(self):
         request = ctx_request.get_admin_request()
         instance = ctx_instance.get_as_type(CategoryType)
+        plan = instance.plan
+
         panels = list(self.panels)
+
         if instance and instance.common:
             panels.insert(1, FieldPanel('common'))
+
+        levels_panels = insert_model_translation_panels(CategoryLevel, self.levels_panels, request, plan)
+        panels.append(
+            CondensedInlinePanel('levels', panels=levels_panels, heading=_("Category levels")),
+        )
+
         tabs = [ObjectList(panels, heading=_('Basic information'))]
 
         i18n_tabs = get_translation_tabs(instance, request)

--- a/actions/models/category.py
+++ b/actions/models/category.py
@@ -320,7 +320,10 @@ class CategoryLevel(OrderedModel):
     name = models.CharField(max_length=100, verbose_name=_('name'))
     name_plural = models.CharField(max_length=100, verbose_name=_('plural name'), null=True, blank=True)
 
-    i18n = TranslationField(fields=('name',), default_language_field='type__plan__primary_language_lowercase')
+    i18n = TranslationField(
+        fields=('name', 'name_plural'),
+        default_language_field='type__plan__primary_language_lowercase',
+    )
 
     public_fields: ClassVar = [
         'id', 'name', 'name_plural', 'order', 'type',


### PR DESCRIPTION
As you can see on https://sunnydale.test.kausal.tech/de/climate/actions/T1, for example, the level "Theme" for the category type of the same name is displayed in English. We do support i18n for the `CategoryLevel` model, but there is no way to edit translations. This PR fixes that. It also makes the field "name_plural" translatable.