### PR TITLE
Feature/notification rescheduling

### DIFF
--- a/notifications/engine.py
+++ b/notifications/engine.py
@@ -315,7 +315,7 @@ class NotificationEngine:
                     email_sender.queue(msg)
                     if not self.force_to and not self.noop:
                         for item in queue_items:
-                            item.notification.mark_sent(recipient)
+                            item.notification.mark_sent(recipient, now=self.now)
                     notification_count += 1
                     if self.limit and notification_count >= self.limit:
                         if not self.noop:

--- a/notifications/notifications.py
+++ b/notifications/notifications.py
@@ -46,7 +46,7 @@ class Notification:
             return None
         return last_notification.sent_at
 
-    def notification_last_sent(self, recipient: NotificationRecipient | None = None, now=None) -> int | None:
+    def days_since_notification_last_sent(self, recipient: NotificationRecipient | None = None, now=None) -> int | None:
         last_notification_sent_at = self.notification_last_sent_datetime(recipient)
         if last_notification_sent_at is None:
             return None
@@ -71,7 +71,7 @@ class DeadlinePassedNotification(Notification):
         if now is None:
             now = self.plan.now_in_local_timezone()
         for recipient in recipients:
-            days = self.notification_last_sent(recipient, now=now)
+            days = self.days_since_notification_last_sent(recipient, now=now)
             if days is not None:
                 if days < MINIMUM_NOTIFICATION_PERIOD:
                     # We don't want to remind too often
@@ -113,7 +113,7 @@ class DeadlineSoonNotification(Notification):
         if now is None:
             now = self.plan.now_in_local_timezone()
         for recipient in recipients:
-            days = self.notification_last_sent(recipient, now=now)
+            days = self.days_since_notification_last_sent(recipient, now=now)
             if days is not None:
                 if days < MINIMUM_NOTIFICATION_PERIOD:
                     # We don't want to remind too often
@@ -157,7 +157,7 @@ class NotEnoughTasksNotification(Notification):
         if now is None:
             now = self.plan.now_in_local_timezone()
         for recipient in recipients:
-            days_since = self.notification_last_sent(recipient, now=now)
+            days_since = self.days_since_notification_last_sent(recipient, now=now)
             if days_since is not None:
                 if days_since < 30:
                     # We don't want to remind too often
@@ -177,7 +177,7 @@ class ActionNotUpdatedNotification(Notification):
         if now is None:
             now = self.plan.now_in_local_timezone()
         for recipient in recipients:
-            days_since = self.notification_last_sent(recipient, now=now)
+            days_since = self.days_since_notification_last_sent(recipient, now=now)
             if days_since is not None:
                 if days_since < 30:
                     # We don't want to remind too often
@@ -197,7 +197,7 @@ class UserFeedbackReceivedNotification(Notification):
         if now is None:
             now = self.plan.now_in_local_timezone()
         # Send user feedback received notifications only if they haven't been sent yet to anybody
-        if self.notification_last_sent(now=now) is None:
+        if self.days_since_notification_last_sent(now=now) is None:
             for recipient in recipients:
                 engine.queue_notification(self, recipient)
 

--- a/notifications/wagtail_admin.py
+++ b/notifications/wagtail_admin.py
@@ -1,6 +1,4 @@
-from typing import reveal_type
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.forms import BaseFormSet, Select
 from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
https://app.asana.com/0/1206017643443542/1207442965750714/f

The rationale for supporting this is that we need to handle changing of the manual notifications in some way.

The alternative would be to just lock the date field after it has been set, but that would have been bad if the user makes a mistake in the initial date selection. I guess we could have also allowed changing the date only for notifications where the date is still in the future compared to when the user tries to change the date (ie. only for not-sent notifications). Anyway, I suppose this flexibility introduced here (always support rescheduling) would be useful to users, for example for reusing the same notification text over and over without copypasting.