### PR TITLE
Do not show internal visibility actions in the public UI by default

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -90,11 +90,13 @@ class ActionQuerySet(SearchableQuerySetMixin, models.QuerySet):
         return self.unmerged().exclude(status__is_completed=True)
 
     def visible_for_user(self, user: UserOrAnon | None, plan: Plan | None = None) -> Self:
-        """ A None value is interpreted identically
-        to a non-authenticated user"""
+        """ A None value is interpreted identically a non-authenticated user"""
         if user is None or not user.is_authenticated:
             return self.filter(visibility=RestrictedVisibilityModel.VisibilityState.PUBLIC)
         return self
+
+    def visible_for_public(self) -> Self:
+        return self.visible_for_user(None)
 
     def complete_for_report(self, report):
         from reports.models import ActionSnapshot

--- a/requirements-kausal.txt
+++ b/requirements-kausal.txt
@@ -1,1 +1,1 @@
-kausal-watch-extensions==0.1.108
+kausal-watch-extensions==0.1.109


### PR DESCRIPTION
Not even for authenticated users. Only when authenticated and explicitly requested (when calling from the admin UI)