### PR TITLE
Fix references in drafts after deleting action-related instances

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -29,7 +29,7 @@ from modeltrans.translator import get_i18n_field
 from reversion.models import Version
 from wagtail.admin.panels.base import Panel
 from wagtail.fields import RichTextField
-from wagtail.models import DraftStateMixin, LockableMixin, RevisionMixin, Task, TaskState, WorkflowMixin
+from wagtail.models import DraftStateMixin, LockableMixin, Revision, RevisionMixin, Task, TaskState, WorkflowMixin
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 
@@ -1170,6 +1170,17 @@ class ActionResponsibleParty(OrderedModel, ModelWithRole['ActionResponsibleParty
     def filter_siblings(self, qs: QuerySet[Self, Self]) -> QuerySet[Self, Self]:
         return qs.filter(action=self.action)
 
+    def fix_action_draft_after_deletion(self):
+        # This should only be called after self just got deleted
+        revision = self.action.latest_revision
+        if not revision:
+            return
+        assert isinstance(revision, Revision)
+        for acp_dict in revision.content.get('responsible_parties', []):
+            if acp_dict.get('pk') == self.pk:
+                acp_dict['pk'] = None
+        revision.save()
+
     @classmethod
     def get_roles_editable_in_action_by(cls, action: Action, person: Person) -> Sequence[Role | None]:
         is_contact_person = person is not None and action.contact_persons.filter(
@@ -1233,6 +1244,17 @@ class ActionContactPerson(OrderedModel, ModelWithRole['ActionContactPerson.Role'
 
     def is_moderator(self) -> bool:
         return self.role == self.Role.MODERATOR
+
+    def fix_action_draft_after_deletion(self):
+        # This should only be called after self just got deleted
+        revision = self.action.latest_revision
+        if not revision:
+            return
+        assert isinstance(revision, Revision)
+        for acp_dict in revision.content.get('contact_persons', []):
+            if acp_dict.get('pk') == self.pk:
+                acp_dict['pk'] = None
+        revision.save()
 
     @classmethod
     def get_roles_editable_in_action_by(cls, action: Action, person: Person) -> Sequence[Role]:

--- a/actions/signals.py
+++ b/actions/signals.py
@@ -57,6 +57,28 @@ def invalidate_attribute_type_cache(sender, instance, **kwargs):
     Category.get_attribute_types_for_plan.cache_clear()
 
 
+@receiver(post_delete, sender=ActionContactPerson)
+def fix_deleted_contact_person_in_draft(sender, instance, **kwargs):
+    # When deleting an ActionContactPerson, drafts of that action may reference the deleted instance, which causes an
+    # error when trying to publish the action. Here we remove the reference from the revision content so that, when the
+    # draft is published, the ActionContactPerson is created anew instead of trying (and failing) to change the one that
+    # doesn't exist anymore.
+    # TODO: This may need to be done for other models as well; investigate.
+    assert isinstance(instance, ActionContactPerson)
+    instance.fix_action_draft_after_deletion()
+
+
+@receiver(post_delete, sender=ActionResponsibleParty)
+def fix_deleted_responsible_party_in_draft(sender, instance, **kwargs):
+    # When deleting an ActionResponsibleParty, drafts of that action may reference the deleted instance, which causes an
+    # error when trying to publish the action. Here we remove the reference from the revision content so that, when the
+    # draft is published, the ActionResponsibleParty is created anew instead of trying (and failing) to change the one
+    # that doesn't exist anymore.
+    # TODO: This may need to be done for other models as well; investigate.
+    assert isinstance(instance, ActionResponsibleParty)
+    instance.fix_action_draft_after_deletion()
+
+
 action_moderator_approval_task_submission_email_notifier = ActionModeratorApprovalTaskStateSubmissionEmailNotifier()
 action_moderator_cancel_task_submission_email_notifier = ActionModeratorCancelTaskStateSubmissionEmailNotifier()
 workflow_approval_email_notifier = WorkflowStateApprovalWithCommentEmailNotifier()


### PR DESCRIPTION
When deleting an instance related to a model, such as a contact person, drafts of that action may reference the deleted instance, which causes an error when trying to publish the action. This can happen when a plan admin uses the grid editor to change the published version of an action that has a draft.

Here we remove the reference from the revision content so that, when the draft is published, the related instance is created anew instead of trying (and failing) to change the one that doesn't exist anymore.

This is an ad-hoc fix. It should probably be improved. We might need to do something about models other than `ActionContactPerson` and `ActionResponsibleParty` too...