### PR TITLE
Fix assertion error when creating indicators

### DIFF
--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -321,7 +321,7 @@ class IndicatorForm(AplansAdminModelForm):
             if field_data is None:
                 continue
             cat_type = field.category_type
-            obj.set_categories(cat_type, field_data)
+            obj.set_categories(cat_type, field_data, plan=plan)
         return obj
 
     def _save_m2m(self):


### PR DESCRIPTION
The assertion in `Indicator.set_categories()` failed when creating an indicator.