### PR TITLE
Fix notification type mismatch with new manual notifications

### DIFF
--- a/notifications/__init__.py
+++ b/notifications/__init__.py
@@ -6,5 +6,6 @@ if typing.TYPE_CHECKING:
     from actions.models import Action, ActionTask
     from feedback.models import UserFeedback
     from indicators.models import Indicator
+    from notifications.models import ManuallyScheduledNotificationTemplate
 
-    NotificationObject: typing.TypeAlias = typing.Union[Action, ActionTask, Indicator, UserFeedback]
+    NotificationObject: typing.TypeAlias = typing.Union[Action, ActionTask, Indicator, UserFeedback, ManuallyScheduledNotificationTemplate]

--- a/notifications/engine.py
+++ b/notifications/engine.py
@@ -10,9 +10,9 @@ from typing import Dict, Sequence
 from .mjml import render_mjml_from_template
 from aplans.email_sender import EmailSender
 
-from .models import NotificationType, ManuallyScheduledNotificationTemplate
+from .models import ManuallyScheduledNotificationTemplate
 from .notifications import (
-    ActionNotUpdatedNotification, ManuallyScheduledNotification, Notification, NotEnoughTasksNotification, TaskDueSoonNotification,
+    NotificationType, ActionNotUpdatedNotification, ManuallyScheduledNotification, Notification, NotEnoughTasksNotification, TaskDueSoonNotification,
     TaskLateNotification, UpdatedIndicatorValuesDueSoonNotification, UpdatedIndicatorValuesLateNotification,
     UserFeedbackReceivedNotification,
 )

--- a/notifications/management/commands/initialize_notifications.py
+++ b/notifications/management/commands/initialize_notifications.py
@@ -37,64 +37,12 @@ def initialize_notification_templates(
         'font_family': None,
         'font_css_url': None
     }
-    default_intro_texts_for_notification_type = {
-        'action_not_updated': pgettext(
-            'action_not_updated',
-            "This is an automatic reminder about "
-            "updating the action details in the action plan.  You can "
-            "see on the action plan watch site what has already been done "
-            "to further the actions and what has been planned for the "
-            "future.  It's already six months since you last updated an "
-            "action. Please go and update the action with the latest "
-            "information. You can add an upcoming task to the action at "
-            "the same time."),
-        'not_enough_tasks': pgettext(
-            'not_enough_tasks',
-            "This is an automatic reminder about "
-            "updating the action details in the action plan.  You can "
-            "see on the action plan watch site what has already been "
-            "done to further the actions and what has been planned for "
-            "the future.  This means that it would be preferrable for "
-            "each action to have at least one upcoming task within the "
-            "next year. Please go and add tasks for the action which "
-            "show what the next planned steps for the action are."),
-        'task_due_soon': pgettext(
-            'task_due_soon',
-            "This is an automatic reminder about "
-            "updating the task information of your action in the action "
-            "plan.  There is an action in the action plan with a "
-            "deadline approaching. Please remember to mark the task as "
-            "done as soon as it has been completed. After the deadline "
-            "has gone, the action will be marked as late. You can edit "
-            "the task details from the link below."),
-        'task_late': pgettext(
-            'task_late',
-            "This is an automatic reminder about updating "
-            "the task information of your action in the action plan. "
-            "There is an action whose deadline has passed. The action "
-            "is shown to be late until you mark it as done and fill in "
-            "some details."),
-        'updated_indicator_values_due_soon': pgettext(
-            'updated_indicator_values_due_soon',
-            "This is an automatic "
-            "reminder about updating indicator details in the action "
-            "plan.  The deadline for updating the indicator values is "
-            "approaching. Please go and update the indicator with the "
-            "latest values."),
-        'updated_indicator_values_late': pgettext(
-            'updated_indicator_values_late',
-            "This is an automatic "
-            "reminder about updating indicator details in the action "
-            "plan.  The deadline for updating the indicator values has "
-            "passed. Please go and update the indicator with the latest "
-            "values."),
-        'user_feedback_received': pgettext(
-            'user_feedback_received',
-            "A user has submitted feedback."),
-    }
-
     base_template, created = BaseTemplate.objects.get_or_create(plan=plan, defaults=base_template_defaults)
     for notification_type in NotificationType:
+        default_intro_text = notification_type.default_intro_text
+        if default_intro_text is None:
+            continue
+
         defaults = {
             'subject': notification_type.verbose_name,
         }
