### PR TITLE
Modeladmin migration – WatchViewSet update

### DIFF
--- a/admin_site/mixins.py
+++ b/admin_site/mixins.py
@@ -58,6 +58,7 @@ class SetInstanceMixin(HasObject):
             return super().dispatch(request, *args, **kwargs)  # type: ignore[misc]
 
 
+# FIXME: Does not work.
 class PersistFiltersEditingMixin:
     request: HttpRequest
     model_name: str

--- a/admin_site/mixins.py
+++ b/admin_site/mixins.py
@@ -10,6 +10,8 @@ from django.http.request import QueryDict
 from django.http.response import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy as _
+from wagtail.snippets.action_menu import ActionMenuItem
 
 from aplans.context_vars import ctx_instance
 from aplans.types import WatchAdminRequest
@@ -77,8 +79,15 @@ class PersistFiltersEditingMixin:
 
 
 class ContinueEditingMixin:
+    """Mixin to add "Save and continue editing" functionality to a view."""
+
     request: HttpRequest
     get_edit_url: Callable
+
+    class ContinueEditingActionMenuItem(ActionMenuItem):
+        label = _("Save and continue editing")
+        name = "_continue"
+        icon_name = "download"
 
     def continue_editing_active(self):
         return '_continue' in self.request.POST
@@ -96,6 +105,11 @@ class ContinueEditingMixin:
             return []
 
         return super().get_success_buttons()  # type: ignore[misc]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)  # type: ignore[misc]
+        context['action_menu'].menu_items.append(self.ContinueEditingActionMenuItem())
+        return context
 
 
 class PlanRelatedViewMixin:

--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -16,7 +16,6 @@ from admin_site.forms import WatchAdminModelForm
 from admin_site.mixins import (
     ActivatePermissionHelperPlanContextMixin,
     ContinueEditingMixin,
-    PersistFiltersEditingMixin,
     PlanRelatedViewMixin,
     SetInstanceMixin,
 )
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
 
 
 class WatchEditView[ModelT: Model, FormT: WagtailAdminModelForm](
-    PersistFiltersEditingMixin,
+    # PersistFiltersEditingMixin,  # TODO: Is this needed? Does not work right now.
     ContinueEditingMixin,
     PlanRelatedViewMixin,
     ActivatePermissionHelperPlanContextMixin,

--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -10,7 +10,7 @@ from wagtail.admin import messages
 from wagtail.admin.forms.models import WagtailAdminModelForm
 from wagtail.snippets.views.snippets import CreateView, EditView, IndexView, SnippetViewSet
 
-from aplans.utils import PlanRelatedModel
+from aplans.utils import PlanDefaultsModel, PlanRelatedModel
 
 from admin_site.forms import WatchAdminModelForm
 from admin_site.mixins import (
@@ -68,8 +68,45 @@ class WatchEditView[ModelT: Model, FormT: WagtailAdminModelForm](
         return _("%s could not be created due to errors.") % capfirst(model_name)
 
 
-class WatchCreateView[ModelT: Model, FormT: ModelForm](CreateView[ModelT, FormT]):
+class WatchCreateView[ModelT: Model, FormT: ModelForm](
+    # PersistFiltersEditingMixin,  # TODO: Is this needed? Does not work right now.
+    ContinueEditingMixin,
+    PlanRelatedViewMixin,
+    CreateView[ModelT, FormT],
+    # SetInstanceMixin,  # TODO: Is this needed? Causes linting errors right now.
+):
     request: WatchAdminRequest
+
+    def initialize_instance(self, request: WatchAdminRequest, instance: ModelT) -> None:
+        """
+        Initialize the instance with plan defaults.
+
+        Override this in subclasses to implement custom initialization logic.
+        """
+        if isinstance(instance, PlanDefaultsModel):
+            plan = request.user.get_active_admin_plan()
+            instance.initialize_plan_defaults(plan)
+
+    def get_initial_form_instance(self):
+        instance = super().get_initial_form_instance()
+        if instance is None:
+            instance = self.model()
+
+        self.initialize_instance(self.request, instance)
+        return instance
+
+    def save_instance(self):
+        instance = super().save_instance()
+
+        if hasattr(instance, 'handle_admin_save'):
+            instance.handle_admin_save(
+                context={
+                    'user': self.request.user,
+                    'operation': 'create',
+                },
+            )
+
+        return instance
 
     def get_form_kwargs(self):
         return {

--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -8,7 +8,7 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
 from wagtail.admin.forms.models import WagtailAdminModelForm
-from wagtail.snippets.views.snippets import CreateView, EditView, SnippetViewSet
+from wagtail.snippets.views.snippets import CreateView, EditView, IndexView, SnippetViewSet
 
 from aplans.utils import PlanRelatedModel
 
@@ -77,8 +77,15 @@ class WatchCreateView[ModelT: Model, FormT: ModelForm](CreateView[ModelT, FormT]
             'plan': self.request.user.get_active_admin_plan(),
         }
 
+class WatchIndexView[ModelT: Model, FormT: ModelForm](
+    ActivatePermissionHelperPlanContextMixin,
+    IndexView,
+):
+    pass
+
 
 class WatchViewSet[ModelT: Model, FormT: ModelForm](SnippetViewSet[ModelT, FormT]):
+    index_view_class = WatchIndexView
     add_view_class = WatchCreateView
     edit_view_class = WatchEditView
 


### PR DESCRIPTION
An attempt at bringing `WatchViewSet` closer to have the same functionality that `AplansModelAdmin` has.

Still unfinished / untested are some mixins, where we should decide whether they are needed at all. Also some functionality that is built in the templates of modeladmin edit and create views (at least a little popup warning about unsaved changes) are not implemented in `WatchViewSet` yet. Some other functionality may also have gone unnoticed...