### PR TITLE
Fix rich-text editor language when editing Wagtail pages

### DIFF
--- a/admin_site/apps.py
+++ b/admin_site/apps.py
@@ -68,6 +68,16 @@ class AdminSiteConfig(AdminConfig):
         from wagtail.admin.views.account import ThemeSettingsPanel
         ThemeSettingsPanel.is_active = lambda self: False  # type: ignore
 
+        from wagtail.admin.rich_text import DraftailRichTextArea
+        from wagtail.telepath import register as register_telepath_adapter
+
+        from admin_site.draftail_rich_text_area import DraftailRichTextAreaAdapterWithFixedTranslations
+
+        # Override existing adapter for DraftailRichTextArea; otherwise the tools when pressing '/' while editing a rich
+        # text field in a Wagtail page will not use the right language. Note that this hack here takes care of Wagtail
+        # pages; we use a different hack for the rich text editor when editing Action instances.
+        register_telepath_adapter(DraftailRichTextAreaAdapterWithFixedTranslations(), DraftailRichTextArea)
+
         # We use this just for overriding some Django translations that are weird in some languages
         def _dummy_function_so_makemessages_finds_strings():
             # This is never called

--- a/admin_site/draftail_rich_text_area.py
+++ b/admin_site/draftail_rich_text_area.py
@@ -1,44 +1,57 @@
-import re
+from __future__ import annotations
+
 from copy import deepcopy
 
 from django.utils.translation import gettext
 from wagtail.admin.rich_text import DraftailRichTextArea
+from wagtail.admin.rich_text.editors.draftail import DraftailRichTextAreaAdapter
 
 
 # Workaround until https://github.com/wagtail/wagtail/pull/11075 is merged
+def _hack_rich_text_editor_options(options: dict) -> None:
+    type_to_trans_map = {
+        "LINK": gettext("Link"),
+        "DOCUMENT": gettext("Document"),
+        "EMBED": gettext("Embed"),
+        "IMAGE": gettext("Image"),
+        "BOLD": gettext("Bold"),
+        "ITALIC": gettext("Italic"),
+        "SUPERSCRIPT": gettext("Superscript"),
+        "SUBSCRIPT": gettext("Subscript"),
+        "header-two": gettext("Heading %(level)d") % {"level": 2},
+        "header-three": gettext("Heading %(level)d") % {"level": 3},
+        "header-four": gettext("Heading %(level)d") % {"level": 4},
+        "ordered-list-item": gettext("Numbered list"),
+        "unordered-list-item": gettext("Bulleted list"),
+    }
+    for option in options.values():
+        if not isinstance(option, list):
+            continue
+        for item in option:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get('type')
+            if not item_type:
+                continue
+            new_trans = type_to_trans_map.get(item_type)
+            if not new_trans:
+                continue
+            item['description'] = new_trans
+
+
 class DraftailRichTextAreaWithFixedTranslations(DraftailRichTextArea):
     def get_context(self, name, value, attrs):
-        type_to_trans_map = {
-            "LINK": gettext("Link"),
-            "DOCUMENT": gettext("Document"),
-            "EMBED": gettext("Embed"),
-            "IMAGE": gettext("Image"),
-            "BOLD": gettext("Bold"),
-            "ITALIC": gettext("Italic"),
-            "SUPERSCRIPT": gettext("Superscript"),
-            "SUBSCRIPT": gettext("Subscript"),
-            "header-two": gettext("Heading %(level)d") % {"level": 2},
-            "header-three": gettext("Heading %(level)d") % {"level": 3},
-            "header-four": gettext("Heading %(level)d") % {"level": 4},
-            "ordered-list-item": gettext("Numbered list"),
-            "unordered-list-item": gettext("Bulleted list"),
-        }
-
         old_options = self.options
         self.options = deepcopy(old_options)
-        for option in self.options.values():
-            if not isinstance(option, list):
-                continue
-            for item in option:
-                if not isinstance(item, dict):
-                    continue
-                item_type = item.get('type')
-                if not item_type:
-                    continue
-                new_trans = type_to_trans_map.get(item_type)
-                if not new_trans:
-                    continue
-                item['description'] = new_trans
+        _hack_rich_text_editor_options(self.options)
         context = super().get_context(name, value, attrs)
         self.options = old_options
         return context
+
+
+class DraftailRichTextAreaAdapterWithFixedTranslations(DraftailRichTextAreaAdapter):
+    def js_args(self, widget):
+        dicts = super().js_args(widget)
+        for d in dicts:
+            _hack_rich_text_editor_options(d)
+        return dicts


### PR DESCRIPTION
Uses the same idea as the hack we used for editing Action instances; however, that one didn't work when editing pages.

https://app.asana.com/0/1202880927552397/1206120724392386/f