### PR TITLE
Improve Accessibility: Add aria-expanded and aria-controls to action menu dropdown

### DIFF
--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -30,12 +30,26 @@
     {{ block.super }}
     {% sentry_init %}
     {# Workaround for being able to navigate to the action button's dropdown menu with the keyboard #}
+    {# Adding aria-expanded and aria-controls to dropdown #}
     <script>
       $(document).ready(function () {
         const dropdownButton = document.querySelector('form footer .dropdown-toggle');
         if (dropdownButton != null) {
           dropdownButton.tabIndex = 0;
           dropdownButton.addEventListener('keydown', (e) => (e.code === "Space" || e.code === "Enter") && dropdownButton.click());
+
+          const dropdownList = document.querySelector('form footer .dropdown-toggle + ul');
+          if (dropdownList != null) {
+            const dropdownListId = 'actionmenu-dropdown-list';
+            dropdownList.id = dropdownListId;
+            dropdownButton.setAttribute('aria-controls', dropdownListId);
+            dropdownButton.setAttribute('aria-expanded', 'false');
+
+            dropdownButton.addEventListener('click', function() {
+              const expanded = dropdownButton.getAttribute('aria-expanded') === 'true' || false;
+              dropdownButton.setAttribute('aria-expanded', !expanded);
+            });
+          }
         }
       });
     </script>


### PR DESCRIPTION
`aria-expanded` and `aria-controls` added to action menu dropdown.
If i understood correctly, this was one of the things wished for.

Asana: https://app.asana.com/0/1206017643443542/1207179169863127


How it was tested:
Only manually by checking that the tags work as they should in Actions and Pages edit view. 
`aria-expanded` reflects if the expandable element the togglebutton controls is expanded or not, and `aria-controls` refers to the element that is controlled by the togglebutton. 