### PR TITLE
Show active plan name on sidebar

### DIFF
--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -43,6 +43,10 @@
   padding: 10px 0;
 }
 
+.sidebar--slim .active-plan {
+  display: none;
+}
+
 .login .login-logo {
   width: 3.5rem;
 }

--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -15,10 +15,10 @@
 {% block branding_logo %}
     {% if active_client and active_client.logo %}
         {% image active_client.logo width-80 %}
-        <!-- <h5>{{ active_plan.name }}</h5> -->
     {% else %}
         <img src="{% static 'images/kausal-avatar-dark-green.svg' %}" alt="Kausal Logo" width="80" />
     {% endif %}
+    <div class="active-plan">{{ active_plan.name }}</div>
 {% endblock %}
 
 {% block extra_css %}


### PR DESCRIPTION
Shows the active plan name on the sidebar.

This is preparation for the feature to copy a plan, to make sure users keep track of which plan they are modifying (so that they don't accidentally edit the copy when they mean to edit the original).

This might not be the prettiest solution or the one that makes it most clear to the users which plan is being worked on, so this might need some tuning. But at least the mechanism and the hooks to style it with CSS are discovered and in place, so future development should be easy.