### PR TITLE
Fix/built in field customizations

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -43,6 +43,7 @@ from admin_site.wagtail import (
     AplansEditView,
     AplansModelAdmin,
     AplansTabbedInterface,
+    BuiltInFieldCustomizationAwareEditHandlerMixin,
     CondensedInlinePanel,
     CustomizableBuiltInFieldPanel,
     CustomizableBuiltInPlanFilteredFieldPanel,
@@ -471,7 +472,7 @@ class RelatedModelWithRolePanel(MultiFieldPanel):
         return kwargs
 
 
-class ActionEditHandler(AplansTabbedInterface):
+class ActionEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTabbedInterface):
     def __init__(self, *args, draft_attributes: DraftAttributes | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.draft_attributes = draft_attributes
@@ -482,8 +483,6 @@ class ActionEditHandler(AplansTabbedInterface):
         return result
 
     def get_form_class(self):
-        from admin_site.models import BuiltInFieldCustomization
-
         request = ctx_request.get()
         instance = ctx_instance.get()
         assert isinstance(instance, Action)
@@ -523,22 +522,7 @@ class ActionEditHandler(AplansTabbedInterface):
             form_class.base_fields['official_name'].disabled = True
             form_class.base_fields['official_name'].required = False
 
-        # Disable / remove built-in fields that are not editable / visible due to customization
-        customizations_qs = BuiltInFieldCustomization.objects.filter(
-            plan=plan,
-            content_type=ContentType.objects.get_for_model(Action),
-        )
-        customizations: dict[str, BuiltInFieldCustomization] = {c.field_name: c for c in customizations_qs}
-        for field_name in list(form_class.base_fields.keys()):
-            customization = customizations.get(field_name)
-            if customization:
-                if not customization.is_instance_visible_for(user, plan, instance):
-                    del form_class.base_fields[field_name]
-                    continue
-                if not customization.is_instance_editable_by(user, plan, instance):
-                    form_class.base_fields[field_name].disabled = True
-                    form_class.base_fields[field_name].required = False
-
+        # TODO: Move this to BuiltInFieldCustomizationAwareEditHandlerMixin or somewhere else so it can be reused?
         if not user.is_general_admin_for_plan(plan):
             for panel in list(self.children):
                 if not isinstance(panel, AdminOnlyPanel):

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -753,12 +753,12 @@ class ActionAdmin(AplansModelAdmin):
     ]
 
     task_panels = [
-        FieldPanel('name'),
-        FieldPanel('due_at'),
-        FieldPanel('date_format'),
-        FieldPanel('state'),
-        FieldPanel('completed_at'),
-        FieldPanel('comment'),
+        CustomizableBuiltInFieldPanel('name'),
+        CustomizableBuiltInFieldPanel('due_at'),
+        CustomizableBuiltInFieldPanel('date_format'),
+        CustomizableBuiltInFieldPanel('state'),
+        CustomizableBuiltInFieldPanel('completed_at'),
+        CustomizableBuiltInFieldPanel('comment'),
     ]
 
     task_header_from_js = """

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -258,32 +258,41 @@ class BuiltInFieldCustomizationAwareEditHandlerMixin:
     It will delete all fields from the edit handler's form that are not visible to the current user.
     """
     def get_form_class(self):
-        from admin_site.models import BuiltInFieldCustomization
-
         form_class = super().get_form_class()
 
-        request = ctx_request.get()
-        instance = ctx_instance.get()
-        user = request.user
-        plan = request.get_active_admin_plan()
+        assert not hasattr(self, 'request') # just to be sure we don't accidentally override something...
+        self.request = ctx_request.get()
+        assert not hasattr(self, 'instance')
+        self.instance = ctx_instance.get()
+        assert not hasattr(self, 'user')
+        self.user = self.request.user
+        assert not hasattr(self, 'plan')
+        self.plan = self.request.get_active_admin_plan()
 
         # Disable / remove built-in fields that are not editable / visible due to customization
+        self._change_base_fields(form_class, self.model)
+        for formset in form_class.formsets.values():
+            self._change_base_fields(formset.form, formset.model)
+
+        return form_class
+
+    def _change_base_fields(self, form_class: WagtailAdminModelForm, model: type[Model]):
+        from admin_site.models import BuiltInFieldCustomization
+
         customizations_qs = BuiltInFieldCustomization.objects.filter(
-            plan=plan,
-            content_type=ContentType.objects.get_for_model(self.model),
+            plan=self.plan,
+            content_type=ContentType.objects.get_for_model(model),
         )
         customizations: dict[str, BuiltInFieldCustomization] = {c.field_name: c for c in customizations_qs}
         for field_name in list(form_class.base_fields.keys()):
             customization = customizations.get(field_name)
             if customization:
-                if not customization.is_instance_visible_for(user, plan, instance):
+                if not customization.is_instance_visible_for(self.user, self.plan, self.instance):
                     del form_class.base_fields[field_name]
                     continue
