### PR TITLE
Update dev environment installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Create a superuser:
 python manage.py createsuperuser
 ```
 
+To access the admin UI with the created superuser, create and associate a `Person` with it:
+
+```shell
+python manage.py shell_plus
+```
+```python
+superuser = User.objects.get(email="<email of the superuser you created>")
+organization = Organization.objects.get(abbreviation='Kausal')  # Found only if database is prepopulated with the help of a coworker
+
+person = Person.objects.create(
+    user=superuser,
+    first_name="<first name of your user>",
+    last_name="<last name of your user>",
+    email="<email of the superuser you created>",
+    organization=organization
+)
+person.save()
+```
+
 Compile the translation files:
 
 ```shell


### PR DESCRIPTION
Installation instructions were missing a vital step for getting access to the admin UI, add instructions for creating a `Person` for the created superuser.