### PR TITLE
Fix the most pressing performance degradation in the Admin people index view

### DIFF
--- a/actions/perms.py
+++ b/actions/perms.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 from functools import lru_cache
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
-from treelib import Tree
 from wagtail.models import PAGE_PERMISSION_TYPES, GroupPagePermission
+
+from treelib import Tree
 
 from content.models import SiteGeneralContent
 from indicators.models import (
@@ -54,9 +57,7 @@ from .models import (
 
 User = get_user_model()
 
-
 ACTIONS_APP = 'actions'
-
 ALL_PERMS = ('view', 'change', 'publish', 'delete', 'add')
 
 

--- a/actions/perms.py
+++ b/actions/perms.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import typing
 from functools import lru_cache
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.query import QuerySet
 from wagtail.models import PAGE_PERMISSION_TYPES, GroupPagePermission
 
 from treelib import Tree
@@ -54,6 +54,10 @@ from .models import (
     MonitoringQualityPoint,
     Plan,
 )
+
+if typing.TYPE_CHECKING:
+    from django.db.models.query import QuerySet
+
 
 User = get_user_model()
 

--- a/actions/perms.py
+++ b/actions/perms.py
@@ -3,6 +3,8 @@ from functools import lru_cache
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db.models.query import QuerySet
+from treelib import Tree
 from wagtail.models import PAGE_PERMISSION_TYPES, GroupPagePermission
 
 from content.models import SiteGeneralContent
@@ -24,7 +26,7 @@ from indicators.models import (
     Unit,
 )
 from notifications.models import AutomaticNotificationTemplate, BaseTemplate, ContentBlock
-from orgs.models import Organization
+from orgs.models import Organization, OrganizationPlanAdmin
 from people.models import Person
 from reports.models import Report, ReportType
 
@@ -43,6 +45,7 @@ from .models import (
     AttributeTypeChoiceOption,
     Category,
     CategoryType,
+    GeneralPlanAdmin,
     ImpactGroup,
     ImpactGroupAction,
     MonitoringQualityPoint,
@@ -362,3 +365,99 @@ class ActionRelatedAdminPermMixin:
         if not isinstance(obj, Action):
             obj = None
         return request.user.can_modify_action(obj)
+
+
+@lru_cache
+def get_people_with_login_rights():
+    all_orgs = _make_organization_tree(
+        Organization.objects.order_by('path').all(),
+    )
+    return calculate_people_with_login_rights(
+        superusers=set(
+            Person.objects.filter(user__is_superuser=True).values_list('pk', flat=True),
+        ),
+        general_plan_admins=set(
+            GeneralPlanAdmin.objects.values_list('person_id', flat=True),
+        ),
+        action_contact_persons=set(
+            ActionContactPerson.objects.values_list('person_id', flat=True),
+        ),
+        indicator_contact_persons=set(
+            IndicatorContactPerson.objects.values_list('person_id', flat=True),
+        ),
+        responsible_orgs=set(
+            ActionResponsibleParty.objects.values_list('organization_id', flat=True),
+        ),
+        primary_orgs=set(
+            Action.objects.values_list('primary_org_id', flat=True),
+        ),
+        indicator_orgs=set(
+            Indicator.objects.values_list('organization_id', flat=True),
+        ),
+        organization_plan_admins=set(
+            OrganizationPlanAdmin.objects.values_list('organization_id', 'person_id'),
+        ),
+        all_orgs=all_orgs,
+    )
+
+
+def calculate_people_with_login_rights(  # noqa: PLR0913
+    *,
+    superusers: set[int],
+    general_plan_admins: set[int],
+    action_contact_persons: set[int],
+    indicator_contact_persons: set[int],
+    responsible_orgs: set[int],
+    primary_orgs: set[int],
+    indicator_orgs: set[int],
+    organization_plan_admins: set[tuple[int, int]],
+    all_orgs: Tree,
+) -> set[int]:
+    """
+    Return a set of Person pks specifying all the persons who have any edit rights in the system.
+
+    Receive a snapshot with sets of pks for all model instances in the db which are needed for determining
+    if a person has some edit rights anywhere in the system to determine this.
+
+    """
+    persons_with_permissions_pks = (
+        superusers |
+        general_plan_admins |
+        action_contact_persons |
+        indicator_contact_persons
+    )
+    used_org_ids = (
+        responsible_orgs |
+        primary_orgs |
+        indicator_orgs
+    )
+    for org_id, person_id in organization_plan_admins:
+        org_and_descendants = set(all_orgs.expand_tree(org_id))
+        if org_and_descendants.intersection(used_org_ids):
+            persons_with_permissions_pks.add(person_id)
+
+    return persons_with_permissions_pks
+
+
+def _make_organization_tree(all_orgs: QuerySet[Organization]) -> Tree:
+    orgs_by_path = { org.path: org for org in all_orgs }
+    tree = Tree()
+    root_id = -1
+    tree.create_node(
+        tag='<root>',
+        identifier=root_id,
+        parent=None,
+    )
+    for o in all_orgs:
+        if o.is_root():
+            parent_id = root_id
+        else:
+            parent_path = o.get_parent_path()
+            assert parent_path is not None
+            parent_id = orgs_by_path[parent_path].pk
+        tree.create_node(
+            tag=o.name,
+            identifier=o.pk,
+            parent=parent_id,
+        )
+    return tree

--- a/actions/signals.py
+++ b/actions/signals.py
@@ -6,11 +6,15 @@ from wagtail.signals import task_cancelled, task_submitted
 
 from anymail.signals import post_send, pre_send
 
+from indicators.models import Indicator, IndicatorContactPerson
 from notifications.models import NotificationSettings
+from orgs.models import Organization, OrganizationPlanAdmin
+from people.models import Person
 
 from .mail import ActionModeratorApprovalTaskStateSubmissionEmailNotifier, ActionModeratorCancelTaskStateSubmissionEmailNotifier
-from .models import Action, Category, Plan, PlanFeatures
+from .models import Action, ActionContactPerson, ActionResponsibleParty, Category, GeneralPlanAdmin, Plan, PlanFeatures
 from .models.attributes import AttributeType
+from .perms import get_people_with_login_rights
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +55,28 @@ def invalidate_attribute_type_cache(sender, instance, **kwargs):
 
 action_moderator_approval_task_submission_email_notifier = ActionModeratorApprovalTaskStateSubmissionEmailNotifier()
 action_moderator_cancel_task_submission_email_notifier = ActionModeratorCancelTaskStateSubmissionEmailNotifier()
+
+
+MODELS_WHICH_AFFECT_LOGIN_RIGHTS = (
+    Person,
+    GeneralPlanAdmin,
+    ActionContactPerson,
+    IndicatorContactPerson,
+    ActionResponsibleParty,
+    Action,
+    Indicator,
+    OrganizationPlanAdmin,
+    Organization,
+)
+
+
+def clear_login_rights_cache(sender, instance, **kwargs):
+    get_people_with_login_rights.cache_clear()
+
+
+for model in MODELS_WHICH_AFFECT_LOGIN_RIGHTS:
+    post_save.connect(clear_login_rights_cache, sender=model)
+    post_delete.connect(clear_login_rights_cache, sender=model)
 
 
 def register_signal_handlers():

--- a/actions/tests/fixtures.py
+++ b/actions/tests/fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from actions.models import AttributeType

--- a/actions/tests/test_api.py
+++ b/actions/tests/test_api.py
@@ -1,53 +1,16 @@
 from __future__ import annotations
 
 from itertools import permutations
-from typing import Iterable, List
 
 from django.urls import reverse
 
 import pytest
 
-from aplans.tests.tree import Tree, parse_tree_string
-
-from actions.api import ActionSerializer, OrganizationSerializer
+from actions.api import ActionSerializer
 from actions.tests.factories import ActionFactory
-from kausal_common.logging.handler import get_rich_log_console
-from orgs.models import Organization
 from orgs.tests.factories import OrganizationFactory
 
 pytestmark = pytest.mark.django_db
-
-
-def orgs_to_trees(roots: Iterable[Organization], indent=0):
-    result: list[Tree] = []
-    for root in roots:
-        tree = Tree(root.name, indent)
-        for child in orgs_to_trees(root.get_children(), indent + 4):
-            tree.add_child(child)
-        result.append(tree)
-    return result
-
-
-def tree_to_org(tree: Tree, parent: Organization | None=None):
-    org = OrganizationFactory.create(name=tree.name, abbreviation=tree.name, parent=parent)
-    for child in tree.children:
-        tree_to_org(child, org)
-    return org
-
-
-@pytest.fixture()
-def org_hierarchy():
-    trees = parse_tree_string("""
-        1
-        2
-            2.1
-            2.2
-        3
-            3.1
-            3.2
-            3.3
-    """)
-    return [tree_to_org(tree) for tree in trees]
 
 
 def test_plan_api_get(api_client, plan_list_url, plan):
@@ -337,154 +300,6 @@ def test_action_bulk_serializer_reorder(plan, order):
     actions_after_save = list(plan.actions.all())
     assert actions_after_save == actions
     assert [a1.order == a2.order for a1, a2 in zip(actions_after_save, actions)]
-
-
-def assert_org_hierarchy(expected_hierarchy: str):
-    actual_roots = Organization.get_root_nodes()
-    actual = orgs_to_trees(actual_roots)
-    expected = parse_tree_string(expected_hierarchy)
-    # We could use this, but comparing the values as strings produces nicer error messages
-    # assert len(actual) == len(expected)
-    # assert all(a.equals(e) for (a, e) in zip(actual, expected))
-    actual_str = ''.join(str(tree) for tree in actual)
-    expected_str = ''.join(str(tree) for tree in expected)
-    assert actual_str == expected_str
-
-
-def update_org_hierarchy(goal_string: str):
-    # Only handles moving subtrees around for now
-    uuid_for_name: dict[str, str | None]  = {'<dummy>': None}
-    goal = Tree('<dummy>', 0)
-    for root in parse_tree_string(goal_string, reset_indent=False):
-        root.reset_indent(4)
-        goal.add_child(root)
-        for node in root.traverse():
-            uuid_for_name[node.name] = str(Organization.objects.get(name=node.name).uuid)
-    current = Tree('<dummy>', 0)
-    for child in orgs_to_trees(Organization.get_root_nodes(), 4):
-        current.add_child(child)
-    serializer_input = []
-    for goal_node in goal.traverse():
-        current_node = current.get_node(goal_node.name)
-        assert current_node
-        changed_fields = []
-        for field in ('parent', 'left_sibling'):
-            current_value = getattr(current_node, field)
-            current_value = current_value.name if current_value else None
-            goal_value = getattr(goal_node, field)
-            goal_value = goal_value.name if goal_value else None
-            if current_value != goal_value:
-                changed_fields.append(field)
-        if changed_fields:
-            node_data = OrganizationSerializer(Organization.objects.get(name=goal_node.name)).data
-            for field in changed_fields:
-                goal_value = getattr(goal_node, field)
-                goal_uuid_str = uuid_for_name[goal_value.name] if goal_value else None
-                assert node_data[field] != goal_uuid_str
-                node_data[field] = goal_uuid_str if goal_uuid_str else None
-            serializer_input.append(node_data)
-    serializer = OrganizationSerializer(many=True, data=serializer_input, instance=Organization.objects.all())
-    assert serializer.is_valid()
-    serializer.save()
-
-
-def test_organization_bulk_serializer_move_org1_after_org2(org_hierarchy):
-    expected = """
-        2
-            2.1
-            2.2
-        1
-        3
-            3.1
-            3.2
-            3.3
-    """
-    update_org_hierarchy(expected)
-    assert_org_hierarchy(expected)
-
-
-def test_organization_bulk_serializer_move_org1_after_org21(org_hierarchy):
-    expected = """
-        2
-            2.1
-            1
-            2.2
-        3
-            3.1
-            3.2
-            3.3
-    """
-    update_org_hierarchy(expected)
-    assert_org_hierarchy(expected)
-
-
-def test_organization_bulk_serializer_move_org22_after_org3(org_hierarchy):
-    expected = """
-        1
-        2
-            2.1
-        3
-            3.1
-            3.2
-            3.3
-        2.2
-    """
-    update_org_hierarchy(expected)
-    assert_org_hierarchy(expected)
-
-
-def test_organization_bulk_serializer_move_org3_below_org22(org_hierarchy):
-    expected = """
-        1
-        2
-            2.1
-            2.2
-                3
-                    3.1
-                    3.2
-                    3.3
-    """
-    update_org_hierarchy(expected)
-    assert_org_hierarchy(expected)
-
-
-@pytest.mark.parametrize('order', permutations(range(3)))
-def test_organization_bulk_serializer_move_children_of_org3(org_hierarchy, order):
-    expected = f"""
-        1
-        2
-            2.1
-            2.2
-        3
-            3.{order[0]+1}
-            3.{order[1]+1}
-            3.{order[2]+1}
-    """
-    update_org_hierarchy(expected)
-    assert_org_hierarchy(expected)
-
-
-@pytest.mark.parametrize('order', permutations(range(3)))
-def test_organization_bulk_serializer_move_roots(org_hierarchy, order):
-    subtrees = [
-        """
-        1
-        """,
-        """
-        2
-            2.1
-            2.2
-        """,
-        """
-        3
-            3.1
-            3.2
-            3.3
-        """,
-    ]
-    expected = subtrees[order[0]] + subtrees[order[1]] + subtrees[order[2]]
-    update_org_hierarchy(expected)
-    assert_org_hierarchy(expected)
 
 
 def test_category_api_get(api_client, category_list_url, category):

--- a/actions/tests/test_api_organization_serializer.py
+++ b/actions/tests/test_api_organization_serializer.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from itertools import permutations
+
+import pytest
+
+from aplans.tests.tree import Tree, parse_tree_string
+
+from actions.api import OrganizationSerializer
+from orgs.models import Organization
+from orgs.tests.fixtures import *  # noqa: F403
+from orgs.tests.utils import assert_org_hierarchy, orgs_to_trees
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def original_org_hierarchy(organization_hierarchy_factory):
+    return organization_hierarchy_factory("""
+        1
+        2
+            2.1
+            2.2
+        3
+            3.1
+            3.2
+            3.3
+    """)
+
+
+def update_org_hierarchy(goal_string: str):
+    # Only handles moving subtrees around for now
+    uuid_for_name: dict[str, str | None]  = {'<dummy>': None}
+    goal = Tree('<dummy>', 0)
+    for root in parse_tree_string(goal_string, reset_indent=False):
+        root.reset_indent(4)
+        goal.add_child(root)
+        for node in root.traverse():
+            uuid_for_name[node.name] = str(Organization.objects.get(name=node.name).uuid)
+    current = Tree('<dummy>', 0)
+    for child in orgs_to_trees(Organization.get_root_nodes(), 4):
+        current.add_child(child)
+    serializer_input = []
+    for goal_node in goal.traverse():
+        current_node = current.get_node(goal_node.name)
+        assert current_node
+        changed_fields = []
+        for field in ('parent', 'left_sibling'):
+            current_value = getattr(current_node, field)
+            current_value = current_value.name if current_value else None
+            goal_value = getattr(goal_node, field)
+            goal_value = goal_value.name if goal_value else None
+            if current_value != goal_value:
+                changed_fields.append(field)
+        if changed_fields:
+            node_data = OrganizationSerializer(Organization.objects.get(name=goal_node.name)).data
+            for field in changed_fields:
+                goal_value = getattr(goal_node, field)
+                goal_uuid_str = uuid_for_name[goal_value.name] if goal_value else None
+                assert node_data[field] != goal_uuid_str
+                node_data[field] = goal_uuid_str if goal_uuid_str else None
+            serializer_input.append(node_data)
+    serializer = OrganizationSerializer(many=True, data=serializer_input, instance=Organization.objects.all())
+    assert serializer.is_valid()
+    serializer.save()
+
+
+def test_organization_bulk_serializer_move_org1_after_org2(original_org_hierarchy):
+    expected = """
+        2
+            2.1
+            2.2
+        1
+        3
+            3.1
+            3.2
+            3.3
+    """
+    update_org_hierarchy(expected)
+    assert_org_hierarchy(expected)
+
+
+def test_organization_bulk_serializer_move_org1_after_org21(original_org_hierarchy):
+    expected = """
+        2
+            2.1
+            1
+            2.2
+        3
+            3.1
+            3.2
+            3.3
+    """
+    update_org_hierarchy(expected)
+    assert_org_hierarchy(expected)
+
+
+def test_organization_bulk_serializer_move_org22_after_org3(original_org_hierarchy):
+    expected = """
+        1
+        2
+            2.1
+        3
+            3.1
+            3.2
+            3.3
+        2.2
+    """
+    update_org_hierarchy(expected)
+    assert_org_hierarchy(expected)
+
+
+def test_organization_bulk_serializer_move_org3_below_org22(original_org_hierarchy):
+    expected = """
+        1
+        2
+            2.1
+            2.2
+                3
+                    3.1
+                    3.2
+                    3.3
+    """
+    update_org_hierarchy(expected)
+    assert_org_hierarchy(expected)
+
+
+@pytest.mark.parametrize('order', permutations(range(3)))
+def test_organization_bulk_serializer_move_children_of_org3(original_org_hierarchy, order):
+    expected = f"""
+        1
+        2
+            2.1
+            2.2
+        3
+            3.{order[0]+1}
+            3.{order[1]+1}
+            3.{order[2]+1}
+    """
+    update_org_hierarchy(expected)
+    assert_org_hierarchy(expected)
+
+
+@pytest.mark.parametrize('order', permutations(range(3)))
+def test_organization_bulk_serializer_move_roots(original_org_hierarchy, order):
+    subtrees = [
+        """
+        1
+        """,
+        """
+        2
+            2.1
+            2.2
+        """,
+        """
+        3
+            3.1
+            3.2
+            3.3
+        """,
+    ]
+    expected = subtrees[order[0]] + subtrees[order[1]] + subtrees[order[2]]
+    update_org_hierarchy(expected)
+    assert_org_hierarchy(expected)

--- a/actions/tests/test_login_rights.py
+++ b/actions/tests/test_login_rights.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from actions.perms import _make_organization_tree, calculate_people_with_login_rights
+from orgs.models import Organization
+from orgs.tests.fixtures import *  # noqa: F403
+from people.models import Person
+
+pytestmark = pytest.mark.django_db
+
+
+ORG_TREE = """
+    1
+    2
+        2.1
+        2.2
+            2.2.1
+    3
+        3.1
+"""
+
+
+@pytest.fixture()
+def organization_hierarchy(organization_hierarchy_factory):
+    return organization_hierarchy_factory(ORG_TREE)
+
+
+def get_org_pk(name: str) -> int:
+    return Organization.objects.get(name=name).pk
+
+
+@pytest.fixture()
+def test_data(organization_hierarchy):
+    all_orgs = _make_organization_tree(Organization.objects.order_by('path').all())
+    return {
+        'superusers': {1},
+        'general_plan_admins': {2},
+        'action_contact_persons': {3},
+        'indicator_contact_persons': {4},
+        'responsible_orgs': {get_org_pk("3.1")},
+        'primary_orgs': {get_org_pk("1")},
+        'indicator_orgs': {get_org_pk("2.2.1")},
+        'organization_plan_admins': {
+            # (org, person)
+            (get_org_pk("2.1"), 3),
+            (get_org_pk("2.2.1"), 4),
+            (get_org_pk("3"), 5),
+        },
+        'all_orgs': all_orgs,
+    }
+
+
+@pytest.fixture()
+def create_models(  # noqa: C901
+        superuser,
+        plan,
+        user_factory,
+        person_factory,
+        action_contact_factory,
+        indicator_contact_factory,
+        action_responsible_party_factory,
+        action_factory,
+        indicator_factory,
+        organization_plan_admin_factory,
+):
+    """Return the same test data but ensure there are models matching it."""
+    def _create_models(test_data) -> dict[str, Any]:
+        for pk in test_data['superusers']:
+            person_factory(user=superuser, pk=pk)
+        for pk in test_data['general_plan_admins']:
+            person_factory(general_admin_plans=[plan], pk=pk)
+        for pk in test_data['action_contact_persons']:
+            person = person_factory(pk=pk)
+            action_contact_factory(person=person)
+        for pk in test_data['indicator_contact_persons']:
+            person = person_factory(pk=pk)
+            ic = indicator_contact_factory(person=person)
+            ic.indicator.plans.set([plan])
+        for pk in test_data['responsible_orgs']:
+            action_responsible_party_factory(organization_id=pk)
+        for pk in test_data['primary_orgs']:
+            action_factory(primary_org_id=pk, plan=plan)
+        for pk in test_data['indicator_orgs']:
+            indicator = indicator_factory(organization_id=pk)
+            indicator.plans.set([plan])
+        for org_pk, person_pk in test_data['organization_plan_admins']:
+            if not Person.objects.filter(pk=person_pk).exists():
+                person_factory(pk=person_pk)
+            organization_plan_admin_factory(
+                plan=plan,
+                organization_id=org_pk,
+                person_id=person_pk,
+            )
+        return test_data
+    return _create_models
+
+
+def test_superusers(test_data):
+    result = calculate_people_with_login_rights(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=set(),
+        indicator_contact_persons=set(),
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    )
+    assert result == {1}
+
+
+def test_general_plan_admins(test_data):
+    result = calculate_people_with_login_rights(
+        superusers=test_data['superusers'],
+        general_plan_admins=test_data['general_plan_admins'],
+        action_contact_persons=set(),
+        indicator_contact_persons=set(),
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    )
+    assert result == {1, 2}
+
+
+def test_action_contact_persons(test_data):
+    result = calculate_people_with_login_rights(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=test_data['action_contact_persons'],
+        indicator_contact_persons=set(),
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    )
+    assert result == {1, 3}
+
+
+def test_indicator_contact_persons(test_data):
+    result = calculate_people_with_login_rights(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=set(),
+        indicator_contact_persons=test_data['indicator_contact_persons'],
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    )
+    assert result == {1, 4}
+
+
+def test_organization_plan_admins(test_data):
+    result = calculate_people_with_login_rights(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=set(),
+        indicator_contact_persons=set(),
+        responsible_orgs=test_data['responsible_orgs'],
+        primary_orgs=test_data['primary_orgs'],
+        indicator_orgs=test_data['indicator_orgs'],
+        organization_plan_admins=test_data['organization_plan_admins'],
+        all_orgs=test_data['all_orgs'],
+    )
+    assert result == {1, 4, 5}
+
+
+def assert_user_access_matches_result(result: set[int]):
+    for pk in result:
+        person = Person.objects.get(pk=pk)
+        assert person.user
+        assert person.user.can_access_admin()
+    for person in Person.objects.all():
+        if person.pk in result:
+            continue
+        user = person.user
+        assert user
+        assert not user.can_access_admin()
+
+
+def test_superusers_match_user_can_access_admin(test_data, create_models):
+    test_data_with_models = create_models(dict(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=set(),
+        indicator_contact_persons=set(),
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    ))
+    result = calculate_people_with_login_rights(**test_data_with_models)
+    assert_user_access_matches_result(result)
+
+
+def test_general_plan_admins_match_user_can_access_admin(test_data, create_models):
+    test_data_with_models = create_models(dict(
+        superusers=test_data['superusers'],
+        general_plan_admins=test_data['general_plan_admins'],
+        action_contact_persons=set(),
+        indicator_contact_persons=set(),
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    ))
+    result = calculate_people_with_login_rights(**test_data_with_models)
+    assert_user_access_matches_result(result)
+
+
+def test_action_contact_persons_match_user_can_access_admin(test_data, create_models):
+    test_data_with_models = create_models(dict(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=test_data['action_contact_persons'],
+        indicator_contact_persons=set(),
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    ))
+    result = calculate_people_with_login_rights(**test_data_with_models)
+    assert_user_access_matches_result(result)
+
+
+def test_indicator_contact_persons_match_user_can_access_admin(test_data, create_models):
+    test_data_with_models = create_models(dict(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=set(),
+        indicator_contact_persons=test_data['indicator_contact_persons'],
+        responsible_orgs=set(),
+        primary_orgs=set(),
+        indicator_orgs=set(),
+        organization_plan_admins=set(),
+        all_orgs=test_data['all_orgs'],
+    ))
+    result = calculate_people_with_login_rights(**test_data_with_models)
+    assert_user_access_matches_result(result)
+
+
+def test_organization_plan_admins_match_user_can_access_admin(test_data, create_models):
+    test_data_with_models = create_models(dict(
+        superusers=test_data['superusers'],
+        general_plan_admins=set(),
+        action_contact_persons=set(),
+        indicator_contact_persons=set(),
+        responsible_orgs=test_data['responsible_orgs'],
+        primary_orgs=test_data['primary_orgs'],
+        indicator_orgs=test_data['indicator_orgs'],
+        organization_plan_admins=test_data['organization_plan_admins'],
+        all_orgs=test_data['all_orgs'],
+    ))
+    result = calculate_people_with_login_rights(**test_data_with_models)
+    assert_user_access_matches_result(result)

--- a/aplans/tests/tree.py
+++ b/aplans/tests/tree.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 
 class Tree:
     def __init__(self, name: str, indent: int):
@@ -19,7 +17,7 @@ class Tree:
             if sibling == self:
                 return prev_node
             prev_node = sibling
-        assert False
+        raise AssertionError('Unexpected tree state: self.parent.children does not contain self')
 
     def add_child(self, child: Tree):
         self.children.append(child)
@@ -31,7 +29,7 @@ class Tree:
         """Determine equality of structure and names, ignoring indentation."""
         return (self.name == other.name
                 and len(self.children) == len(other.children)
-                and all(x.equals(y) for (x, y) in zip(self.children, other.children)))
+                and all(x.equals(y) for (x, y) in zip(self.children, other.children, strict=True)))
 
     def reset_indent(self, indent=0, shiftwidth=4):
         """Make indentation nice."""
@@ -77,7 +75,8 @@ def parse_tree_string(tree_string: str, reset_indent=True):
         while indent <= stack[-1].indent:
             last_popped = stack.pop()
         if last_popped and indent < last_popped.indent:
-            raise ValueError(f"Invalid indentation for '{name}' at line {i}")
+            msg = f"Invalid indentation for '{name}' at line {i}"
+            raise ValueError(msg)
         child = Tree(name, indent)
         stack[-1].add_child(child)
         stack.append(child)

--- a/orgs/models.py
+++ b/orgs/models.py
@@ -83,6 +83,13 @@ class Node[QS: MP_NodeQuerySet](MP_Node[QS], ClusterableModel):
     def __str__(self) -> str:
         return self.name
 
+    def get_parent_path(self, update=False) -> str | None:
+        depth = int(len(self.path) / self.steplen)
+        if depth <= 1:
+            return None
+        parentpath = self._get_basepath(self.path, depth - 1)
+        return parentpath
+
 
 class OrganizationClass(models.Model):
     identifier = models.CharField(max_length=255, unique=True, editable=False)

--- a/orgs/tests/fixtures.py
+++ b/orgs/tests/fixtures.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from aplans.tests.tree import parse_tree_string
+
+if typing.TYPE_CHECKING:
+    from orgs.models import Organization
+
+from .utils import tree_to_org
+
+
+@pytest.fixture()
+def organization_hierarchy_factory():
+    def _organization_hierachy_factory(tree_string: str) -> list[Organization]:
+        trees = parse_tree_string(tree_string)
+        return [tree_to_org(tree) for tree in trees]
+    return _organization_hierachy_factory

--- a/orgs/tests/utils.py
+++ b/orgs/tests/utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from aplans.tests.tree import Tree, parse_tree_string
+
+from orgs.models import Organization
+
+from .factories import OrganizationFactory
+
+
+def tree_to_org(tree: Tree, parent: Organization | None=None):
+    org = OrganizationFactory.create(name=tree.name, abbreviation=tree.name, parent=parent)
+    for child in tree.children:
+        tree_to_org(child, org)
+    return org
+
+
+def orgs_to_trees(roots: Iterable[Organization], indent=0):
+    result: list[Tree] = []
+    for root in roots:
+        tree = Tree(root.name, indent)
+        for child in orgs_to_trees(root.get_children(), indent + 4):
+            tree.add_child(child)
+        result.append(tree)
+    return result
+
+
+def assert_org_hierarchy(expected_hierarchy: str):
+    actual_roots = Organization.get_root_nodes()
+    actual = orgs_to_trees(actual_roots)
+    expected = parse_tree_string(expected_hierarchy)
+    # We could use this, but comparing the values as strings produces nicer error messages
+    # assert len(actual) == len(expected)
+    # assert all(a.equals(e) for (a, e) in zip(actual, expected))
+    actual_str = ''.join(str(tree) for tree in actual)
+    expected_str = ''.join(str(tree) for tree in expected)
+    assert actual_str == expected_str, f"\n{actual_str}\n!=\n{expected_str}"

--- a/people/wagtail_admin.py
+++ b/people/wagtail_admin.py
@@ -26,6 +26,7 @@ from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import naturaltime
 
 from actions.models import ActionContactPerson, Plan, PlanPublicSiteViewer
+from actions.perms import get_people_with_login_rights
 from admin_site.utils import admin_req
 from admin_site.wagtail import (
     ActivatePermissionHelperPlanContextModelAdminMixin,
@@ -301,6 +302,11 @@ class PersonPermissionHelper(PlanContextModelAdminPermissionHelper):
             return False
         return super().user_can_create(user)
 
+
+def _person_can_access_admin(person) -> bool:
+    return person.pk in get_people_with_login_rights()
+
+
 class PersonButtonHelper(ButtonHelper):
     def delete_button(self, *args, **kwargs):
         button = super().delete_button(*args, **kwargs)
@@ -340,7 +346,7 @@ class PersonButtonHelper(ButtonHelper):
                 **kwargs,
             )
             buttons.append(reset_password_button)
-        if user.is_superuser and obj.user != user and obj.user.can_access_admin():
+        if user.is_superuser and obj.user != user and _person_can_access_admin(obj):
             impersonation_button = self.impersonation_button(
                 pk=getattr(obj, self.opts.pk.attname),
                 **kwargs,
@@ -454,7 +460,7 @@ class PersonAdmin(AplansModelAdmin):
         avatar.short_description = ''
 
         def cannot_access_admin_warning(obj: Person) -> str:
-            if obj.user and not obj.user.can_access_admin():
+            if not _person_can_access_admin(obj):
                 tooltip = _(
                     "This person has no access to the admin interface. This is commonly because no actions or "
                     "indicators are assigned to them.",
@@ -504,6 +510,7 @@ class PersonAdmin(AplansModelAdmin):
         organization.admin_order_field = 'organization__name'
 
         fields = [avatar, cannot_access_admin_warning, first_name, last_name, 'title', organization]
+        #fields = [avatar, first_name, last_name, 'title', organization]
 
         def last_logged_in(obj):
             user = obj.user
@@ -599,7 +606,7 @@ class PersonAdmin(AplansModelAdmin):
 
     def get_extra_attrs_for_row(self, obj, context):
         assert isinstance(obj, Person)
-        if obj.user and not obj.user.can_access_admin():
+        if not _person_can_access_admin(obj):
             # Add CSS class to highlight rows of users without admin access
             return {
                 'class': 'user-without-admin-access',

--- a/people/wagtail_admin.py
+++ b/people/wagtail_admin.py
@@ -22,11 +22,11 @@ from wagtail_modeladmin.helpers import ButtonHelper
 from wagtail_modeladmin.options import modeladmin_register
 from wagtail_modeladmin.views import DeleteView
 
-from admin_site.utils import admin_req
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import naturaltime
 
 from actions.models import ActionContactPerson, Plan, PlanPublicSiteViewer
+from admin_site.utils import admin_req
 from admin_site.wagtail import (
     ActivatePermissionHelperPlanContextModelAdminMixin,
     AplansAdminModelForm,
@@ -112,8 +112,7 @@ class IsContactPersonFilter(SimpleListFilter):
 def smart_truncate(content, length=100, suffix='...'):
     if len(content) <= length:
         return content
-    else:
-        return ' '.join(content[:length + 1].split(' ')[0:-1]) + suffix
+    return ' '.join(content[:length + 1].split(' ')[0:-1]) + suffix
 
 
 class AvatarWidget(AdminFileWidget):
@@ -171,10 +170,9 @@ class PersonFormForGeneralAdmin(PersonForm):
                 del self.fields['is_admin_for_active_plan']
                 del self.fields['contact_for_actions_unordered']
                 del self.fields['participated_in_training']
-        else:
+        elif initial.get('access_level') != self.AccessLevel.PUBLIC_SITE_ONLY:
             # Allow removing lingering public site restriction if public site login was recently removed
-            if initial.get('access_level') != self.AccessLevel.PUBLIC_SITE_ONLY:
-                del self.fields['access_level']
+            del self.fields['access_level']
         if 'organization_plan_admin_orgs' in self.fields:
             self.fields['organization_plan_admin_orgs'].queryset = (
                 Organization.objects.available_for_plan(self.plan).filter(dissolution_date=None)
@@ -421,7 +419,7 @@ class PersonAdmin(AplansModelAdmin):
 
     def get_empty_value_display(self, field=None):
         if getattr(field, '_name', field) == 'last_logged_in':
-            return display_for_value(False, None, boolean=True)
+            return display_for_value(value=False, empty_value_display='', boolean=True)
         return super().get_empty_value_display(field)
 
     def get_list_display(self, request: WatchAdminRequest):
@@ -455,7 +453,7 @@ class PersonAdmin(AplansModelAdmin):
                 return img
         avatar.short_description = ''
 
-        def cannot_access_admin_warning(obj):
+        def cannot_access_admin_warning(obj: Person) -> str:
             if obj.user and not obj.user.can_access_admin():
                 tooltip = _(
                     "This person has no access to the admin interface. This is commonly because no actions or "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ ignore = [
 "kausal_common/typings/*" = ["D"]
 "kausal_common/typings/django/*" = ["ALL"]
 "**/migrations/*" = ["I002"]
+"**/tests/test_*" = ["PLR0913"]
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = true

--- a/requirements.in
+++ b/requirements.in
@@ -81,3 +81,4 @@ logfmter
 s3cmd
 psutil
 django-stubs-ext
+treelib

--- a/requirements.txt
+++ b/requirements.txt
@@ -419,6 +419,7 @@ six==1.16.0
     #   l18n
     #   promise
     #   python-dateutil
+    #   treelib
 social-auth-app-django==5.4.1
     # via -r requirements.in
 social-auth-core==4.5.4
@@ -434,6 +435,8 @@ telepath==0.3.1
 text-unidecode==1.3
     # via graphene-django
 tinycss2==1.3.0
+    # via -r requirements.in
+treelib==1.7.0
     # via -r requirements.in
 typing-extensions==4.11.0
     # via


### PR DESCRIPTION
Locally, before this fix:
⛁ 655 SQL queries took 10018 ms /admin/people/person/

Locally, after the fix: (cold cache)
⛁ 184 SQL queries took 360 ms /admin/people/person/

Locally, after the fix: (warm cache)
⛁ 160 SQL queries took 247 ms /admin/people/person/

Explanation: the biggest performance hit comes from calling `user.can_access_admin()` in a loop. While it would be nice to use that function because it actually calls the actual implementation that is used when determining user access, it is very difficult to cache this result the way it's currently implemented. I have decided to add another implementation tuned for mass querying and caching, while writing some tests which hopefully give errors when these two implementations get out-of-sync. It's not ideal but the new implementation is so simple it's hopefully ok.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208110855280844