### PR TITLE
Fix read only fields bugs

### DIFF
--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -59,7 +59,10 @@ class AttributeFieldPanel[M: models.ModelWithAttributes](FieldPanel[M]):
             ):
                 rev = self.instance.get_latest_revision()
                 draft_attributes = DraftAttributes.from_revision_content(rev.content.get('attributes'))
-                attribute_value = draft_attributes.get_value_for_attribute_type(self.panel.attribute_type)
+                try:
+                    attribute_value = draft_attributes.get_value_for_attribute_type(self.panel.attribute_type)
+                except KeyError:
+                    return ''
                 if attribute_value.should_exist_in_database():
                     attribute = attribute_value.instantiate_attribute(self.panel.attribute_type, self.instance)
                     return str(attribute)

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -7,12 +7,11 @@ from typing import Any, Generic, TypeVar, cast
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Field, ForeignKey, Model, QuerySet
+from django.db.models import Field, ForeignKey, QuerySet
+from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, field_panel
-from wagtail.fields import RichTextField
 from wagtail.models import DraftStateMixin, RevisionMixin
-from wagtail.rich_text import RichText as WagtailRichText
 
 from dal import autocomplete, forward as dal_forward
 
@@ -33,9 +32,11 @@ class AttributeFieldPanel[M: models.ModelWithAttributes](FieldPanel[M]):
     """Add compatibility for Wagtail read_only field panels for attributes."""
 
     attribute_type: AttributeType | None
+    language: str
 
-    def __init__(self, *args, attribute_type: AttributeType, **kwargs):
+    def __init__(self, *args, attribute_type: AttributeType, language: str, **kwargs):
         super().__init__(*args, **kwargs)
+        self.language = language
         self.attribute_type = attribute_type
         # Important! Icon and placeholder must exist and be Truthy in this object
         # or otherwise Wagtail starts introspecting for a modelfield
@@ -46,6 +47,7 @@ class AttributeFieldPanel[M: models.ModelWithAttributes](FieldPanel[M]):
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
         kwargs['attribute_type'] = self.attribute_type
+        kwargs['language'] = self.language
         return kwargs
 
     class BoundPanel[_M: models.ModelWithAttributes](field_panel.FieldPanel.BoundPanel):
@@ -65,11 +67,20 @@ class AttributeFieldPanel[M: models.ModelWithAttributes](FieldPanel[M]):
                     return ''
                 if attribute_value.should_exist_in_database():
                     attribute = attribute_value.instantiate_attribute(self.panel.attribute_type, self.instance)
-                    return str(attribute)
+                    if not self.panel.language:
+                        return str(attribute)
+                    with translation.override(self.panel.language):
+                        return str(attribute)
+
                 return ''
-            return " ".join(
-                str(x) for x in self.panel.attribute_type.get_attributes(self.instance)
-            )
+            def get_value() -> str:
+                return " ".join(
+                    str(x) for x in self.panel.attribute_type.get_attributes(self.instance)
+                )
+            if not self.panel.language:
+                return get_value()
+            with translation.override(self.panel.language):
+                return get_value()
 
     def format_value_for_display(self, value):
         return value()
@@ -100,6 +111,7 @@ class FormField[M: models.ModelWithAttributes]:
             heading=heading,
             read_only=self.read_only,
             attribute_type=self.attribute_type,
+            language=self.language,
         )
 
 
@@ -603,15 +615,17 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
             choice_options, initial=initial_choice, required=False, help_text=self.instance.help_text_i18n,
         )
         is_public = self.instance.instances_visible_for == self.instance.VisibleFor.PUBLIC
-        fields: list[FormField] = [FormField(
-            plan=plan,
-            attribute_type=self,
-            django_field=choice_field,
-            name=self.choice_form_field_name,
-            is_public=is_public,
-            label=_('%(attribute_type)s (choice)') % {'attribute_type': self.instance.name_i18n},
-            read_only=not editable,
-        )]
+        fields: list[FormField] = []
+        if editable:
+            fields.append(FormField(
+                plan=plan,
+                attribute_type=self,
+                django_field=choice_field,
+                name=self.choice_form_field_name,
+                is_public=is_public,
+                label=_('%(attribute_type)s (choice)') % {'attribute_type': self.instance.name_i18n},
+                read_only=False,
+            ))
 
         # Text (one field for each language)
         for language in ('', *self.instance.other_languages):
@@ -625,13 +639,17 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
             if self.instance.max_length:
                 form_field_kwargs.update(max_length=self.instance.max_length)
             text_field = self.ATTRIBUTE_MODEL._meta.get_field(attribute_text_field_name).formfield(**form_field_kwargs)  # type: ignore[union-attr]
+            if editable:
+                label = _('%(attribute_type)s (text)') % {'attribute_type': self.instance.name_i18n}
+            else:
+                label = _('%(attribute_type)s') % {'attribute_type': self.instance.name_i18n}
             fields.append(FormField(
                 plan=plan,
                 attribute_type=self,
                 django_field=text_field,
                 name=self.get_text_form_field_name(language),
                 language=language,
-                label=_('%(attribute_type)s (text)') % {'attribute_type': self.instance.name_i18n},
+                label=label,
                 is_public=is_public,
                 read_only=not editable,
             ))

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -37,8 +37,11 @@ class AttributeFieldPanel[M: models.ModelWithAttributes](FieldPanel[M]):
     def __init__(self, *args, attribute_type: AttributeType, **kwargs):
         super().__init__(*args, **kwargs)
         self.attribute_type = attribute_type
+        # Important! Icon and placeholder must exist and be Truthy in this object
+        # or otherwise Wagtail starts introspecting for a modelfield
+        # for this attribute
         self.icon = 'placeholder'
-        self.help_text = attribute_type.instance.help_text
+        self.help_text = attribute_type.instance.help_text or ' '
 
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -325,7 +325,9 @@ class AttributeChoiceWithText(Attribute):
         unique_together = ('type', 'content_type', 'object_id')
 
     def __str__(self):
-        return f'{self.choice}; {self.text}'
+        text_field = typing.cast(RichTextField, self._meta.get_field('text'))
+        text = " ".join(text_field.get_searchable_content(str(self.text_i18n)))
+        return f'{self.choice}; {text}'
 
 
 @reversion.register()

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -315,6 +315,7 @@ class AttributeChoiceWithText(Attribute):
         related_name='choice_with_text_attributes',
     )
     text = RichTextField(verbose_name=_('Text'), blank=True, null=True)
+    text_i18n: str
 
     i18n = TranslationField(
         fields=('text',),

--- a/reports/tests/test_excel_roundtrip.py
+++ b/reports/tests/test_excel_roundtrip.py
@@ -54,7 +54,7 @@ def test_excel_export(
         user,
         django_assert_max_num_queries,
 ):
-    with django_assert_max_num_queries(272):
+    with django_assert_max_num_queries(282):
         # report.get_live_action_versions hack still causes some extra queries
         # because of implementation details wrt. reversion
         excel_file_incomplete = excel_file_from_report_factory()


### PR DESCRIPTION
For the recent read_only field support for attributes there was a critical bug which caused a crash for attribute types without help text.

This PR includes other fixes as well.