### PR TITLE
Migrate modeladmin classes to snippets

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -30,7 +30,7 @@ from wagtail_modeladmin.views import IndexView
 from admin_site.wagtail import (
     AplansEditView, AdminOnlyPanel, AplansButtonHelper, AplansCreateView, AplansModelAdmin, AplansTabbedInterface,
     CondensedInlinePanel, CustomizableBuiltInFieldPanel, CustomizableBuiltInPlanFilteredFieldPanel,
-    PlanFilteredFieldPanel, PlanRelatedPermissionHelper, insert_model_translation_panels, get_translation_tabs
+    PlanFilteredFieldPanel, PlanRelatedModelAdminPermissionHelper, insert_model_translation_panels, get_translation_tabs
 )
 from actions.chooser import ActionChooser
 from admin_site.utils import FieldLabelRenderer
@@ -84,7 +84,7 @@ class ReadOnlyInlinePanel(Panel):
             return context
 
 
-class ActionPermissionHelper(PlanRelatedPermissionHelper):
+class ActionPermissionHelper(PlanRelatedModelAdminPermissionHelper):
     def get_plans(self, obj):
         return [obj.plan]
 

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -283,7 +283,10 @@ class PlanAdmin(AplansModelAdmin):
 
 
 # FIXME: This is partly duplicated in content/admin.py.
-class ActivePlanPermissionHelper(PermissionHelper):
+# TODO: Reimplemented in admin_site/permissions.py to make this work without
+# ModelAdmin. Use that when implementing new classes or migrating away from
+# ModelAdmin. Remove this class when ModelAdmin migration is finished.
+class ActivePlanModelAdminPermissionHelper(PermissionHelper):
     def user_can_list(self, user):
         return user.is_superuser
 
@@ -336,7 +339,7 @@ class ActivePlanMenuItem(PlanSpecificSingletonModelAdminMenuItem):
 
 class ActivePlanAdmin(PlanAdmin):
     edit_view_class = ActivePlanEditView
-    permission_helper_class = ActivePlanPermissionHelper
+    permission_helper_class = ActivePlanModelAdminPermissionHelper
     menu_label = _('Plan')
     add_to_settings_menu = True
 
@@ -416,7 +419,7 @@ class ActivePlanFeaturesEditView(SuccessUrlEditPageModelAdminMixin, EditView):
 
 class ActivePlanFeaturesAdmin(PlanFeaturesAdmin):
     edit_view_class = ActivePlanFeaturesEditView
-    permission_helper_class = ActivePlanPermissionHelper
+    permission_helper_class = ActivePlanModelAdminPermissionHelper
     add_to_settings_menu = True
 
     def get_menu_item(self, order=None):
