### PR TITLE
Feat/override branding title

### DIFF
--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -1,5 +1,15 @@
 {% extends "wagtailadmin/base.html" %}
 {% load static wagtailimages_tags wagtailadmin_tags sentry %}
+{% load i18n %}
+
+
+{% block branding_title %}
+    {% if active_plan.short_name %}
+        {{ active_plan.short_name }} - {% trans "Administration" %}
+    {% else %}
+        {{ active_plan.name }} - {% trans "Administration" %}
+    {% endif %}
+{% endblock %}
 
 {% block branding_logo %}
     {% if active_client and active_client.logo %}

--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -5,11 +5,12 @@
 
 {% block branding_title %}
     {% if active_plan.short_name %}
-        {{ active_plan.short_name }} - {% trans "Administration" %}
+        {{ active_plan.short_name|title }} - {% trans "Administration" %}
     {% else %}
-        {{ active_plan.name }} - {% trans "Administration" %}
+        {{ active_plan.name|title }} - {% trans "Administration" %}
     {% endif %}
 {% endblock %}
+
 
 {% block branding_logo %}
     {% if active_client and active_client.logo %}


### PR DESCRIPTION
* The template checks for `active_plan.short_name` first; if not found, it uses `active_plan.name`.
* "Administration" is appended to the title and translated based on the language settings.
* The first letter of the plan name is capitalized by applying `title` template filter.

Related Asana task https://app.asana.com/0/0/1206348022567685/f