-                if not customization.is_instance_editable_by(user, plan, instance):
+                if not customization.is_instance_editable_by(self.user, self.plan, self.instance):
                     form_class.base_fields[field_name].disabled = True
                     form_class.base_fields[field_name].required = False
-
-        return form_class
 
 
 class ButtonHelperProtocol(Protocol):

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -220,7 +220,6 @@ class BoundCustomizableBuiltInFieldPanelMixin:
     request: WatchAdminRequest
 
     def __init__(self, **kwargs):
-        from actions.models.action import Action
         from admin_site.models import BuiltInFieldCustomization
         super().__init__(**kwargs)
         plan = self.request.get_active_admin_plan()
@@ -228,7 +227,7 @@ class BoundCustomizableBuiltInFieldPanelMixin:
         try:
             customization: BuiltInFieldCustomization = BuiltInFieldCustomization.objects.get(
                 plan=plan,
-                content_type=ContentType.objects.get_for_model(Action),
+                content_type=ContentType.objects.get_for_model(self.panel.model),
                 field_name=self.field_name,
             )
         except BuiltInFieldCustomization.DoesNotExist:

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -40,7 +40,7 @@ from wagtail_modeladmin.views import CreateView, EditView, IndexView
 from wagtailautocomplete.edit_handlers import AutocompletePanel as WagtailAutocompletePanel
 
 from actions.models.plan import Plan
-from aplans.context_vars import set_instance
+from aplans.context_vars import ctx_instance, ctx_request, set_instance
 from aplans.utils import InstancesVisibleForMixin, PlanDefaultsModel, PlanRelatedModel, get_language_from_default_language_field
 from budget.models import DatasetSchema
 from pages.models import ActionListPage
@@ -251,6 +251,40 @@ class CustomizableBuiltInFieldPanel(FieldPanel):
 class CustomizableBuiltInPlanFilteredFieldPanel(FieldPanel):  # Ugh...
     class BoundPanel(BoundCustomizableBuiltInFieldPanelMixin, BoundPlanFilteredFieldPanelMixin, FieldPanel.BoundPanel):
         pass
