### PR TITLE
Add visibility field to the public fields for the action model

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -413,6 +413,7 @@ class Action(  # type: ignore[django-manager-missing]
         'related_actions', 'related_indicators', 'impact', 'status_updates', 'merged_with', 'merged_actions',
         'impact_groups', 'monitoring_quality_points', 'implementation_phase', 'manual_status_reason', 'links',
         'primary_org', 'order', 'superseded_by', 'superseded_actions', 'dependent_relationships', 'dependency_role',
+        'visibility'
     ]
 
     # type annotations for related objects


### PR DESCRIPTION
Related Asana task https://app.asana.com/0/1205310117865974/1206503417119354/f
Related frontend PR https://github.com/kausaltech/kausal-extensions/pull/28
* Made `visibility` the public field for the Action model to get access to the field for the query in extensions.

