### PR TITLE
Fix the handling of rejections in workflows

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -29,7 +29,7 @@ from modeltrans.translator import get_i18n_field
 from reversion.models import Version
 from wagtail.admin.panels.base import Panel
 from wagtail.fields import RichTextField
-from wagtail.models import DraftStateMixin, LockableMixin, RevisionMixin, Task, WorkflowMixin, TaskState
+from wagtail.models import DraftStateMixin, LockableMixin, RevisionMixin, Task, TaskState, WorkflowMixin
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 
@@ -55,7 +55,7 @@ from users.models import User
 from ..action_status_summary import ActionStatusSummaryIdentifier, ActionTimelinessIdentifier, SummaryContext
 from ..attributes import AttributeFieldPanel, AttributeType
 from ..monitoring_quality import determine_monitoring_quality
-from .attributes import Attribute, AttributeType as AttributeTypeModel, ModelWithAttributes
+from .attributes import AttributeType as AttributeTypeModel, ModelWithAttributes
 
 if typing.TYPE_CHECKING:
     from collections.abc import Sequence
@@ -357,8 +357,9 @@ class Action(
 
     def commit_attributes(self, attributes: dict[str, Any], user):
         """
-        Called when the serialized draft contents of attribute values must be persisted to the actual Attribute models
-        when publishing an action from a draft
+        Persist unpublished serialized draft contents to Attribute models.
+
+        Called when when publishing an action from a draft.
         """
         from actions.attributes import DraftAttributes
         draft_attributes = DraftAttributes.from_revision_content(attributes)
@@ -819,7 +820,7 @@ class Action(
                 if i == 0:
                     return None
                 return all_actions[i - 1]
-        assert False  # should have returned above at some point
+        raise AssertionError()  # should have returned above at some point
 
     def get_snapshots(self, report=None):
         """Return the snapshots of this action, optionally restricted to those for the given report."""
@@ -900,31 +901,31 @@ class Action(
 
     def get_workflow_progress(self) -> tuple[int, int]:
         """
+        Return a tuple of integers (i, n) showing how far in moderation the action is.
+
+        In the sequence of all the moderation tasks, for a workflow with n tasks,
+        shows in which task of the sequence the latest revision of this action is.
+
         A workflow with n amount of tasks can be used for moderating
         action revisions in a plan. (Currently only n=1 and n=2 are actually
-        in use.)
-
-        The tasks of the workflow form a sequence and the action revision
+        in use.). The tasks of the workflow form a sequence and the action revision
         must go through each task in the sequence to be finally
         published (after the last task has been completed, ie. approved).
         Initially, before being submitted and hence before having reached
         the first task in the sequence, the action revision is just a draft revision
         without a corresponding task.
 
-        This method returns a tuple of integers(i, n).
-
-        The integer i indicates how far the current latest action revision has
-        progressed in the sequence of moderation tasks in use in this plan.
-        The integer n indicates the final stage in the workflow task sequence,
-        in other words a published action. It is the amount of moderation tasks
-        in use in this plan.
+        The integer i in the returned tuple indicates how far the current latest action
+        revision has progressed in the sequence of moderation tasks in use in this plan.
+        If i==n, this indicates the revision is in the final stage in the workflow task
+        sequence, in other words it is a published action.
 
         For a moderation workflow with n tasks, the integer i is interpreted like this:
 
         0         Initial state; a draft revision has been saved
                   but not submitted to moderation.
         1         The revision has been sent to the first moderation task.
-        i (where i < n)
+        i, where i < n
                   The revision has progressed to the i'th moderation task,
                   with approvals from all the previous tasks.
         n         The public live version of the action
@@ -1237,7 +1238,8 @@ class ActionRelatedModelTransModelMixin:
             del data['i18n']
         kwargs = {}
         to_delete = set()
-        meta = cast(Options, getattr(cls, '_meta'))
+        assert hasattr(cls, '_meta')
+        meta = cast(Options, cls._meta)
         for field_name, value in data.items():
             field = None
             try:

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -29,7 +29,7 @@ from modeltrans.translator import get_i18n_field
 from reversion.models import Version
 from wagtail.admin.panels.base import Panel
 from wagtail.fields import RichTextField
-from wagtail.models import DraftStateMixin, LockableMixin, RevisionMixin, Task, WorkflowMixin
+from wagtail.models import DraftStateMixin, LockableMixin, RevisionMixin, Task, WorkflowMixin, TaskState
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 
@@ -917,10 +917,17 @@ class Action(
         max_progress = len(workflow_tasks) + 1
         if not self.has_unpublished_changes:
             return (max_progress, max_progress)
-        if self.current_workflow_state is None:
+        workflow_state = self.current_workflow_state
+        if workflow_state is None:
             return (min_progress, max_progress)
-        task = self.current_workflow_task
+        task_state = workflow_state.current_task_state
+        task = task_state.task.specific
         task_index = workflow_tasks.index(task)
+        if task_state.status in [TaskState.STATUS_REJECTED, TaskState.STATUS_CANCELLED]:
+            # After rejection or cancellation, we consider the workflow state
+            # to be in the previous state compared to the the task itself
+            # (ie. in the same state as if it had not been submitted yet at all)
+            task_index -= 1
         return (task_index + 1, max_progress)
 
     def get_dependency_relationships(self, user: UserOrAnon | None, plan: Plan | None) -> ActionDependencyRelationshipQuerySet:

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -900,16 +900,43 @@ class Action(
 
     def get_workflow_progress(self) -> tuple[int, int]:
         """
-        Return a numerical digest of where in the moderation workflow the latest available action revision is.
+        A workflow with n amount of tasks can be used for moderating
+        action revisions in a plan. (Currently only n=1 and n=2 are actually
+        in use.)
 
-        From 0 to n, including the maximum n as the second element in the tuple.
+        The tasks of the workflow form a sequence and the action revision
+        must go through each task in the sequence to be finally
+        published (after the last task has been completed, ie. approved).
+        Initially, before being submitted and hence before having reached
+        the first task in the sequence, the action revision is just a draft revision
+        without a corresponding task.
 
-        0         there is a draft not yet in moderation
-        1         the draft has been sent to moderation
-        2...(n-1) the action is somewhere in moderation
-                  with at least one approval
-                  (if n == 2, this state does not exist)
-        n         there is only the public live version
+        This method returns a tuple of integers(i, n).
+
+        The integer i indicates how far the current latest action revision has
+        progressed in the sequence of moderation tasks in use in this plan.
+        The integer n indicates the final stage in the workflow task sequence,
+        in other words a published action. It is the amount of moderation tasks
+        in use in this plan.
+
+        For a moderation workflow with n tasks, the integer i is interpreted like this:
+
+        0         Initial state; a draft revision has been saved
+                  but not submitted to moderation.
+        1         The revision has been sent to the first moderation task.
+        i (where i < n)
+                  The revision has progressed to the i'th moderation task,
+                  with approvals from all the previous tasks.
+        n         The public live version of the action
+                  is the latest revision available for the action,
+                  ie. the action revision has received an approval
+                  in all the tasks of the moderation workflow.
+
+        Notice that an action can also be sent backwards in the sequence
+        if a moderator requests changes to the revision, rejecting the
+        revision while in a task t. When this happens, the first integer
+        of the tuple is decremented by 1 compared to when the revision was
+        in moderation in that specific task t, before the rejection.
         """
         workflow = self.get_workflow()
         workflow_tasks = [t.specific for t in workflow.tasks.all()]
@@ -926,7 +953,7 @@ class Action(
         if task_state.status in [TaskState.STATUS_REJECTED, TaskState.STATUS_CANCELLED]:
             # After rejection or cancellation, we consider the workflow state
             # to be in the previous state compared to the the task itself
-            # (ie. in the same state as if it had not been submitted yet at all)
+            # (ie. in the same state as if it had not been submitted yet to that task)
             task_index -= 1
         return (task_index + 1, max_progress)
 


### PR DESCRIPTION
In Wagtail, the property current_workflow_task returns None if the workflow is not in progress. We actually need to differentiate between the states where a specific workflow task has been rejected, and the model instance has been returned back to the previous stage, and handle that case explicitly.