+
+
+class BuiltInFieldCustomizationAwareEditHandlerMixin:
+    """Mixin to make an edit handler take instances of BuiltInFieldCustomization into account.
+
+    It will delete all fields from the edit handler's form that are not visible to the current user.
+    """
+    def get_form_class(self):
+        from admin_site.models import BuiltInFieldCustomization
+
+        form_class = super().get_form_class()
+
+        request = ctx_request.get()
+        instance = ctx_instance.get()
+        user = request.user
+        plan = request.get_active_admin_plan()
+
+        # Disable / remove built-in fields that are not editable / visible due to customization
+        customizations_qs = BuiltInFieldCustomization.objects.filter(
+            plan=plan,
+            content_type=ContentType.objects.get_for_model(self.model),
+        )
+        customizations: dict[str, BuiltInFieldCustomization] = {c.field_name: c for c in customizations_qs}
+        for field_name in list(form_class.base_fields.keys()):
+            customization = customizations.get(field_name)
+            if customization:
+                if not customization.is_instance_visible_for(user, plan, instance):
+                    del form_class.base_fields[field_name]
+                    continue
+                if not customization.is_instance_editable_by(user, plan, instance):
+                    form_class.base_fields[field_name].disabled = True
+                    form_class.base_fields[field_name].required = False
+
+        return form_class
 
 
 class ButtonHelperProtocol(Protocol):

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -258,41 +258,36 @@ class BuiltInFieldCustomizationAwareEditHandlerMixin:
     It will delete all fields from the edit handler's form that are not visible to the current user.
     """
     def get_form_class(self):
-        form_class = super().get_form_class()
-
-        assert not hasattr(self, 'request') # just to be sure we don't accidentally override something...
-        self.request = ctx_request.get()
-        assert not hasattr(self, 'instance')
-        self.instance = ctx_instance.get()
-        assert not hasattr(self, 'user')
-        self.user = self.request.user
-        assert not hasattr(self, 'plan')
-        self.plan = self.request.get_active_admin_plan()
-
-        # Disable / remove built-in fields that are not editable / visible due to customization
-        self._change_base_fields(form_class, self.model)
-        for formset in form_class.formsets.values():
-            self._change_base_fields(formset.form, formset.model)
-
-        return form_class
-
-    def _change_base_fields(self, form_class: WagtailAdminModelForm, model: type[Model]):
         from admin_site.models import BuiltInFieldCustomization
 
-        customizations_qs = BuiltInFieldCustomization.objects.filter(
-            plan=self.plan,
-            content_type=ContentType.objects.get_for_model(model),
-        )
-        customizations: dict[str, BuiltInFieldCustomization] = {c.field_name: c for c in customizations_qs}
-        for field_name in list(form_class.base_fields.keys()):
-            customization = customizations.get(field_name)
-            if customization:
-                if not customization.is_instance_visible_for(self.user, self.plan, self.instance):
-                    del form_class.base_fields[field_name]
-                    continue
-                if not customization.is_instance_editable_by(self.user, self.plan, self.instance):
-                    form_class.base_fields[field_name].disabled = True
-                    form_class.base_fields[field_name].required = False
+        form_class = super().get_form_class()
+        request = ctx_request.get()
+        instance = ctx_instance.get()
+        user = request.user
+        plan = request.get_active_admin_plan()
+
+        def change_base_fields(form_class: WagtailAdminModelForm, model: type[Model]):
+            customizations_qs = BuiltInFieldCustomization.objects.filter(
+                plan=plan,
+                content_type=ContentType.objects.get_for_model(model),
+            )
+            customizations: dict[str, BuiltInFieldCustomization] = {c.field_name: c for c in customizations_qs}
+            for field_name in list(form_class.base_fields.keys()):
+                customization = customizations.get(field_name)
+                if customization:
+                    if not customization.is_instance_visible_for(user, plan, instance):
+                        del form_class.base_fields[field_name]
+                        continue
+                    if not customization.is_instance_editable_by(user, plan, instance):
+                        form_class.base_fields[field_name].disabled = True
+                        form_class.base_fields[field_name].required = False
+
+        # Disable / remove built-in fields that are not editable / visible due to customization
+        change_base_fields(form_class, self.model)
+        for formset in form_class.formsets.values():
+            change_base_fields(formset.form, formset.model)
+
+        return form_class
 
 
 class ButtonHelperProtocol(Protocol):

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -385,10 +385,9 @@ class IndicatorAdmin(AplansModelAdmin):
         InlinePanel(
             'related_actions',
             panels=[
-                # TODO: Can we use CustomizableBuiltInFieldPanel here, nested in the inline panel?
-                FieldPanel('action', widget=autocomplete.ModelSelect2(url='action-autocomplete')),
-                FieldPanel('effect_type'),
-                FieldPanel('indicates_action_progress'),
+                CustomizableBuiltInFieldPanel('action', widget=autocomplete.ModelSelect2(url='action-autocomplete')),
+                CustomizableBuiltInFieldPanel('effect_type'),
+                CustomizableBuiltInFieldPanel('indicates_action_progress'),
             ],
             heading=_('Indicator for actions'),
         ),

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -22,6 +22,7 @@ from admin_site.wagtail import (
     AplansEditView,
     AplansModelAdmin,
     AplansTabbedInterface,
+    BuiltInFieldCustomizationAwareEditHandlerMixin,
     CondensedInlinePanel,
     CustomizableBuiltInFieldPanel,
     InitializeFormWithPlanMixin,
@@ -337,7 +338,7 @@ class IndicatorEditView(InitializeFormWithPlanMixin, AplansEditView):
     pass
 
 
-class IndicatorEditHandler(AplansTabbedInterface):
+class IndicatorEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTabbedInterface):
     def get_form_class(self):
         request = ctx_request.get()
         instance = ctx_instance.get()
@@ -373,24 +374,25 @@ class IndicatorAdmin(AplansModelAdmin):
     base_form_class = IndicatorForm
 
     basic_panels = [
-        FieldPanel('name'),
-        FieldPanel('time_resolution'),
-        FieldPanel('updated_values_due_at'),
-        FieldPanel('min_value'),
-        FieldPanel('max_value'),
-        FieldPanel('level'),
-        FieldPanel('reference'),
-        FieldPanel('internal_notes'),
+        CustomizableBuiltInFieldPanel('name'),
+        CustomizableBuiltInFieldPanel('time_resolution'),
+        CustomizableBuiltInFieldPanel('updated_values_due_at'),
+        CustomizableBuiltInFieldPanel('min_value'),
+        CustomizableBuiltInFieldPanel('max_value'),
+        CustomizableBuiltInFieldPanel('level'),
+        CustomizableBuiltInFieldPanel('reference'),
+        CustomizableBuiltInFieldPanel('internal_notes'),
         InlinePanel(
             'related_actions',
             panels=[
+                # TODO: Can we use CustomizableBuiltInFieldPanel here, nested in the inline panel?
                 FieldPanel('action', widget=autocomplete.ModelSelect2(url='action-autocomplete')),
                 FieldPanel('effect_type'),
                 FieldPanel('indicates_action_progress'),
             ],
             heading=_('Indicator for actions'),
         ),
-        FieldPanel('description'),
+        CustomizableBuiltInFieldPanel('description'),
     ]
 
     advanced_panels = []


### PR DESCRIPTION
Even though we have been using `CustomizableBuiltInFieldPanel` in models other than `Action`, it did not work there. This PR fixes this.

This PR also implements functionality to be able to use built-in field customizations within inline panels. Previously, customizations only had an effect for panels at the top level of a form.

There still seems to be a persisting old issue that this does not fix: rich-text fields that should not be editable by the current user are editable. This is out of scope of the current PR.