### PR TITLE
Start using Wagtail's read_only implementation for read-only attributes

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -510,10 +510,12 @@ class ActionEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTa
                                 for attribute_type in attribute_types
                                 for field in attribute_type.get_form_fields(
                                     user, plan, instance, draft_attributes=self.draft_attributes,
-                                )}
+                                )
+                                # The wagtail implementation of read_only panels assumes
+                                # those are not added to the forms as fields
+                                if not field.read_only}
         else:
             attribute_fields = {}
-
         self.base_form_class = type(
             'ActionAdminForm',
             (ActionAdminForm,),

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -506,14 +506,16 @@ class ActionEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTa
 
         if instance is not None:
             attribute_types = instance.get_visible_attribute_types(user)
-            attribute_fields = {field.name: field.django_field
-                                for attribute_type in attribute_types
-                                for field in attribute_type.get_form_fields(
-                                    user, plan, instance, draft_attributes=self.draft_attributes,
-                                )
-                                # The wagtail implementation of read_only panels assumes
-                                # those are not added to the forms as fields
-                                if not field.read_only}
+            attribute_fields = {
+                field.name: field.django_field
+                for attribute_type in attribute_types
+                for field in attribute_type.get_form_fields(
+                        user, plan, instance, draft_attributes=self.draft_attributes,
+                )
+                # The wagtail implementation of read_only panels assumes
+                # those are not added to the forms as fields
+                if not field.read_only
+            }
         else:
             attribute_fields = {}
         self.base_form_class = type(

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -46,10 +46,17 @@ class AttributeFieldPanel[M: Model](FieldPanel[M]):
 
     class BoundPanel(field_panel.FieldPanel.BoundPanel):
         def value_from_instance(self):
-            attributes = " ".join(
+            if self.instance.has_unpublished_changes:
+                rev = self.instance.get_latest_revision()
+                draft_attributes = DraftAttributes.from_revision_content(rev.content.get('attributes'))
+                attribute_value = draft_attributes.get_value_for_attribute_type(self.panel.attribute_type)
+                if attribute_value.should_exist_in_database():
+                    attribute = attribute_value.instantiate_attribute(self.panel.attribute_type, self.instance)
+                    return str(attribute)
+                return ''
+            return " ".join(
                 str(x) for x in self.panel.attribute_type.get_attributes(self.instance)
             )
-            return attributes
 
     def format_value_for_display(self, value):
         return value()

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -11,6 +11,7 @@ from django.db.models import Field, ForeignKey, Model, QuerySet
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, field_panel
 from wagtail.fields import RichTextField
+from wagtail.models import DraftStateMixin, RevisionMixin
 from wagtail.rich_text import RichText as WagtailRichText
 
 from dal import autocomplete, forward as dal_forward
@@ -28,7 +29,7 @@ if typing.TYPE_CHECKING:
     from users.models import User
 
 
-class AttributeFieldPanel[M: Model](FieldPanel[M]):
+class AttributeFieldPanel[M: models.ModelWithAttributes](FieldPanel[M]):
     """Add compatibility for Wagtail read_only field panels for attributes."""
 
     attribute_type: AttributeType | None
@@ -44,9 +45,15 @@ class AttributeFieldPanel[M: Model](FieldPanel[M]):
         kwargs['attribute_type'] = self.attribute_type
         return kwargs
 
-    class BoundPanel(field_panel.FieldPanel.BoundPanel):
+    class BoundPanel[_M: models.ModelWithAttributes](field_panel.FieldPanel.BoundPanel):
+        instance: _M
+
         def value_from_instance(self):
-            if self.instance.has_unpublished_changes:
+            if (
+                isinstance(self.instance, DraftStateMixin) and
+                isinstance(self.instance, RevisionMixin) and
+                self.instance.has_unpublished_changes
+            ):
                 rev = self.instance.get_latest_revision()
                 draft_attributes = DraftAttributes.from_revision_content(rev.content.get('attributes'))
                 attribute_value = draft_attributes.get_value_for_attribute_type(self.panel.attribute_type)
@@ -63,7 +70,7 @@ class AttributeFieldPanel[M: Model](FieldPanel[M]):
 
 
 @dataclass
-class FormField[M: Model]:
+class FormField[M: models.ModelWithAttributes]:
     plan: Plan
     attribute_type: AttributeType
     django_field: forms.Field

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -431,9 +431,6 @@ class OrderedChoice(AttributeType[models.AttributeChoice]):
         field = forms.ModelChoiceField(
             choice_options, initial=initial_choice, required=False, help_text=self.instance.help_text_i18n,
         )
-        if not self.is_editable(user, plan, obj):
-            field.disabled = True
-
         is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
         return [FormField(
             plan=plan,
@@ -505,8 +502,6 @@ class CategoryChoice(AttributeType[models.AttributeCategoryChoice]):
                 ),
             ),
         )
-        if not self.is_editable(user, plan, obj):
-            field.disabled = True
         is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
         return [FormField(
             plan=plan,
@@ -585,8 +580,6 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
         choice_field = forms.ModelChoiceField(
             choice_options, initial=initial_choice, required=False, help_text=self.instance.help_text_i18n,
         )
-        if not editable:
-            choice_field.disabled = True
         is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
         fields: list[FormField] = [FormField(
             plan=plan,
@@ -595,6 +588,7 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
             name=self.choice_form_field_name,
             is_public=is_public,
             label=_('%(attribute_type)s (choice)') % {'attribute_type': self.instance.name_i18n},
+            read_only=not editable,
         )]
 
         # Text (one field for each language)
@@ -609,9 +603,6 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
             if self.instance.max_length:
                 form_field_kwargs.update(max_length=self.instance.max_length)
             text_field = self.ATTRIBUTE_MODEL._meta.get_field(attribute_text_field_name).formfield(**form_field_kwargs)  # type: ignore[union-attr]
-            if not editable:
-                text_field.disabled = True
-                is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
             fields.append(FormField(
                 plan=plan,
                 attribute_type=self,
@@ -620,7 +611,7 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
                 language=language,
                 label=_('%(attribute_type)s (text)') % {'attribute_type': self.instance.name_i18n},
                 is_public=is_public,
-                read_only=not self.is_editable(user, plan, obj),
+                read_only=not editable,
             ))
         return fields
 
@@ -700,8 +691,6 @@ class GenericTextAttributeType(AttributeType[T]):
                 form_field_kwargs.update(max_length=self.instance.max_length)
             db_field = cast(Field, self.ATTRIBUTE_MODEL._meta.get_field(attribute_text_field_name))
             field = db_field.formfield(**form_field_kwargs)
-            if not editable:
-                field.disabled = True
             is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
             fields.append(FormField(
                 plan=plan,
@@ -784,8 +773,6 @@ class Numeric(AttributeType[models.AttributeNumericValue]):
             if committed_attribute:
                 initial_value = committed_attribute.value
         field = forms.FloatField(initial=initial_value, required=False, help_text=self.instance.help_text_i18n)
-        if not self.is_editable(user, plan, obj):
-            field.disabled = True
         is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
         return [FormField(
             plan=plan,

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -9,7 +9,7 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Field, ForeignKey, Model, QuerySet
 from django.utils.translation import gettext_lazy as _
-from wagtail.admin.panels import FieldPanel
+from wagtail.admin.panels import FieldPanel, field_panel
 from wagtail.fields import RichTextField
 from wagtail.rich_text import RichText as WagtailRichText
 
@@ -29,7 +29,30 @@ if typing.TYPE_CHECKING:
 
 
 class AttributeFieldPanel[M: Model](FieldPanel[M]):
-    pass
+    """Add compatibility for Wagtail read_only field panels for attributes."""
+
+    attribute_type: AttributeType | None
+
+    def __init__(self, *args, attribute_type: AttributeType, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.attribute_type = attribute_type
+        self.icon = 'placeholder'
+        self.help_text = attribute_type.instance.help_text
+
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs['attribute_type'] = self.attribute_type
+        return kwargs
+
+    class BoundPanel(field_panel.FieldPanel.BoundPanel):
+        def value_from_instance(self):
+            attributes = " ".join(
+                str(x) for x in self.panel.attribute_type.get_attributes(self.instance)
+            )
+            return attributes
+
+    def format_value_for_display(self, value):
+        return value()
 
 
 @dataclass
@@ -42,6 +65,7 @@ class FormField[M: Model]:
     # If the field refers to a modeltrans field and `language` is not empty, use localized virtual field for `language`.
     language: str = ''
     is_public: bool = False
+    read_only: bool = False
 
     def get_panel(self) -> AttributeFieldPanel[M]:
         if self.label:
@@ -51,7 +75,12 @@ class FormField[M: Model]:
         if self.language:
             heading += f' ({self.language})'
         heading = FieldLabelRenderer(self.plan)(heading, public=self.is_public)
-        return AttributeFieldPanel[M](self.name, heading=heading)
+        return AttributeFieldPanel[M](
+            self.name,
+            heading=heading,
+            read_only=self.read_only,
+            attribute_type=self.attribute_type,
+        )
 
 
 class AttributeValue(ABC):
@@ -412,6 +441,7 @@ class OrderedChoice(AttributeType[models.AttributeChoice]):
             django_field=field,
             name=self.form_field_name,
             is_public=is_public,
+            read_only=not self.is_editable(user, plan, obj),
         )]
 
     def get_value_from_form_data(self, cleaned_data: dict[str, Any]) -> OrderedChoiceAttributeValue | None:
@@ -484,6 +514,7 @@ class CategoryChoice(AttributeType[models.AttributeCategoryChoice]):
             django_field=field,
             name=self.form_field_name,
             is_public=is_public,
+            read_only=not self.is_editable(user, plan, obj),
         )]
 
     def get_value_from_form_data(self, cleaned_data: dict[str, Any]) -> CategoryChoiceAttributeValue | None:
@@ -589,6 +620,7 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
                 language=language,
                 label=_('%(attribute_type)s (text)') % {'attribute_type': self.instance.name_i18n},
                 is_public=is_public,
+                read_only=not self.is_editable(user, plan, obj),
             ))
         return fields
 
@@ -678,6 +710,7 @@ class GenericTextAttributeType(AttributeType[T]):
                 name=self.get_form_field_name(language),
                 language=language,
                 is_public=is_public,
+                read_only=not editable,
             ))
         return fields
 
@@ -760,6 +793,7 @@ class Numeric(AttributeType[models.AttributeNumericValue]):
             django_field=field,
             name=self.form_field_name,
             is_public=is_public,
+            read_only=not self.is_editable(user, plan, obj),
         )]
 
     def get_value_from_form_data(self, cleaned_data: dict[str, Any]) -> NumericAttributeValue | None:

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -108,9 +108,11 @@ class AttributeValue(ABC):
     @abstractmethod
     def should_exist_in_database(self) -> bool:
         """
-        If this returns true, committing an attribute will create or update an attribute model instance; otherwise,
-        committing will delete any existing attribute model instance for the respective attribute type.
+        If this returns true, committing an attribute will create or update an attribute model instance.
+
+        Otherwise, committing will delete any existing attribute model instance for the respective attribute type.
         """
+
         pass
 
     def instantiate_attribute(self, type: AttributeType[T], obj: models.ModelWithAttributes) -> T:

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -373,7 +373,9 @@ class AttributeRichText(Attribute):
         unique_together = ('type', 'content_type', 'object_id')
 
     def __str__(self):
-        return self.text_i18n
+        text_field = typing.cast(RichTextField, self._meta.get_field('text'))
+        return " ".join(text_field.get_searchable_content(str(self.text_i18n)))
+
 
 
 @reversion.register()


### PR DESCRIPTION
Fixes bug where rich text fields were not correctly disabled in the action edit form due to the rich text editor implementation.

This PR switches to using the new wagtail read_only field panel implementation, which however requires an adapter class for attributes because the default implementation assumes the fields being edited are directly named model fields that can be found as db fields in the model itself. Attributes are separate models.