### PR TITLE
Remove duplicate plan menu item

### DIFF
--- a/actions/tests/test_admin.py
+++ b/actions/tests/test_admin.py
@@ -8,13 +8,11 @@ import pytest
 from pytest_django.asserts import assertContains
 
 from actions.action_admin import ActionAdmin
-from actions.tests.factories import ActionContactFactory, ActionFactory, PlanFactory
-from actions.wagtail_admin import ActivePlanAdmin
+from actions.tests.factories import ActionFactory, PlanFactory
+from actions.wagtail_admin import PlanIndexView, PlanViewSet
 from admin_site.tests.factories import ClientPlanFactory
 
 if typing.TYPE_CHECKING:
-    from aplans.types import WatchAdminRequest
-
     from actions.models import Action
     from conftest import ModelAdminEditTest
     from people.models import Person
@@ -32,6 +30,27 @@ def get_request(rf, user=None, view_name='wagtailadmin_home', url=None):
     return request
 
 
+def get_plan_index_view(rf, client, user, view_set=None) -> PlanIndexView:
+    if view_set is None:
+        view_set = PlanViewSet()
+    client.force_login(user)
+    request = get_request(rf, user)
+    index_view = PlanIndexView(**view_set.get_common_view_kwargs(), **view_set.get_index_view_kwargs())
+    index_view.setup(request)
+    return index_view
+
+
+def edit_button_shown(rf, client, user, plan) -> bool:
+    view_set = PlanViewSet()
+    index_view = get_plan_index_view(rf, client, user, view_set)
+    buttons = index_view.get_list_buttons(user.get_active_admin_plan())
+    edit_url_name = view_set.get_url_name('edit')
+    return any(
+        any(b.url == reverse(edit_url_name, args=[plan.pk]) for b in getattr(button, 'dropdown_buttons', []))
+        for button in buttons
+    )
+
+
 @pytest.mark.parametrize("user__is_staff", [False])
 def test_no_access_for_non_staff_user(user, client):
     client.force_login(user)
@@ -47,64 +66,57 @@ def test_login_removes_user_from_staff_if_no_plan_admin(user, client):
     assert not user.is_staff
 
 
-def test_active_plan_menu_item_not_shown_to_action_contact_person(rf):
-    action_contact = ActionContactFactory()
-    request = get_request(rf, action_contact.person.user)
-    active_plan_admin = ActivePlanAdmin()
-    assert not active_plan_admin.get_menu_item().is_shown(request)
+def test_plan_edit_button_shown_to_superuser(rf, client, superuser, plan):
+    assert edit_button_shown(rf, client, superuser, plan)
 
 
-def test_active_plan_menu_item_shown_to_plan_admin(plan_admin_user, rf):
-    request = get_request(rf, plan_admin_user)
-    active_plan_admin = ActivePlanAdmin()
-    assert active_plan_admin.get_menu_item().is_shown(request)
+def test_plan_edit_button_shown_to_plan_admin(rf, client, plan_admin_user, plan):
+    assert edit_button_shown(rf, client, plan_admin_user, plan)
 
 
-def test_active_plan_menu_item_shown_to_superuser(superuser, rf):
-    request: WatchAdminRequest = get_request(rf, superuser)
-    active_plan_admin = ActivePlanAdmin()
-    assert active_plan_admin.get_menu_item().is_shown(request)
+def test_plan_edit_button_not_shown_to_action_contact_person(rf, client, action_contact_person_user, plan):
+    assert not edit_button_shown(rf, client, action_contact_person_user, plan)
 
 
-def test_cannot_list_plans(plan_admin_user, client):
-    active_plan_admin = ActivePlanAdmin()
-    url = active_plan_admin.url_helper.index_url
-    client.force_login(plan_admin_user)
-    response = client.get(url)
-    # Wagtail doesn't respond with HTTP status 403 but with a redirect and an error message in a cookie.
-    assert response.status_code == 302
-    assert response.url == reverse('wagtailadmin_home')
-
-
-def test_superuser_can_list_plans(superuser, plan, client):
-    # If the `plan` fixture is not included, the code will fail as there would be no plan, hence no active admin plan.
-    ClientPlanFactory(plan=plan)
-    active_plan_admin = ActivePlanAdmin()
-    url = active_plan_admin.url_helper.index_url
-    client.force_login(superuser)
-    response = client.get(url)
-    assert response.status_code == 200
-
-
-def test_cannot_access_other_plan_edit_page(plan_admin_user, client):
+def test_superuser_can_list_plans(rf, superuser, plan, client):
     other_plan = PlanFactory()