@@ -102,8 +50,8 @@ def initialize_notification_templates(
             base=base_template, type=notification_type.identifier, defaults=defaults)
         ContentBlock.objects.get_or_create(
             template=template, identifier='intro', base=base_template,
-            defaults={'content': split_into_draftail_paragraphs(
-                default_intro_texts_for_notification_type.get(notification_type.identifier))})
+            defaults={'content': split_into_draftail_paragraphs(default_intro_text)}
+        )
 
     default_shared_texts = {
         'motivation': pgettext(

--- a/notifications/management/commands/initialize_notifications.py
+++ b/notifications/management/commands/initialize_notifications.py
@@ -93,6 +93,18 @@ def initialize_notification_templates(
             "A user has submitted feedback."),
     }
 
+    base_template, created = BaseTemplate.objects.get_or_create(plan=plan, defaults=base_template_defaults)
+    for notification_type in NotificationType:
+        defaults = {
+            'subject': notification_type.verbose_name,
+        }
+        template, created = AutomaticNotificationTemplate.objects.get_or_create(
+            base=base_template, type=notification_type.identifier, defaults=defaults)
+        ContentBlock.objects.get_or_create(
+            template=template, identifier='intro', base=base_template,
+            defaults={'content': split_into_draftail_paragraphs(
+                default_intro_texts_for_notification_type.get(notification_type.identifier))})
+
     default_shared_texts = {
         'motivation': pgettext(
             'motivation',
@@ -107,18 +119,6 @@ def initialize_notification_templates(
             "Thank you for taking part in implementing the action plan!\n\n"
             "Kind regards,\nthe action plan administrators"),
     }
-
-    base_template, created = BaseTemplate.objects.get_or_create(plan=plan, defaults=base_template_defaults)
-    for notification_type in NotificationType:
-        defaults = {
-            'subject': notification_type.verbose_name,
-        }
-        template, created = AutomaticNotificationTemplate.objects.get_or_create(
-            base=base_template, type=notification_type.identifier, defaults=defaults)
-        ContentBlock.objects.get_or_create(
-            template=template, identifier='intro', base=base_template,
-            defaults={'content': split_into_draftail_paragraphs(
-                default_intro_texts_for_notification_type.get(notification_type.identifier))})
 
     for block_type in ['motivation', 'outro']:
         ContentBlock.objects.get_or_create(

--- a/notifications/management/commands/send_daily_notifications.py
+++ b/notifications/management/commands/send_daily_notifications.py
@@ -4,7 +4,7 @@ from django.utils import translation
 from logging import getLogger
 
 from actions.models import Plan
-from notifications.models import NotificationType
+from notifications.notifications import NotificationType
 from .send_plan_notifications import NotificationEngine
 
 logger = getLogger(__name__)

--- a/notifications/management/commands/send_plan_notifications.py
+++ b/notifications/management/commands/send_plan_notifications.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils import translation
 
 from notifications.engine import NotificationEngine
-from notifications.models import NotificationType
+from notifications.notifications import NotificationType
 from actions.models import Plan
 
 

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -11,7 +11,6 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils.translation import pgettext_lazy, gettext_lazy as _
-from enum import Enum
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
 from typing import Dict, Sequence
@@ -19,6 +18,8 @@ from wagtail.fields import RichTextField
 
 from aplans.utils import PlanRelatedModel
 from people.models import Person
+
+from .notifications import NotificationType
 
 if typing.TYPE_CHECKING:
     from .recipients import EmailRecipient, NotificationRecipient
@@ -29,25 +30,6 @@ DEFAULT_FONT_FAMILY = (
 )
 DEFAULT_LANG = settings.LANGUAGES[0][0]
 logger = logging.getLogger('aplans.notifications')
-
-
-class NotificationType(Enum):
-    TASK_LATE = _("Task is late")
-    TASK_DUE_SOON = _("Task is due soon")
-    ACTION_NOT_UPDATED = _("Action metadata has not been updated recently")
-    NOT_ENOUGH_TASKS = _("Action doesn't have enough in-progress tasks")
-    UPDATED_INDICATOR_VALUES_LATE = _("Updated indicator values are late")
-    UPDATED_INDICATOR_VALUES_DUE_SOON = _("Updated indicator values are due soon")
-    USER_FEEDBACK_RECEIVED = _("User feedback received")
-    MANUALLY_SCHEDULED = _("Manually scheduled notification")
-
-    @property
-    def identifier(self):
-        return self.name.lower()
-
-    @property
-    def verbose_name(self):
-        return self.value
 
 
 ACTION_NOTIFICATION_TYPES = {

--- a/notifications/queue.py
+++ b/notifications/queue.py
@@ -4,8 +4,7 @@ import typing
 from dataclasses import dataclass
 from typing import Dict, List
 
-from .models import NotificationType
-from .notifications import Notification
+from .notifications import Notification, NotificationType
 
 if typing.TYPE_CHECKING:
     from .recipients import NotificationRecipient


### PR DESCRIPTION
Fixes a bug preventing creating plans and adding default notification contents.

Note, there are still some type problems in the file notifications.py, I would like to make the base class Notification generic wrt. the obj attribute, but better get this out soon and do that later.