### PR TITLE
Use permission policy also for document chooser viewset

### DIFF
--- a/documents/apps.py
+++ b/documents/apps.py
@@ -17,5 +17,8 @@ class DocumentsConfig(AppConfig):
         from wagtail.documents.forms import BaseDocumentForm
         BaseDocumentForm.permission_policy = permission_policy
 
+        from wagtail.documents.views.chooser import viewset
+        viewset.permission_policy = permission_policy
+
         from wagtail.documents import wagtail_hooks  # noqa
         from .rich_text import DocumentLinkHandler  # noqa


### PR DESCRIPTION
Quickfix. Use our permission policy also for document chooser viewset