@@ -466,7 +469,7 @@ class ActivePlanNotificationSettingsEditView(SuccessUrlEditPageModelAdminMixin, 
 
 class ActivePlanNotificationSettingsAdmin(NotificationSettingsAdmin):
     edit_view_class = ActivePlanNotificationSettingsEditView
-    permission_helper_class = ActivePlanPermissionHelper
+    permission_helper_class = ActivePlanModelAdminPermissionHelper
     menu_label = _('Plan notification settings')
     add_to_settings_menu = True
 

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -35,7 +35,7 @@ from admin_site.chooser import ClientChooser
 from admin_site.viewsets import WatchEditView, WatchViewSet
 from admin_site.menu import PlanSpecificSingletonModelMenuItem
 from admin_site.mixins import SuccessUrlEditPageMixin
-from admin_site.permissions import ActivePlanPermissionPolicy
+from admin_site.permissions import PlanSpecificSingletonModelSuperuserPermissionPolicy
 
 import typing
 if typing.TYPE_CHECKING:
@@ -286,9 +286,6 @@ class PlanAdmin(AplansModelAdmin):
 
 
 # FIXME: This is partly duplicated in content/admin.py.
-# TODO: Reimplemented in admin_site/permissions.py to make this work without
-# ModelAdmin. Use that when implementing new classes or migrating away from
-# ModelAdmin. Remove this class when ModelAdmin migration is finished.
 class ActivePlanModelAdminPermissionHelper(PermissionHelper):
     def user_can_list(self, user):
         return user.is_superuser
@@ -420,7 +417,12 @@ class ActivePlanFeaturesViewSet(PlanFeaturesViewSet):
 
     @property
     def permission_policy(self):
-        return ActivePlanPermissionPolicy(self.model)
+        # TODO: Commit history looks like this viewset was meant to be open for
+        # plan admins, but due to a bug was really open only for superusers.
+        # Restrict access to superusers to keep the functionality same for now.
+        # Check in the future if this viewset should be opened up for plan
+        # admins.
+        return PlanSpecificSingletonModelSuperuserPermissionPolicy(self.model)
 
 
 register_snippet(ActivePlanFeaturesViewSet)
@@ -452,10 +454,7 @@ class ActivePlanNotificationSettingsMenuItem(PlanSpecificSingletonModelMenuItem)
 
 
 class ActivePlanNotificationSettingsEditView(SuccessUrlEditPageMixin, WatchEditView):
-    permission_policy: ActivePlanPermissionPolicy
-
-    def user_has_permission(self, permission):
-        return self.permission_policy.user_has_permission_for_instance(self.request.user, permission, self.object)
+    pass
 
 
 class ActivePlanNotificationSettingsViewSet(NotificationSettingsViewSet):
@@ -465,7 +464,12 @@ class ActivePlanNotificationSettingsViewSet(NotificationSettingsViewSet):
 
     @property
     def permission_policy(self):
-        return ActivePlanPermissionPolicy(self.model)
+        # TODO: Commit history looks like this viewset was meant to be open for
+        # plan admins, but due to a bug was really open only for superusers.
+        # Restrict access to superusers to keep the functionality same for now.
+        # Check in the future if this viewset should be opened up for plan
+        # admins.
+        return PlanSpecificSingletonModelSuperuserPermissionPolicy(self.model)
 
     def get_menu_item(self, order=None):
         item = ActivePlanNotificationSettingsMenuItem(self, order or self.menu_order)

--- a/admin_site/mixins.py
+++ b/admin_site/mixins.py
@@ -1,4 +1,17 @@
 from typing import Callable
+from urllib.parse import urljoin
+
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.decorators import login_required
+from django.http.request import QueryDict
+from django.http.response import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+
+from admin_site.permissions import PlanContextPermissionPolicy
+from aplans.context_vars import set_instance
+from aplans.types import WatchAdminRequest
+from aplans.utils import PlanRelatedModel
 
 
 class SuccessUrlEditPageMixin:
@@ -12,3 +25,101 @@ class SuccessUrlEditPageMixin:
         # Remove the button that takes the user to the edit view from the
         # success message, since we're redirecting back to the edit view already
         return []
+
+
+class SetInstanceMixin:
+    def setup(self, *args, **kwargs):
+        with set_instance(self.object):
+            super().setup(*args, **kwargs)
+
+    def dispatch(self, *args, **kwargs):
+        with set_instance(self.object):
+            return super().dispatch(*args, **kwargs)
+
+
+class PersistFiltersEditingMixin:
+    def get_success_url(self):
+        if hasattr(super(), 'continue_editing_active') and super().continue_editing_active():
+            return super().get_success_url()
+        model = getattr(self, 'model_name')
+        url = super().get_success_url()
+        if model is None:
+            return url
+        filter_qs = self.request.session.get(f'{model}_filter_querystring')
+        if filter_qs is None:
+            return url
+        # Notice that urljoin will just overwrite any existing query
+        # strings in the url.  The query strings would have to be
+        # parsed, merged, and serialized if url contains query strings
+        return urljoin(url, filter_qs)
+
+
+class ContinueEditingMixin:
+    request: WatchAdminRequest
+
+    def continue_editing_active(self):
+        return '_continue' in self.request.POST
+
+    def get_success_url(self):
+        if self.continue_editing_active():
+            # Save and continue editing
+            return self.get_edit_url()
+
+        return super().get_success_url()
+
+    def get_success_buttons(self):
+        if self.continue_editing_active():
+            # Save and continue editing -> No edit button required
+            return []
+
+        return super().get_success_buttons()
+
+
+class PlanRelatedViewMixin:
+    request: WatchAdminRequest
+
+    def form_valid(self, form, *args, **kwargs):
+        obj = form.instance
+        if isinstance(obj, PlanRelatedModel):
+            # Sanity check to ensure we're saving the model to a currently active
+            # action plan.
+            active_plan = self.request.user.get_active_admin_plan()
+            plans = obj.get_plans()
+            assert active_plan in plans
+
+        return super().form_valid(form, *args, **kwargs)
+
+    def dispatch(self, request: WatchAdminRequest, *args, **kwargs):
+        user = request.user
+        instance = getattr(self, 'object', None)
+        # Check if we need to change the active action plan to be able to modify
+        # the instance. This might happen e.g. when the user clicks on an edit link
+        # in the email notification.
+        if (instance is not None and isinstance(instance, PlanRelatedModel) and
+                user is not None and user.is_authenticated):
+            plan = user.get_active_admin_plan()
+            instance_plans = instance.get_plans()
+            if plan not in instance_plans:
+                querystring = QueryDict(mutable=True)
+                querystring[REDIRECT_FIELD_NAME] = request.get_full_path()
+                url = reverse('change-admin-plan', kwargs=dict(plan_id=instance_plans[0].id))
+                return HttpResponseRedirect(url + '?' + querystring.urlencode())
+
+        return super().dispatch(request, *args, **kwargs)
+
+
+class ActivatePermissionHelperPlanContextMixin:
+    @method_decorator(login_required)
+    def dispatch(self, request: WatchAdminRequest, *args, **kwargs):
+        """Set the plan context for permission helper before dispatching request."""
+
+        if isinstance(self.permission_policy, PlanContextPermissionPolicy):
+            with self.permission_policy.activate_plan_context(request.get_active_admin_plan()):
+                ret = super().dispatch(request, *args, **kwargs)
+                # We trigger render here, because the plan context is needed
+                # still in the render stage.
+                if hasattr(ret, 'render'):
+                    ret = ret.render()
+            return ret
+        else:
+            return super().dispatch(request, *args, **kwargs)

--- a/admin_site/mixins.py
+++ b/admin_site/mixins.py
@@ -26,6 +26,11 @@ class SuccessUrlEditPageMixin:
         # success message, since we're redirecting back to the edit view already
         return []
 
+    def get_breadcrumbs_items(self):
+        # As the idea is to stay only on the edit page, hide the breadcrumb trail
+        # that gives access e.g. to the index view
+        return []
+
 
 class SetInstanceMixin:
     def setup(self, *args, **kwargs):

--- a/admin_site/permissions.py
+++ b/admin_site/permissions.py
@@ -1,8 +1,15 @@
+from contextlib import contextmanager
 from typing import Optional
-from django.conf import settings
-from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
 
+from django.conf import settings
+from wagtail.permission_policies.base import ModelPermissionPolicy
+from wagtail.permission_policies.collections import (
+    CollectionOwnershipPermissionPolicy
+)
+
+from actions.models.plan import Plan
 from aplans.types import WatchAdminRequest
+from aplans.utils import PlanRelatedModel
 
 
 class PlanRelatedCollectionOwnershipPermissionPolicy(CollectionOwnershipPermissionPolicy):
@@ -25,3 +32,79 @@ class PlanRelatedCollectionOwnershipPermissionPolicy(CollectionOwnershipPermissi
         collections = plan.root_collection.get_descendants(inclusive=True)
         qs = qs.filter(collection__in=collections)
         return qs
+
+
+class ActivePlanPermissionPolicy(ModelPermissionPolicy):
+    def user_has_permission(self, user, action):
+        if action == 'view':
+            return user.is_superuser
+        if action == 'add':
+            return user.is_superuser
+        if action == 'change':
+            return user.is_general_admin_for_plan(user.get_active_admin_plan())
+        if action == 'delete':
+            return False
+        return super().user_has_permission(user, action)
+
+    def user_has_permission_for_instance(self, user, action, instance):
+        if action == 'change':
+            if isinstance(instance, Plan):
+                return user.is_general_admin_for_plan(instance)
+            else:
+                return user.is_general_admin_for_plan(instance.plan)
+
+        return super().user_has_permission_for_instance(user, action, instance)
+
+
+class PlanContextPermissionPolicy(ModelPermissionPolicy):
+    plan: Plan | None
+
+    def __init__(self, model, inspect_view_enabled=False):
+        self.plan = None
+        super().__init__(model, inspect_view_enabled)
+
+    def prefetch_cache(self):
+        """Prefetch plan-related content for permission checking."""
+        pass
+
+    def clean_cache(self):
+        pass
+
+    @contextmanager
+    def activate_plan_context(self, plan: Plan):
+        self.plan = plan
+        self.prefetch_cache()
+        try:
+            yield
+        finally:
+            self.clean_cache()
+            self.plan = None
+
+
+class PlanRelatedPermissionPolicy(ModelPermissionPolicy):
+    check_admin_plan = True
+
+    def disable_admin_plan_check(self):
+        self.check_admin_plan = False
+
+    def get_plans(self, obj):
+        if isinstance(obj, PlanRelatedModel):
+            return obj.get_plans()
+        else:
+            raise NotImplementedError('implement in subclass')
+
+    def _obj_matches_active_plan(self, user, obj):
+        if not self.check_admin_plan:
+            return True
+
+        obj_plans = self.get_plans(obj)
+        active_plan = user.get_active_admin_plan()
+        for obj_plan in obj_plans:
+            if obj_plan == active_plan:
+                return True
+        return False
+
+    def user_has_permission_for_instance(self, user, action, instance):
+        if not super().user_has_permission_for_instance(user, action, instance):
+            return False
+        return self._obj_matches_active_plan(user, instance)

--- a/admin_site/permissions.py
+++ b/admin_site/permissions.py
@@ -34,26 +34,13 @@ class PlanRelatedCollectionOwnershipPermissionPolicy(CollectionOwnershipPermissi
         return qs
 
 
-class ActivePlanPermissionPolicy(ModelPermissionPolicy):
+class PlanSpecificSingletonModelSuperuserPermissionPolicy(ModelPermissionPolicy):
+    """Allow access to edit a plan specific singleton model only if user is superuser."""
+
     def user_has_permission(self, user, action):
-        if action == 'view':
-            return user.is_superuser
-        if action == 'add':
-            return user.is_superuser
-        if action == 'change':
-            return user.is_general_admin_for_plan(user.get_active_admin_plan())
-        if action == 'delete':
-            return False
-        return super().user_has_permission(user, action)
-
-    def user_has_permission_for_instance(self, user, action, instance):
-        if action == 'change':
-            if isinstance(instance, Plan):
-                return user.is_general_admin_for_plan(instance)
-            else:
-                return user.is_general_admin_for_plan(instance.plan)
-
-        return super().user_has_permission_for_instance(user, action, instance)
+        if action == 'change' and user.is_superuser:
+            return True
+        return False
 
 
 class PlanContextPermissionPolicy(ModelPermissionPolicy):

--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -1,15 +1,34 @@
 from typing import Generic, Type, TypeVar
 
 from django.db import models
+from django.db.models import ProtectedError
+from django.utils.text import capfirst
+from django.utils.translation import gettext as _
+from wagtail.admin import messages
 from wagtail.snippets.views.snippets import CreateView, EditView, SnippetViewSet
 
 from admin_site.forms import WatchAdminModelForm
+from admin_site.mixins import (
+    ActivatePermissionHelperPlanContextMixin, ContinueEditingMixin,
+    PersistFiltersEditingMixin, PlanRelatedViewMixin, SetInstanceMixin
+)
+from admin_site.permissions import PlanRelatedPermissionPolicy
+from admin_site.wagtail import execute_admin_post_save_tasks
 from aplans.types import WatchAdminRequest
+from aplans.utils import PlanRelatedModel
 
 M = TypeVar('M', bound=models.Model)
 
 
-class WatchEditView(EditView, Generic[M]):
+class WatchEditView(
+    PersistFiltersEditingMixin,
+    ContinueEditingMixin,
+    PlanRelatedViewMixin,
+    ActivatePermissionHelperPlanContextMixin,
+    EditView,
+    SetInstanceMixin,
+    Generic[M]
+):
     request: WatchAdminRequest
     model: Type[M]
 
@@ -18,6 +37,29 @@ class WatchEditView(EditView, Generic[M]):
             **super().get_form_kwargs(),
             'plan': self.request.user.get_active_admin_plan()
         }
+
+    def form_valid(self, form, *args, **kwargs):
+        try:
+            form_valid_return = super().form_valid(form, *args, **kwargs)
+        except ProtectedError as e:
+            for o in e.protected_objects:
+                name = type(o)._meta.verbose_name_plural
+                error = _("Error deleting items. Try first deleting any %(name)s that are in use.") % {'name': name}
+                form.add_error(None, error)
+                form.add_error(None, _('In use: "%(instance)s".') % {'instance': str(o)})
+            messages.validation_error(self.request, self.get_error_message(), form)
+            return self.render_to_response(self.get_context_data(form=form))
+
+        execute_admin_post_save_tasks(form.instance, self.request.user)
+        return form_valid_return
+
+    def get_error_message(self):
+        if hasattr(self.object, 'verbose_name_partitive'):
+            model_name = self.object.verbose_name_partitive
+        else:
+            model_name = self.object._meta.verbose_name
+
+        return _("%s could not be created due to errors.") % capfirst(model_name)
 
 
 class WatchCreateView(CreateView, Generic[M]):
@@ -35,6 +77,12 @@ class WatchViewSet(SnippetViewSet, Generic[M]):
     model: Type[M]
     add_view_class = WatchCreateView
     edit_view_class = WatchEditView
+
+    @property
+    def permission_policy(self):
+        if issubclass(self.model, PlanRelatedModel):
+            return PlanRelatedPermissionPolicy(self.model)
+        return super().permission_policy
 
     def get_form_class(self, for_update: bool = False):
         if not self._edit_handler.base_form_class:

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -399,20 +399,22 @@ class PlanRelatedViewModelAdminMixin:
 # ModelAdmin. Use that when implementing new classes or migrating away from
 # ModelAdmin. Remove this class when ModelAdmin migration is finished.
 class ActivatePermissionHelperPlanContextModelAdminMixin:
+    permission_helper: PermissionHelper
+
     @method_decorator(login_required)
     def dispatch(self, request: WatchAdminRequest, *args, **kwargs):
         """Set the plan context for permission helper before dispatching request."""
 
         if isinstance(self.permission_helper, PlanContextModelAdminPermissionHelper):
             with self.permission_helper.activate_plan_context(request.get_active_admin_plan()):
-                ret = super().dispatch(request, *args, **kwargs)
+                ret = super().dispatch(request, *args, **kwargs)  # type: ignore[misc]
                 # We trigger render here, because the plan context is needed
                 # still in the render stage.
                 if hasattr(ret, 'render'):
                     ret = ret.render()
             return ret
         else:
-            return super().dispatch(request, *args, **kwargs)
+            return super().dispatch(request, *args, **kwargs)  # type: ignore[misc]
 
 
 # TODO: Reimplemented in admin_site/mixins.py to make this work without

--- a/aplans/graphql_helpers.py
+++ b/aplans/graphql_helpers.py
@@ -8,7 +8,7 @@ from graphql.error import GraphQLError
 from graphql.utilities.ast_to_dict import ast_to_dict
 
 from .graphql_types import AdminButton, AuthenticatedUserNode, GQLInfo
-from admin_site.wagtail import AplansModelAdmin, PlanRelatedPermissionHelper
+from admin_site.wagtail import AplansModelAdmin, PlanRelatedModelAdminPermissionHelper
 
 
 def collect_fields(node, fragments):
@@ -131,7 +131,7 @@ class AdminButtonsMixin:
         index_view = adm.index_view_class(adm)
         helper_class = adm.get_button_helper_class()
         helper = helper_class(index_view, info.context)
-        if isinstance(helper.permission_helper, PlanRelatedPermissionHelper):
+        if isinstance(helper.permission_helper, PlanRelatedModelAdminPermissionHelper):
             helper.permission_helper.disable_admin_plan_check()
         buttons = helper.get_buttons_for_obj(root)
         return buttons

--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -20,7 +20,7 @@ from actions.models import Plan
 from aplans.cache import OrganizationActionCountCache
 from aplans.utils import public_fields
 from aplans.graphql_types import WorkflowStateGrapheneEnum
-from admin_site.wagtail import PlanRelatedPermissionHelper
+from admin_site.wagtail import PlanRelatedModelAdminPermissionHelper
 from content.models import SiteGeneralContent
 from feedback import schema as feedback_schema
 from indicators import schema as indicators_schema

--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -20,7 +20,6 @@ from actions.models import Plan
 from aplans.cache import OrganizationActionCountCache
 from aplans.utils import public_fields
 from aplans.graphql_types import WorkflowStateGrapheneEnum
-from admin_site.wagtail import PlanRelatedModelAdminPermissionHelper
 from content.models import SiteGeneralContent
 from feedback import schema as feedback_schema
 from indicators import schema as indicators_schema

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -52,6 +52,7 @@ def notification_type_choice_builder(include_manual: bool = False):
         yield (val.identifier, val.verbose_name)
 
 
+@reversion.register()
 class NotificationSettings(ClusterableModel, PlanRelatedModel):
     plan = models.OneToOneField(
         'actions.Plan', on_delete=models.CASCADE, related_name='notification_settings',

--- a/orgs/views.py
+++ b/orgs/views.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy
 from wagtail.admin import messages
 from wagtail_modeladmin.views import EditView, WMABaseView
 
-from admin_site.wagtail import SetInstanceMixin
+from admin_site.wagtail import SetInstanceModelAdminMixin
 from admin_site.wagtail import AplansCreateView
 from orgs.models import Organization
 
@@ -55,7 +55,7 @@ class OrganizationCreateView(OrganizationViewMixin, AplansCreateView):
         return result
 
 
-class OrganizationEditView(OrganizationViewMixin, SetInstanceMixin, EditView):
+class OrganizationEditView(OrganizationViewMixin, SetInstanceModelAdminMixin, EditView):
     pass
 
 

--- a/people/wagtail_admin.py
+++ b/people/wagtail_admin.py
@@ -22,8 +22,8 @@ from wagtail_modeladmin.views import DeleteView
 from actions.models import ActionContactPerson, Plan, PlanPublicSiteViewer
 from admin_site.wagtail import (
     AplansIndexView, AplansModelAdmin, AplansAdminModelForm, AplansCreateView, AplansEditView,
-    InitializeFormWithPlanMixin, InitializeFormWithUserMixin, PlanContextPermissionHelper,
-    ActivatePermissionHelperPlanContextMixin,
+    InitializeFormWithPlanMixin, InitializeFormWithUserMixin, PlanContextModelAdminPermissionHelper,
+    ActivatePermissionHelperPlanContextModelAdminMixin,
     get_translation_tabs
 )
 from aplans.context_vars import ctx_instance, ctx_request
@@ -204,7 +204,7 @@ class PersonFormForGeneralAdmin(PersonForm):
 
 
 class PersonCreateView(
-        ActivatePermissionHelperPlanContextMixin, InitializeFormWithPlanMixin, InitializeFormWithUserMixin, AplansCreateView
+        ActivatePermissionHelperPlanContextModelAdminMixin, InitializeFormWithPlanMixin, InitializeFormWithUserMixin, AplansCreateView
 ):
     def form_valid(self, form, *args, **kwargs):
         # Make sure form only contains is_admin_for_active_plan
@@ -247,7 +247,7 @@ class PersonIndexView(AplansIndexView):
         return out
 
 
-class PersonPermissionHelper(PlanContextPermissionHelper):
+class PersonPermissionHelper(PlanContextModelAdminPermissionHelper):
     _org_map: dict[int, Organization] | None
 
     def __init__(self, model, inspect_view_enabled=False):
@@ -326,7 +326,7 @@ class PersonButtonHelper(ButtonHelper):
         return buttons
 
 
-class PersonDeleteView(ActivatePermissionHelperPlanContextMixin, DeleteView):
+class PersonDeleteView(ActivatePermissionHelperPlanContextModelAdminMixin, DeleteView):
     instance: Person
     model: typing.Type[Person]
 


### PR DESCRIPTION
Migrates notification settings and plan features to snippets.

As the original classes were using `AplansEditView`, the new `WatchEditView` was updated to mimic the original as closely as possible.