-    active_plan_admin = ActivePlanAdmin()
-    url = active_plan_admin.url_helper.get_action_url('edit', other_plan.pk)
-    client.force_login(plan_admin_user)
-    response = client.get(url)
-    # Wagtail doesn't respond with HTTP status 403 but with a redirect and an error message in a cookie.
-    assert response.status_code == 302
-    assert response.url == reverse('wagtailadmin_home')
+    view_set = PlanViewSet()
+    index_view = get_plan_index_view(rf, client, superuser, view_set)
+    qs = index_view.get_queryset()
+    assert plan in qs
+    assert other_plan in qs
 
 
-def test_can_access_plan_edit_page(plan_admin_user, client):
-    active_plan_admin = ActivePlanAdmin()
-    plan = plan_admin_user.get_adminable_plans()[0]
+def test_admin_can_list_only_own_plan(rf, plan, plan_admin_user, client):
+    other_plan = PlanFactory()
+    view_set = PlanViewSet()
+    index_view = get_plan_index_view(rf, client, plan_admin_user, view_set)
+    qs = index_view.get_queryset()
+    assert plan in qs
+    assert other_plan not in qs
+
+
+def test_can_access_plan_edit_page(plan, plan_admin_user, client):
     ClientPlanFactory(plan=plan)
-    url = active_plan_admin.url_helper.get_action_url('edit', plan.pk)
+    view_set = PlanViewSet()
+    edit_url_name = view_set.get_url_name('edit')
+    url = reverse(edit_url_name, args=[plan.pk])
     client.force_login(plan_admin_user)
     response = client.get(url)
     assert response.status_code == 200
