### PR TITLE
Accessibility. Fix for screenreader to read out unsaved edits notification.

### DIFF
--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -115,7 +115,7 @@ section[role="tabpanel"] .help-block {
 }
 /* Fix footer in, e.g., custom React-based action index view since Wagtail upgrade */
 .footer__container--hidden {
-  display: none;
+  display: block;
 }
 /* Fix space between action buttons */
 .listing .actions > li {


### PR DESCRIPTION
Change `.footer__container .footer__container--hidden`:  `display:none` --> `display:block`

With `none` the screenreaders ignore the changes that `aria-live` was set to detect

Depends on WT6 upgrade: https://github.com/kausaltech/kausal-watch-private/tree/chore/dependencies-upgrade

Tested manually with orca and NVDA.