### PR TITLE
Avoid saving Indicator, CategoryType, Action accidentally from a different plan

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -213,7 +213,6 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
             # Organizations can only have at most one role as a responsible party
 
     def save(self, commit=True):
-
         initial_plan_id = self.initial_plan_id
         # Use initial_plan_id to detect mismatch between the active plan and the initial plan on form load.
         if initial_plan_id and str(initial_plan_id) != str(self.instance.plan.id):
@@ -221,8 +220,8 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
 
             request = ctx_request.get()
             messages.add_message(request, messages.WARNING,
-                                 _("Active plan was changed during the editing of this action. "
-                                   "Action was saved with the original plan: %s")
+                                 _('While editing this action you have switched to a different plan. '
+                                   'This action was still saved with the original plan "%s".')
                                  % initial_plan.name)
             self.instance.plan = initial_plan
 

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -53,6 +53,7 @@ from admin_site.wagtail import (
     CondensedInlinePanel,
     CustomizableBuiltInFieldPanel,
     CustomizableBuiltInPlanFilteredFieldPanel,
+    InitializeFormWithInitialPlanMixin,
     PlanFilteredFieldPanel,
     PlanRelatedModelAdminPermissionHelper,
     get_translation_tabs,
@@ -155,6 +156,7 @@ MODELS_WITH_ROLES: list[tuple[type[ModelWithRole], str, type[Model], str]] = [
 
 class ActionAdminForm(WagtailAdminModelForm[Action]):
     def __init__(self, *args, **kwargs):
+        self.initial_plan_id = kwargs.pop('initial_plan_id', None)
         super().__init__(*args, **kwargs)
         # There is a corresponding formset for a role if and only if we can edit contact persons of that role.
         for cls, relation_name, __, __ in MODELS_WITH_ROLES:
@@ -208,6 +210,16 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
             self._validate_unique_relations_with_roles(_cls, relation_name, wrapped_object_cls, wrapped_object_attr)
             # Persons can only have at most one role as a contact person.
             # Organizations can only have at most one role as a responsible party
+
+        # Check for plan_id mismatch.
+        # This can happen if the user is editing an action and opens another plan in a different tab.
+        super().clean()
+
+        initial_plan_id = self.initial_plan_id
+
+        # Use initial_plan_id to detect mismatch
+        if initial_plan_id and initial_plan_id != str(self.instance.plan.id):
+            raise ValidationError("Plan ID mismatch")
 
     def save(self, commit=True):
         if hasattr(self.instance, 'updated_at'):
@@ -588,7 +600,7 @@ class ActionEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTa
         return form_class
 
 
-class ActionCreateView(AplansCreateView):
+class ActionCreateView(InitializeFormWithInitialPlanMixin, AplansCreateView):
     instance: Action
 
     def initialize_instance(self, request):
@@ -669,7 +681,7 @@ class ActionButtonHelper(AplansButtonHelper):
         return buttons
 
 
-class ActionEditView(SnippetsEditViewCompatibilityMixin, SingleObjectMixin, AplansEditView):
+class ActionEditView(InitializeFormWithInitialPlanMixin, SnippetsEditViewCompatibilityMixin, SingleObjectMixin, AplansEditView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.instance.plan.features.enable_moderation_workflow:

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -5,7 +5,7 @@ import logging
 import typing
 from typing import Any, Iterable, Unpack, cast
 
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.admin.utils import quote
 from django.core.exceptions import ValidationError
 from django.urls import URLPattern, path, re_path
@@ -35,6 +35,7 @@ from dal import autocomplete, forward as dal_forward
 from wagtail_modeladmin.options import ModelAdminMenuItem
 from wagtail_modeladmin.views import IndexView
 
+from actions.models.plan import Plan
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.extensions import modeladmin_register
 from aplans.utils import naturaltime
@@ -211,17 +212,20 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
             # Persons can only have at most one role as a contact person.
             # Organizations can only have at most one role as a responsible party
 
-        # Check for plan_id mismatch.
-        # This can happen if the user is editing an action and opens another plan in a different tab.
-        super().clean()
+    def save(self, commit=True):
 
         initial_plan_id = self.initial_plan_id
+        # Use initial_plan_id to detect mismatch between the active plan and the initial plan on form load.
+        if initial_plan_id and str(initial_plan_id) != str(self.instance.plan.id):
+            initial_plan = Plan.objects.get(id=initial_plan_id)
 
-        # Use initial_plan_id to detect mismatch
-        if initial_plan_id and initial_plan_id != str(self.instance.plan.id):
-            raise ValidationError("Plan ID mismatch")
+            request = ctx_request.get()
+            messages.add_message(request, messages.WARNING,
+                                 _("Active plan was changed during the editing of this action. "
+                                   "Action was saved with the original plan: %s")
+                                 % initial_plan.name)
+            self.instance.plan = initial_plan
 
-    def save(self, commit=True):
         if hasattr(self.instance, 'updated_at'):
             self.instance.updated_at = timezone.now()
 

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -35,13 +35,13 @@ from dal import autocomplete, forward as dal_forward
 from wagtail_modeladmin.options import ModelAdminMenuItem
 from wagtail_modeladmin.views import IndexView
 
-from actions.models.plan import Plan
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.extensions import modeladmin_register
 from aplans.utils import naturaltime
 from aplans.wagtail_utils import _get_category_fields
 
 from actions.chooser import ActionChooser
+from actions.models.plan import Plan
 from admin_site.utils import FieldLabelRenderer
 from admin_site.wagtail import (
     AdminOnlyPanel,

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -94,7 +94,11 @@ class AttributeTypeIndexView(IndexView):
     page_title = _("Fields")
 
 
-class AttributeTypeCreateView(ContentTypeQueryParameterMixin, InitializeFormWithPlanMixin, AplansCreateView):
+class AttributeTypeCreateView(
+    ContentTypeQueryParameterMixin,
+    InitializeFormWithPlanMixin,
+    AplansCreateView,
+):
     def get_object_content_type(self):
         object_ct_id = self.request.GET.get('content_type')
         if not object_ct_id:
@@ -132,7 +136,11 @@ class AttributeTypeCreateView(ContentTypeQueryParameterMixin, InitializeFormWith
         return instance
 
 
-class AttributeTypeEditView(ContentTypeQueryParameterMixin, InitializeFormWithPlanMixin, AplansEditView):
+class AttributeTypeEditView(
+    ContentTypeQueryParameterMixin,
+    InitializeFormWithPlanMixin,
+    AplansEditView,
+):
     pass
 
 

--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
-from django.contrib.admin import SimpleListFilter
 from django.contrib import messages
+from django.contrib.admin import SimpleListFilter
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.forms import ModelChoiceField
@@ -25,11 +25,11 @@ from wagtail_modeladmin.options import modeladmin_register
 from wagtail_modeladmin.views import DeleteView
 from wagtailorderable.modeladmin.mixins import OrderableMixin
 
-from actions.models.plan import Plan
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import append_query_parameter
 
 from actions.blocks.mixins import ActionListPageBlockFormMixin
+from actions.models.plan import Plan
 from admin_site.utils import admin_req
 from admin_site.wagtail import (
     AplansAdminModelForm,
@@ -39,8 +39,8 @@ from admin_site.wagtail import (
     AplansTabbedInterface,
     CondensedInlinePanel,
     DatasetButtonMixin,
-    InitializeFormWithPlanMixin,
     InitializeFormWithInitialPlanMixin,
+    InitializeFormWithPlanMixin,
     PlanFilteredFieldPanel,
     get_translation_tabs,
 )

--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -266,8 +266,8 @@ class CategoryTypeForm(ActionListPageBlockFormMixin, AplansAdminModelForm):
             initial_plan = Plan.objects.get(pk=initial_plan_id)
             request = ctx_request.get_admin_request()
             messages.add_message(request, messages.WARNING,
-                                 _("Active plan was changed during the editing of this category type. "
-                                   "Category type was saved with the original plan: %s")
+                                 _('While editing this category type you have switched to a different plan. '
+                                   'This category type was still saved with the original plan "%s".')
                                  % initial_plan.name)
             self.plan = initial_plan
             obj.plan = self.plan

--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib.admin import SimpleListFilter
+from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.forms import ModelChoiceField
@@ -24,6 +25,7 @@ from wagtail_modeladmin.options import modeladmin_register
 from wagtail_modeladmin.views import DeleteView
 from wagtailorderable.modeladmin.mixins import OrderableMixin
 
+from actions.models.plan import Plan
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import append_query_parameter
 
@@ -38,6 +40,7 @@ from admin_site.wagtail import (
     CondensedInlinePanel,
     DatasetButtonMixin,
     InitializeFormWithPlanMixin,
+    InitializeFormWithInitialPlanMixin,
     PlanFilteredFieldPanel,
     get_translation_tabs,
 )
@@ -81,11 +84,11 @@ class CommonCategoryTypeFilter(SimpleListFilter):
         return queryset
 
 
-class CategoryTypeCreateView(InitializeFormWithPlanMixin, AplansCreateView):
+class CategoryTypeCreateView(InitializeFormWithPlanMixin, InitializeFormWithInitialPlanMixin, AplansCreateView):
     pass
 
 
-class CategoryTypeEditView(InitializeFormWithPlanMixin, AplansEditView):
+class CategoryTypeEditView(InitializeFormWithPlanMixin, InitializeFormWithInitialPlanMixin, AplansEditView):
     pass
 
 
@@ -253,7 +256,24 @@ class CategoryEditHandler(AplansTabbedInterface):
 class CategoryTypeForm(ActionListPageBlockFormMixin, AplansAdminModelForm):
     def __init__(self, *args, **kwargs):
         self.plan = kwargs.pop('plan')
+        self.initial_plan_id = kwargs.pop('initial_plan_id')
         super().__init__(*args, **kwargs)
+
+    def save(self, commit=True):
+        obj = super().save(commit)
+        initial_plan_id = self.initial_plan_id
+        if initial_plan_id and str(initial_plan_id) != str(self.plan.id):
+            initial_plan = Plan.objects.get(pk=initial_plan_id)
+            request = ctx_request.get_admin_request()
+            messages.add_message(request, messages.WARNING,
+                                 _("Active plan was changed during the editing of this category type. "
+                                   "Category type was saved with the original plan: %s")
+                                 % initial_plan.name)
+            self.plan = initial_plan
+            obj.plan = self.plan
+            obj.save()
+
+        return obj
 
 
 class CategoryTypeEditHandler(AplansTabbedInterface):

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -793,6 +793,22 @@ class InitializeFormWithPlanMixin:
         return kwargs
 
 
+class InitializeFormWithInitialPlanMixin:
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs() # type: ignore
+        kwargs.update({'initial_plan_id': self.request.session.get('initial_plan_id')}) # type: ignore
+        return kwargs
+
+    def dispatch(self, request, *args, **kwargs):
+        # Retrieve the active plan and set the plan ID in the session
+        if request.method == 'GET':
+            active_plan = request.get_active_admin_plan()
+            request.session['initial_plan_id'] = str(active_plan.id)
+
+        # Proceed with the normal dispatch process
+        return super().dispatch(request, *args, **kwargs) # type: ignore
+
+
 class InitializeFormWithUserMixin:
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -36,6 +36,7 @@ from admin_site.wagtail import (
     BuiltInFieldCustomizationAwareEditHandlerMixin,
     CondensedInlinePanel,
     CustomizableBuiltInFieldPanel,
+    InitializeFormWithInitialPlanMixin,
     InitializeFormWithPlanMixin,
     get_translation_tabs,
 )
@@ -235,7 +236,9 @@ class IndicatorForm(AplansAdminModelForm):
 
     def __init__(self, *args, **kwargs):
         self.plan = kwargs.pop('plan')
+        self.initial_plan_id = kwargs.pop('initial_plan_id', None)
         super().__init__(*args, **kwargs)
+
         if self.instance.pk is not None:
             # We are editing an existing indicator. If the indicator is in the
             # active plan, set this form's `level` field to the proper value.
@@ -266,10 +269,17 @@ class IndicatorForm(AplansAdminModelForm):
         return organization
 
     def clean(self):
-        data = super().clean()
-        common = data.get('common')
+        super().clean()
+
+        initial_plan_id = str(self.initial_plan_id)
+        # Use initial_plan_id to detect mismatch between the active plan and the initial plan on form load.
+        if initial_plan_id and initial_plan_id != str(self.plan.id):
+            raise ValidationError("Plan ID mismatch")
+
+        common = self.cleaned_data.get('common')
         # Dimensions cannot be accessed from self.instance.dimensions yet
         new_dimensions = self.get_dimension_ids_from_formset()
+
         if common and new_dimensions is not None:
             common_indicator_dimensions = list(common.dimensions.values_list('dimension', flat=True))
             if new_dimensions != common_indicator_dimensions:
@@ -281,7 +291,8 @@ class IndicatorForm(AplansAdminModelForm):
                 # common indicator, you'll get this validation error but the condensed inline panel will be gone. WTF?
                 # This may also affect CommonIndicatorForm.
                 raise ValidationError(_("Dimensions must be the same as in common indicator"))
-        return data
+
+        return self.cleaned_data
 
     def save(self, commit=True):
         if self.instance.organization_id is None:
@@ -342,13 +353,11 @@ class IndicatorAdminOrganizationFilter(SimpleListFilter):
         return queryset
 
 
-class IndicatorCreateView(InitializeFormWithPlanMixin, AplansCreateView):
+class IndicatorCreateView(InitializeFormWithPlanMixin, InitializeFormWithInitialPlanMixin, AplansCreateView):
     pass
 
-
-class IndicatorEditView(InitializeFormWithPlanMixin, AplansEditView):
+class IndicatorEditView(InitializeFormWithPlanMixin, InitializeFormWithInitialPlanMixin, AplansEditView):
     pass
-
 
 class IndicatorEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTabbedInterface[Indicator]):
     def get_form_class(self):

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -299,8 +299,8 @@ class IndicatorForm(AplansAdminModelForm):
 
             request = ctx_request.get()
             messages.add_message(request, messages.WARNING,
-                                 _("Active plan was changed during the editing of this indicator. "
-                                   "Indicator was saved with the original plan: %s")
+                                 _('While editing this indicator you have switched to a different plan. '
+                                   'This indicator was still saved with the original plan "%s".')
                                  % initial_plan.name)
             self.plan = initial_plan
 

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from django import forms
+from django.contrib import messages
 from django.contrib.admin import SimpleListFilter
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _, ngettext_lazy
@@ -26,6 +27,7 @@ from aplans.context_vars import ctx_instance, ctx_request
 from aplans.extensions import modeladmin_register
 from aplans.wagtail_utils import _get_category_fields
 
+from actions.models.plan import Plan
 from admin_site.utils import admin_req
 from admin_site.wagtail import (
     AplansAdminModelForm,
@@ -271,11 +273,6 @@ class IndicatorForm(AplansAdminModelForm):
     def clean(self):
         super().clean()
 
-        initial_plan_id = str(self.initial_plan_id)
-        # Use initial_plan_id to detect mismatch between the active plan and the initial plan on form load.
-        if initial_plan_id and initial_plan_id != str(self.plan.id):
-            raise ValidationError("Plan ID mismatch")
-
         common = self.cleaned_data.get('common')
         # Dimensions cannot be accessed from self.instance.dimensions yet
         new_dimensions = self.get_dimension_ids_from_formset()
@@ -295,6 +292,18 @@ class IndicatorForm(AplansAdminModelForm):
         return self.cleaned_data
 
     def save(self, commit=True):
+        initial_plan_id = self.initial_plan_id
+        # Use initial_plan_id to detect mismatch between the active plan and the initial plan on form load.
+        if initial_plan_id and str(initial_plan_id) != str(self.plan.id):
+            initial_plan = Plan.objects.get(id=initial_plan_id)
+
+            request = ctx_request.get()
+            messages.add_message(request, messages.WARNING,
+                                 _("Active plan was changed during the editing of this indicator. "
+                                   "Indicator was saved with the original plan: %s")
+                                 % initial_plan.name)
+            self.plan = initial_plan
+
         if self.instance.organization_id is None:
             self.instance.organization = self.plan.organization
         old_dimensions = list(self.instance.dimensions.values_list('dimension', flat=True))
@@ -304,6 +313,7 @@ class IndicatorForm(AplansAdminModelForm):
             self.instance.latest_value = None
             self.instance.save()
             self.instance.values.all().delete()
+
         obj = super().save(commit)
         plan = self.plan
         for field_name, field in _get_category_fields(plan, Indicator, obj).items():


### PR DESCRIPTION
Check that the active plan when saving is the same as when the edit form was loaded.
For action, indicator and categorytype.

Doesn't seem to be a problem anywhere else that I can think of (not really in Action either, but doesn't hurt)