+
+
+def test_cannot_access_other_plan_edit_page(plan, plan_admin_user, client):
+    other_plan = PlanFactory()
+    view_set = PlanViewSet()
+    edit_url_name = view_set.get_url_name('edit')
+    url = reverse(edit_url_name, args=[other_plan.pk])
+    client.force_login(plan_admin_user)
+    response = client.get(url)
+    # Wagtail doesn't respond with HTTP status 403 but with a redirect and an error message in a cookie.
+    view_set.permission_policy.user_has_permission_for_instance(plan_admin_user, 'edit', plan)
+    assert response.status_code == 302
+    assert response.url == reverse('wagtailadmin_home')
 
 
 def test_action_admin(

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -5,9 +5,12 @@ import typing
 from functools import cached_property
 
 from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.db.models import Model, ProtectedError
 from django.urls import re_path, reverse
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.filters import WagtailFilterSet
+from wagtail.admin.messages import validation_error
 from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,
@@ -17,13 +20,14 @@ from wagtail.admin.panels import (
 from wagtail.admin.ui.tables import BulkActionsCheckboxColumn, Column
 from wagtail.admin.widgets.button import ButtonWithDropdown
 from wagtail.coreutils import capfirst
+from wagtail.permissions import ModelPermissionPolicy
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import IndexView, SnippetViewSet
 
 from dal import autocomplete
 from django_filters import filters
 from wagtail_modeladmin.helpers import PermissionHelper
-from wagtail_modeladmin.options import ModelAdminMenuItem, modeladmin_register
+from wagtail_modeladmin.options import modeladmin_register
 
 from aplans.context_vars import ctx_instance, ctx_request
 
@@ -36,11 +40,12 @@ from admin_site.models import Client, ClientPlan
 from admin_site.permissions import PlanSpecificSingletonModelSuperuserPermissionPolicy
 from admin_site.viewsets import WatchEditView, WatchViewSet
 from admin_site.wagtail import (
-    ActivePlanEditView,
     AplansAdminModelForm,
     AplansCreateView,
+    AplansEditView,
     AplansModelAdmin,
     CondensedInlinePanel,
+    SuccessUrlEditPageModelAdminMixin,
     insert_model_translation_panels,
 )
 from copying.views import PlanCopyView
@@ -59,11 +64,10 @@ from . import (
 from .models import ActionImpact, ActionStatus, Plan, PlanFeatures
 
 if typing.TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser
     from django.db.models import QuerySet
     from django.http import HttpRequest
     from wagtail.admin.menu import MenuItem
-
-    from aplans.types import WatchAdminRequest
 
 
 class PlanForm(AplansAdminModelForm):
@@ -125,15 +129,59 @@ class PlanCreateView(AplansCreateView):
             plan_id=self.instance.id))
 
 
+class PlanEditView(SuccessUrlEditPageModelAdminMixin, AplansEditView):
+    @transaction.atomic()
+    def form_valid(self, form):
+        old_common_category_types = self.instance.common_category_types.all()
+        new_common_category_types = form.cleaned_data['common_category_types']
+        for added_cct in new_common_category_types.difference(old_common_category_types):
+            # Create category type corresponding to this common category type and link it to this plan
+            ct = added_cct.instantiate_for_plan(self.instance)
+            # Create categories for the common categories having that common category type
+            for common_category in added_cct.categories.all():
+                common_category.instantiate_for_category_type(ct)
+        for removed_cct in old_common_category_types.difference(new_common_category_types):
+            try:
+                self.instance.category_types.filter(common=removed_cct).delete()
+            except ProtectedError:
+                # Actually validation should have been done before this method is called, but it seems to work for now
+                error = _(
+                    'Could not remove common category type "%(removed_cct)" from the plan because categories '
+                    'with the corresponding category type exist.',
+                ) % {'removed_cct': removed_cct}
+                form.add_error('common_category_types', error)
+                validation_error(self.request, self.get_error_message(), form)
+                return self.render_to_response(self.get_context_data(form=form))
+        return super().form_valid(form)
+
+
+class PlanModelAdminPermissionHelper(PermissionHelper):
+    def user_can_list(self, user):
+        return user.is_superuser
+
+    def user_can_create(self, user):
+        return user.is_superuser
+
+    def user_can_inspect_obj(self, user, obj):
+        return False
+
+    def user_can_delete_obj(self, user, obj):
+        return False
+
+    def user_can_edit_obj(self, user, obj):
+        return user.is_general_admin_for_plan(obj)
+
+
+
 class PlanAdmin(AplansModelAdmin):
     model = Plan
-    menu_icon = 'kausal-plan'
-    menu_label = _('Plans')
-    menu_order = 500
+    add_to_admin_menu = False  # We only have PlanViewSet in the menu and use the views of PlanAdmin in that viewset
     list_display = ('name',)
     search_fields = ('name',)
+    permission_helper_class = PlanModelAdminPermissionHelper
     create_view_class = PlanCreateView
     copy_view_class = PlanCopyView
+    edit_view_class = PlanEditView
 
     panels = [
         FieldPanel('name'),
@@ -325,74 +373,7 @@ class PlanAdmin(AplansModelAdmin):
         return qs
 
 
-# TODO: Add this to superusers once quick autocomplete search is included and status of plans is shown on index view
-# modeladmin_register(PlanAdmin)
-
-
-# FIXME: This is partly duplicated in content/admin.py.
-class ActivePlanModelAdminPermissionHelper(PermissionHelper):
-    def user_can_list(self, user):
-        return user.is_superuser
-
-    def user_can_create(self, user):
-        return user.is_superuser
-
-    def user_can_inspect_obj(self, user, obj):
-        return False
-
-    def user_can_delete_obj(self, user, obj):
-        return False
-
-    def user_can_edit_obj(self, user, obj):
-        return user.is_general_admin_for_plan(obj)
-
-
-# TODO: Reimplemented in admin_site/menu.py to make this work without
-# ModelAdmin. Use that when implementing new classes or migrating away from
-# ModelAdmin. Remove this class when ModelAdmin migration is finished.
-class PlanSpecificSingletonModelAdminMenuItem(ModelAdminMenuItem):
-    def get_one_to_one_field(self, plan):
-        # Implement in subclass
-        raise NotImplementedError()
-
-    def render_component(self, request):
-        # When clicking the menu item, use the edit view instead of the index view.
-        link_menu_item = super().render_component(request)
-        plan = request.user.get_active_admin_plan()
-        field = self.get_one_to_one_field(plan)
-        link_menu_item.url = self.model_admin.url_helper.get_action_url('edit', field.pk)
-        return link_menu_item
-
-    def is_shown(self, request: WatchAdminRequest):
-        # The overridden superclass method returns True iff user_can_list from the permission helper returns true. But
-        # this menu item is about editing a plan features instance, not listing.
-        user = request.user
-        if user.is_superuser:
-            return True
-        plan = request.user.get_active_admin_plan(required=False)
-        if plan is None:
-            return False
-        field = self.get_one_to_one_field(plan)
-        return self.model_admin.permission_helper.user_can_edit_obj(request.user, field)
-
-
-class ActivePlanMenuItem(PlanSpecificSingletonModelAdminMenuItem):
-    def get_one_to_one_field(self, plan):
-        return plan
-
-
-class ActivePlanAdmin(PlanAdmin):
-    edit_view_class = ActivePlanEditView
-    permission_helper_class = ActivePlanModelAdminPermissionHelper
-    menu_label = _('Plan')
-    add_to_settings_menu = True
-
-    def get_menu_item(self, order=None):
-        item = ActivePlanMenuItem(self, order or self.get_menu_order())
-        return item
-
-
-modeladmin_register(ActivePlanAdmin)
+modeladmin_register(PlanAdmin)
 
 
 class PlanFeaturesViewSet(WatchViewSet):
@@ -586,6 +567,18 @@ class PlanFilter(WagtailFilterSet):
         fields = ['clients__client']
 
 
+class PlanPermissionPolicy(ModelPermissionPolicy):
+    def __init__(self):
+        super().__init__(Plan)
+
+    def user_has_permission_for_instance(self, user: AbstractBaseUser, action: str, instance: Model) -> bool:
+        if not super().user_has_permission_for_instance(user, action, instance):
+            return False
+        if not user.is_authenticated:
+            return False
+        assert isinstance(user, User)
+        return not user.is_anonymous and instance == user.get_active_admin_plan()
+
 
 class PlanViewSet(SnippetViewSet[Plan]):
     model = Plan
@@ -598,6 +591,10 @@ class PlanViewSet(SnippetViewSet[Plan]):
     list_per_page = None  # disable pagination
     index_view_class = PlanIndexView
     # Note that we can't use PlanCopyView as copy_view_class because it is not a (snippet) CopyView
+
+    @property
+    def permission_policy(self):
+        return PlanPermissionPolicy()
 
     # Copied from UserFeedbackViewSet
     # FIXME: As of writing this latest Wagtail (6.1.X) has a bug which only

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -567,19 +567,6 @@ class PlanFilter(WagtailFilterSet):
         fields = ['clients__client']
 
 
-class PlanPermissionPolicy(ModelPermissionPolicy):
-    def __init__(self):
-        super().__init__(Plan)
-
-    def user_has_permission_for_instance(self, user: AbstractBaseUser, action: str, instance: Model) -> bool:
-        if not super().user_has_permission_for_instance(user, action, instance):
-            return False
-        if not user.is_authenticated:
-            return False
-        assert isinstance(user, User)
-        return not user.is_anonymous and instance == user.get_active_admin_plan()
-
-
 class PlanViewSet(SnippetViewSet[Plan]):
     model = Plan
     add_to_admin_menu = True
@@ -591,10 +578,6 @@ class PlanViewSet(SnippetViewSet[Plan]):
     list_per_page = None  # disable pagination
     index_view_class = PlanIndexView
     # Note that we can't use PlanCopyView as copy_view_class because it is not a (snippet) CopyView
-
-    @property
-    def permission_policy(self):
-        return PlanPermissionPolicy()
 
     # Copied from UserFeedbackViewSet
     # FIXME: As of writing this latest Wagtail (6.1.X) has a bug which only

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -6,7 +6,7 @@ from functools import cached_property
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Model, ProtectedError
+from django.db.models import ProtectedError
 from django.urls import re_path, reverse
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.filters import WagtailFilterSet
@@ -20,7 +20,6 @@ from wagtail.admin.panels import (
 from wagtail.admin.ui.tables import BulkActionsCheckboxColumn, Column
 from wagtail.admin.widgets.button import ButtonWithDropdown
 from wagtail.coreutils import capfirst
-from wagtail.permissions import ModelPermissionPolicy
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import IndexView, SnippetViewSet
 
@@ -64,7 +63,6 @@ from . import (
 from .models import ActionImpact, ActionStatus, Plan, PlanFeatures
 
 if typing.TYPE_CHECKING:
-    from django.contrib.auth.models import AbstractBaseUser
     from django.db.models import QuerySet
     from django.http import HttpRequest
     from wagtail.admin.menu import MenuItem

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -660,32 +660,6 @@ class SuccessUrlEditPageModelAdminMixin:
         return self.url_helper.get_action_url('edit', self.instance.pk)
 
 
-class ActivePlanEditView(SuccessUrlEditPageModelAdminMixin, AplansEditView):
-    @transaction.atomic()
-    def form_valid(self, form):
-        old_common_category_types = self.instance.common_category_types.all()
-        new_common_category_types = form.cleaned_data['common_category_types']
-        for added_cct in new_common_category_types.difference(old_common_category_types):
-            # Create category type corresponding to this common category type and link it to this plan
-            ct = added_cct.instantiate_for_plan(self.instance)
-            # Create categories for the common categories having that common category type
-            for common_category in added_cct.categories.all():
-                common_category.instantiate_for_category_type(ct)
-        for removed_cct in old_common_category_types.difference(new_common_category_types):
-            try:
-                self.instance.category_types.filter(common=removed_cct).delete()
-            except ProtectedError:
-                # Actually validation should have been done before this method is called, but it seems to work for now
-                error = _(
-                    'Could not remove common category type "%(removed_cct)" from the plan because categories '
-                    'with the corresponding category type exist.',
-                ) % {'removed_cct': removed_cct}
-                form.add_error('common_category_types', error)
-                messages.validation_error(self.request, self.get_error_message(), form)
-                return self.render_to_response(self.get_context_data(form=form))
-        return super().form_valid(form)
-
-
 class AplansCreateView(
     PersistFiltersEditingModelAdminMixin,
     ContinueEditingModelAdminMixin,


### PR DESCRIPTION
This (and removing the associated modeladmin classes) required some changes to the tests.