### PR TITLE
Set correct colors in css variables

### DIFF
--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -64,7 +64,7 @@ section[role="tabpanel"] .help-block {
   padding-left: 0;
   span.field-visibility-label.w-status--primary {
     color: var(--w-color-grey-800);
-    font-size: .8rem;
+    font-size: 0.8rem;
     font-weight: bold;
   }
   svg {
@@ -89,4 +89,12 @@ section[role="tabpanel"] .help-block {
 /* Wagtail notifications */
 .messages {
   z-index: 1;
+}
+
+.w-tabs__tab {
+  color: var(--w-color-grey-600);
+}
+
+.w-field__help .help {
+  color: var(--w-color-grey-600);
 }


### PR DESCRIPTION
Fix insufficient color contrast for the tab navigation labels and advisory text according accessibility requirements. Set grey-600 instead of default grey-400 for the elements. Tested with Axe tool - no contrast issues detected.

<img width="1241" alt="Screen Shot 2024-04-24 at 09 23 47" src="https://github.com/kausaltech/kausal-watch-private/assets/96352283/0d823659-c3b9-4b1f-bdfa-00383ed76022">

Related Asana task https://app.asana.com/0/0/1206348022567683/f