### PR TITLE
Fix assumption there is get_help_panel for all report fields

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -964,6 +964,8 @@ class ActionAdmin(AplansModelAdmin):
         help_panels_for_field = {}
         for snapshot in instance.get_snapshots():
             for field in snapshot.report.type.fields:
+                if not hasattr(field.block, 'get_help_panel'):
+                    continue
                 help_panel = field.block.get_help_panel(field.value, snapshot)
                 if help_panel:
                     help_panels_for_field.setdefault(field.id, []).append(help_panel)


### PR DESCRIPTION
Internal fields don't have help panels for the reporting tab because they cannot be displayed in the reporting tab. Should probably fix this properly later.