### PR TITLE
Custom field column block for action dashboard

### DIFF
--- a/actions/blocks/__init__.py
+++ b/actions/blocks/__init__.py
@@ -27,7 +27,7 @@ from actions.blocks.action_content import (
 from actions.blocks.action_dashboard import (
     IdentifierColumnBlock, NameColumnBlock, ImplementationPhaseColumnBlock, StatusColumnBlock, TasksColumnBlock,
     ResponsiblePartiesColumnBlock, IndicatorsColumnBlock, UpdatedAtColumnBlock, OrganizationColumnBlock,
-    ImpactColumnBlock, ActionDashboardColumnBlock
+    ImpactColumnBlock, ActionDashboardColumnBlock, FieldColumnBlock
 )
 from actions.blocks.action_list import ActionHighlightsBlock, ActionListBlock
 from actions.blocks.category_list import CategoryListBlock, CategoryTreeMapBlock
@@ -138,5 +138,5 @@ __all__ = [
     'ResponsiblePartyFilterBlock', 'ContinuousActionFilterBlock',
     'IdentifierColumnBlock', 'NameColumnBlock', 'ImplementationPhaseColumnBlock', 'StatusColumnBlock',
     'TasksColumnBlock', 'ResponsiblePartiesColumnBlock', 'IndicatorsColumnBlock', 'UpdatedAtColumnBlock',
-    'OrganizationColumnBlock', 'ImpactColumnBlock', 'ActionDashboardColumnBlock'
+    'OrganizationColumnBlock', 'ImpactColumnBlock', 'ActionDashboardColumnBlock', FieldColumnBlock
 ]

--- a/actions/blocks/action_dashboard.py
+++ b/actions/blocks/action_dashboard.py
@@ -1,8 +1,11 @@
 from django.utils.translation import gettext_lazy as _
 from grapple.helpers import register_streamfield_block
-from grapple.models import GraphQLString
+from grapple.models import GraphQLForeignKey, GraphQLString
 from wagtail import blocks
 import graphene
+from actions.models.attributes import AttributeType
+
+from actions.blocks.choosers import ActionAttributeTypeChooserBlock
 
 
 class DashboardColumnInterface(graphene.Interface):
@@ -80,6 +83,16 @@ class ImpactColumnBlock(ColumnBlockBase):
     class Meta:
         label = _("Impact")
 
+@register_streamfield_block
+class FieldColumnBlock(ColumnBlockBase):
+    attribute_type = ActionAttributeTypeChooserBlock()
+    class Meta:
+        label = _("Field")
+
+    graphql_fields = ColumnBlockBase.graphql_fields + [
+        GraphQLForeignKey('attribute_type', AttributeType)
+    ]
+
 
 @register_streamfield_block
 class ActionDashboardColumnBlock(blocks.StreamBlock):
@@ -93,9 +106,10 @@ class ActionDashboardColumnBlock(blocks.StreamBlock):
     updated_at = UpdatedAtColumnBlock()
     organization = OrganizationColumnBlock()
     imact = ImpactColumnBlock()
+    field = FieldColumnBlock()
 
     graphql_types = [
         IdentifierColumnBlock, NameColumnBlock, ImplementationPhaseColumnBlock, StatusColumnBlock, TasksColumnBlock,
         ResponsiblePartiesColumnBlock, IndicatorsColumnBlock, UpdatedAtColumnBlock, OrganizationColumnBlock,
-        ImpactColumnBlock
+        ImpactColumnBlock, FieldColumnBlock
     ]


### PR DESCRIPTION
What was done
=============
FieldColumnBlock added to ActionDashboardColumnBlock - Support for AttributeTypes to Action Dashboard

Changelog
=============
Added back-end support for custom attribute fields to Action Dashboard

Reference/Asana
======
https://app.asana.com/0/1206017643443542/1207025752902925

Depends on
================
Nothing, but needs frontend work to show columns to user

How to test & What was tested
========
- Add field(s) to action dashboard in admin.
- Add FieldColumnBlock to DashboardActionList query in GQL :

 ```
 query DashboardActionList($plan: ID!, $relatedPlanActions: Boolean!, $path: String!, $workflow: WorkflowState) @workflow(state: $workflow) @locale(lang: "en") {
.......
fragment ActionTableColumnFragment on ActionListPage {
  dashboardColumns {
    .........
    ... on ImpactColumnBlock {
      columnLabel
      __typename
    }
    ... on FieldColumnBlock {
      columnLabel
      field
      __typename
    }
  }
  __typename
}

```

See that the ids for the fields are returned for the dashboard.