### PR TITLE
Fix Attributetype richtext document links

### DIFF
--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -662,10 +662,6 @@ class GenericTextAttributeType(AttributeType[T]):
                 initial_text = draft_attribute.text_vals.get(attribute_text_field_name)
             elif committed_attribute:
                 initial_text = getattr(committed_attribute, attribute_text_field_name)
-                # If this is a rich text field, wrap the pseudo-HTML in a RichTextObject
-                # https://docs.wagtail.org/en/v5.1.1/extending/rich_text_internals.html#data-format
-                if isinstance(committed_attribute._meta.get_field(attribute_text_field_name), RichTextField):
-                    initial_text = WagtailRichText(initial_text)
 
             form_field_kwargs: dict[str, Any] = dict(initial=initial_text, required=False, help_text=self.instance.help_text_i18n)
             if self.instance.max_length:

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -548,7 +548,7 @@ class AttributeRichTextNode(DjangoNode):
 
     @staticmethod
     def resolve_value(root: AttributeRichText, info):
-        return root.text_i18n
+        return RichText(root.text_i18n)
 
     class Meta:
         model = AttributeRichText


### PR DESCRIPTION
Fixes RichTextAttributeType document links:

- Resolve value for AttributeRichText as RichText so frontend can show them correctly.
- Also removed wrapping of RichTextAttributeType to Richtext for form fields, so that edit form doesn't mangle the values when opening editor again after saving .

Asana: https://app.asana.com/0/1206017643443542/1207810862758771

Tested:
Added richtext document embeds to action attribute, they resolve correctly in frontend.
Open the saved action again, document still shows in editor as document, and hasn't been transformed into a link.