### PR TITLE
New fields to optimize queries for indicators in prep for visibility and ordering

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -13,7 +13,7 @@ from django.contrib.admin import display
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.validators import URLValidator
 from django.db import models
-from django.db.models import IntegerField, Max, Q
+from django.db.models import Count, IntegerField, Max, Q
 from django.db.models.functions import Cast
 from django.urls import reverse
 from django.utils import timezone, translation
@@ -35,6 +35,7 @@ from aplans.utils import (
     IdentifierField, OrderedModel, PlanRelatedModel, generate_identifier, get_available_variants_for_language,
     ConstantMetadata, DateFormatField
 )
+from indicators.models import Indicator
 from orgs.models import Organization
 from users.models import User
 from search.backends import TranslatedSearchField, TranslatedAutocompleteField
@@ -108,6 +109,18 @@ class ActionQuerySet(SearchableQuerySetMixin, models.QuerySet):
             .values_list('action_id')
         )
         return self.filter(id__in=action_ids)
+
+    def annotate_related_indicator_counts(self, plan):
+        # TODO: visibility coming soon
+        return self.annotate(
+            indicator_count=Count(
+                'related_indicators',filter=Q(
+                    related_indicators__indicator__in=Indicator.objects.available_for_plan(plan))),
+            indicators_with_goals_count=Count(
+                'related_indicators', filter=Q(
+                    related_indicators__indicator__in=Indicator.objects.available_for_plan(plan).filter(
+                        goals__isnull=False))),
+                )
 
 
 class HasGetValue(Protocol):

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -39,6 +39,7 @@ from aplans.utils import (
     get_default_language,
     get_supported_languages
 )
+from indicators.models import Indicator, IndicatorLevel, RelatedIndicator
 from orgs.models import Organization
 from people.models import Person
 
@@ -805,6 +806,13 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage):
             if workflow_state == WorkflowStateEnum.APPROVED: return tasks.last().task
             return None
         return None
+
+    def has_indicator_relationships(self):
+        # TODO: indicator visibility coming soon!
+        visible_levels = IndicatorLevel.objects.filter(plan=self)
+        visible_indicators = Indicator.objects.filter(levels__in=visible_levels)
+        return RelatedIndicator.objects.filter(Q(causal_indicator__in=visible_indicators) &
+                                               Q(effect_indicator__in=visible_indicators)).exists()
 
 
 class PublicationStatus(models.TextChoices):

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -228,6 +228,7 @@ class PlanNode(DjangoNode):
     action_timeliness_classes = graphene.List(
         graphene.NonNull('actions.schema.ActionTimelinessNode'), required=True
     )
+    has_indicator_relationships = graphene.Boolean()
 
     @staticmethod
     def resolve_action_status_summaries(root: Plan, info):
@@ -418,6 +419,10 @@ class PlanNode(DjangoNode):
     @staticmethod
     def resolve_superseded_plans(root: Plan, info, recursive=False):
         return root.get_superseded_plans(recursive)
+
+    @staticmethod
+    def resolve_has_indicator_relationships(root: Plan, info):
+        return root.has_indicator_relationships()
 
     class Meta:
         model = Plan
@@ -1012,6 +1017,8 @@ class ActionNode(AdminButtonsMixin, AttributesMixin, DjangoNode):
     )
     workflow_status = graphene.Field('actions.schema.WorkflowInfoNode')
 
+    indicators_count = graphene.Int()
+    has_indicators_with_goals = graphene.Boolean()
     class Meta:
         model = Action
         fields = Action.public_fields
@@ -1174,6 +1181,16 @@ class ActionNode(AdminButtonsMixin, AttributesMixin, DjangoNode):
             return None
         return root
 
+    @staticmethod
+    def resolve_indicators_count(root: Action, info):
+        inds_count = getattr(root, 'indicator_count', 0)
+        return inds_count
+
+    @staticmethod
+    def resolve_has_indicators_with_goals(root: Action, info):
+        goals_count = getattr(root, 'indicators_with_goals_count', 0)
+        return goals_count > 0
+
 
 class ActionScheduleNode(DjangoNode):
     class Meta:
@@ -1269,6 +1286,9 @@ def plans_actions_queryset(plans, category, first, order_by, user, restrict_to_p
         )
         descendant_cats = Category.objects.filter(f)
         qs = qs.filter(categories__in=descendant_cats).distinct()
+    if isinstance(plans, list) and len(plans) == 1:
+        plan = plans[0]
+        qs = qs.annotate_related_indicator_counts(plan)
     qs = order_queryset(qs, ActionNode, order_by)
     if first is not None:
         qs = qs[0:first]


### PR DESCRIPTION
 In preparation for indicator visibility and ordering:
https://github.com/kausaltech/kausal-watch-private/pull/191
https://github.com/kausaltech/kausal-watch-private/pull/196

Depends on this: https://github.com/kausaltech/kausal-watch-ui/pull/374/files