### PR TITLE
Fix/update cluster related objects in plan copy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 /static/
 /.direnv/
 /.*env*
+!/.env.test
 /.git/
 /.github/
 /.pytest_cache/

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+HOSTNAME_PLAN_DOMAINS=example.org

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tmp/**
 *.bz2
 *.xlsx
 .env*
+!/.env.test
 venv/**
 bin/**
 Attic/**

--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib.util
-import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -102,8 +101,11 @@ env = environ.FileAwareEnv(
 
 BASE_DIR = root()
 
-if env.bool('ENV_FILE'):
-    environ.Env.read_env(env.str('ENV_FILE'))
+ENV_FILE = env.str('ENV_FILE', None)  # pyright: ignore[reportArgumentType]
+if ENV_FILE:
+    if not Path(ENV_FILE).exists():
+        raise ImproperlyConfigured(f'File {ENV_FILE} specified in ENV_FILE does not exist')
+    environ.Env.read_env(ENV_FILE)
 else:
     dotenv_path = BASE_DIR / Path('.env')
     if dotenv_path.exists():

--- a/copying/main.py
+++ b/copying/main.py
@@ -489,7 +489,7 @@ def copy_plan(
     version_name: str | None = None,
     supersede_original_plan: bool = False,
     supersede_original_actions: bool = False,
-):
+) -> Plan:
     """
     Copy the given plan.
 
@@ -504,6 +504,8 @@ def copy_plan(
 
     If `supersede_original_plan` is true, the copy will supersede the original plan; if
     `supersede_original_actions` is true, each action copy will supersede its original.
+
+    Returns the copy.
     """
     if new_plan_identifier is None:
         new_plan_identifier = plan.default_identifier_for_copying()
@@ -582,6 +584,8 @@ def copy_plan(
     # Restore temporarily removed links
     clone_visitor.restore_removed_links()
     update_references(plan_copy, attribute_types, clone_visitor)
+
+    return plan_copy
 
 
 def update_references(plan_copy: Plan, attribute_types: list[AttributeType], clone_visitor: CloneVisitor):

--- a/copying/main.py
+++ b/copying/main.py
@@ -136,6 +136,10 @@ class CloneVisitor(AbstractVisitor):
         self.supersede_original_plan = supersede_original_plan
         self.supersede_original_actions = supersede_original_actions
 
+    def has_copy(self, instance: Model) -> bool:
+        """Return true if a copy has been created for the given instance."""
+        return (type(instance), instance.pk) in self.copies
+
     def get_copy[M: Model](self, instance: M) -> M:
         """Get the copy that has been created for the given instance."""
         copy = self.copies[(type(instance), instance.pk)]
@@ -315,6 +319,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
     def update_instance(self, instance: Model, save: bool = True):
         """Update all references from `instance` to objects that have been copied to point to the copies."""
         logger.trace(f"Update references of {type(instance).__name__} {instance.pk}: {instance}")
+        self.update_cluster_related_objects(instance)
         update_fields = []
         update_fields += self.update_foreign_keys(instance)
         if isinstance(instance, Page):
@@ -351,6 +356,38 @@ class UpdateReferencesVisitor(AbstractVisitor):
     def _(self, instance: Plan) -> Generator[Field | GenericForeignKey]:
         return self._get_references(instance, exclude_fields=['copy_of'])
 
+    def update_cluster_related_objects(self, instance: Model):
+        for cros in getattr(instance, '_cluster_related_objects', {}).values():
+            for cro in cros:
+                if cro.id is not None:
+                    try:
+                        cro_copy = self.clone_visitor.get_copy(cro)
+                    except KeyError:
+                        # Probably there is no copy because the model instance that `cro` originally corresponded to no
+                        # longer exists in the database.
+                        cro.id = None
+                        logger.trace(
+                            f"In cluster related objects of {type(instance).__name__} {instance.pk}: Could not find "
+                            f"copy for {type(cro).__name__} {cro.pk}: {cro}"
+                        )
+                    else:
+                        cro.id = cro_copy.id
+                        logger.trace(
+                            f"In cluster related objects of {type(instance).__name__} {instance.pk}: Set primary key "
+                            f"of {type(cro).__name__} {cro.pk} to: {cro_copy.id}"
+                        )
+                for fk in self.get_references(cro):
+                    related_object = getattr(cro, fk.name)
+                    if related_object:
+                        # `related_object` should be a copy already
+                        assert not self.clone_visitor.has_copy(related_object)
+                        # `cro` currently references the ID of the original of the copy `related_object`, so we update it
+                        setattr(cro, fk.name, related_object)
+                        logger.trace(
+                            f"In cluster related objects of {type(instance).__name__} {instance.pk}: Set foreign key "
+                            f"'{fk.name}' of {type(cro).__name__} {instance.pk} to: {related_object.pk}"
+                        )
+
     def update_foreign_keys(self, instance: Model) -> list[str]:
         update_fields = []
         for fk in self.get_references(instance):
@@ -365,7 +402,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
                         f"{related_object}"
                     )
                     continue
-                logger.trace(f"Set foreign key '{fk.name}' of {type(instance).__name__} {instance.pk} to: {copy}")
+                logger.trace(f"Set foreign key '{fk.name}' of {type(instance).__name__} {instance.pk} to: {copy.pk}")
                 setattr(instance, fk.name, copy)
                 if isinstance(fk, GenericForeignKey):
                     # Technically we'd also need to update fk.ct_field, but content types don't change by copying

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from actions.tests.factories import ActionContactFactory, WorkflowFactory
+from copying.main import copy_plan
+
+pytestmark = pytest.mark.django_db
+
+
+def test_publish_copied_action_does_not_steal_contact_persons(plan_with_pages, action, user):
+    ActionContactFactory(action=action)
+    plan = plan_with_pages
+    plan.features.moderation_workflow = WorkflowFactory()
+    plan.features.save(update_fields=['moderation_workflow'])
+    action.save_revision(user=user)
+    plan_copy = copy_plan(plan)
+    assert action == plan.actions.first()
+    action_copy = plan_copy.actions.first()
+    assert action_copy
+    assert action_copy.latest_revision
+    action_copy.latest_revision.publish()
+    assert action.contact_persons.exists()

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from wagtail.models import Revision
+
 import pytest
 
 from actions.tests.factories import ActionContactFactory, WorkflowFactory
@@ -18,6 +20,6 @@ def test_publish_copied_action_does_not_steal_contact_persons(plan_with_pages, a
     assert action == plan.actions.first()
     action_copy = plan_copy.actions.first()
     assert action_copy
-    assert action_copy.latest_revision
+    assert isinstance(action_copy.latest_revision, Revision)
     action_copy.latest_revision.publish()
     assert action.contact_persons.exists()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ norecursedirs = [
 ]
 filterwarnings = ["ignore::DeprecationWarning:easy_thumbnails"]
 testpaths = ["**/tests"]
+env = [
+  "ENV_FILE=.env.test",
+]
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]

--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,7 @@ django-anymail[mailjet]
 django-reversion
 pytest-django
 pytest-cov
+pytest-env
 factory-boy
 pytest-factoryboy
 pytest-html

--- a/requirements.txt
+++ b/requirements.txt
@@ -377,16 +377,19 @@ pyjwt==2.8.0
     #   social-auth-core
 pynacl==1.5.0
     # via pygithub
-pytest==8.2.1
+pytest==8.3.4
     # via
     #   pytest-cov
     #   pytest-django
+    #   pytest-env
     #   pytest-factoryboy
     #   pytest-html
     #   pytest-metadata
 pytest-cov==5.0.0
     # via -r requirements.in
 pytest-django==4.8.0
+    # via -r requirements.in
+pytest-env==1.1.5
     # via -r requirements.in
 pytest-factoryboy==2.7.0
     # via -r requirements.in


### PR DESCRIPTION
This should fix an error where copying a plan with drafts and then publishing a draft in the copy would steal related objects (e.g., contact persons) from the original action. That would happen because the serialized data in the revisions still contains references to instances belonging to the original plan.