### PR TITLE
Bring back plan settings to settings menu

### DIFF
--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -26,7 +26,7 @@ from wagtail.snippets.views.snippets import IndexView, SnippetViewSet
 from dal import autocomplete
 from django_filters import filters
 from wagtail_modeladmin.helpers import PermissionHelper
-from wagtail_modeladmin.options import modeladmin_register
+from wagtail_modeladmin.options import ModelAdminMenuItem, modeladmin_register
 
 from aplans.context_vars import ctx_instance, ctx_request
 
@@ -39,6 +39,7 @@ from admin_site.models import Client, ClientPlan
 from admin_site.permissions import PlanSpecificSingletonModelSuperuserPermissionPolicy
 from admin_site.viewsets import WatchEditView, WatchViewSet
 from admin_site.wagtail import (
+    ActivePlanEditView,
     AplansAdminModelForm,
     AplansCreateView,
     AplansEditView,
@@ -67,6 +68,7 @@ if typing.TYPE_CHECKING:
     from django.http import HttpRequest
     from wagtail.admin.menu import MenuItem
 
+    from aplans.types import WatchAdminRequest
 
 class PlanForm(AplansAdminModelForm):
     def clean_primary_language(self):
@@ -617,3 +619,60 @@ def org_autocomplete_label(self):
 
 Organization.autocomplete_search_field = 'distinct_name'
 Organization.autocomplete_label = org_autocomplete_label
+
+
+# FIXME: This is partly duplicated in content/admin.py.
+class ActivePlanModelAdminPermissionHelper(PermissionHelper):
+    def user_can_list(self, user):
+        return user.is_superuser
+    def user_can_create(self, user):
+        return user.is_superuser
+    def user_can_inspect_obj(self, user, obj):
+        return False
+    def user_can_delete_obj(self, user, obj):
+        return False
+    def user_can_edit_obj(self, user, obj):
+        return user.is_general_admin_for_plan(obj)
+
+# TODO: Reimplemented in admin_site/menu.py to make this work without
+# ModelAdmin. Use that when implementing new classes or migrating away from
+# ModelAdmin. Remove this class when ModelAdmin migration is finished.
+class PlanSpecificSingletonModelAdminMenuItem(ModelAdminMenuItem):
+    def get_one_to_one_field(self, plan):
+        # Implement in subclass
+        raise NotImplementedError()
+
+    def render_component(self, request):
+        # When clicking the menu item, use the edit view instead of the index view.
+        link_menu_item = super().render_component(request)
+        plan = request.user.get_active_admin_plan()
+        field = self.get_one_to_one_field(plan)
+        link_menu_item.url = self.model_admin.url_helper.get_action_url('edit', field.pk)
+        return link_menu_item
+
+    def is_shown(self, request: WatchAdminRequest):
+        # The overridden superclass method returns True iff user_can_list from the permission helper returns true. But
+        # this menu item is about editing a plan features instance, not listing.
+        user = request.user
+        if user.is_superuser:
+            return True
+        plan = request.user.get_active_admin_plan(required=False)
+        if plan is None:
+            return False
+        field = self.get_one_to_one_field(plan)
+        return self.model_admin.permission_helper.user_can_edit_obj(request.user, field)
+
+class ActivePlanMenuItem(PlanSpecificSingletonModelAdminMenuItem):
+    def get_one_to_one_field(self, plan):
+        return plan
+
+class ActivePlanAdmin(PlanAdmin):
+    edit_view_class = ActivePlanEditView
+    permission_helper_class = ActivePlanModelAdminPermissionHelper
+    menu_label = _('Plan')
+    menu_icon = 'kausal-plan'
+    add_to_settings_menu = True
+    def get_menu_item(self, order=None):
+        item = ActivePlanMenuItem(self, order or self.get_menu_order())
+        return item
+modeladmin_register(ActivePlanAdmin)

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -787,3 +787,28 @@ class InitializeFormWithUserMixin:
         kwargs = super().get_form_kwargs()
         kwargs.update({'user': self.request.user})
         return kwargs
+
+class ActivePlanEditView(SuccessUrlEditPageModelAdminMixin, AplansEditView):
+    @transaction.atomic()
+    def form_valid(self, form):
+        old_common_category_types = self.instance.common_category_types.all()
+        new_common_category_types = form.cleaned_data['common_category_types']
+        for added_cct in new_common_category_types.difference(old_common_category_types):
+            # Create category type corresponding to this common category type and link it to this plan
+            ct = added_cct.instantiate_for_plan(self.instance)
+            # Create categories for the common categories having that common category type
+            for common_category in added_cct.categories.all():
+                common_category.instantiate_for_category_type(ct)
+        for removed_cct in old_common_category_types.difference(new_common_category_types):
+            try:
+                self.instance.category_types.filter(common=removed_cct).delete()
+            except ProtectedError:
+                # Actually validation should have been done before this method is called, but it seems to work for now
+                error = _(
+                    'Could not remove common category type "%(removed_cct)" from the plan because categories '
+                    'with the corresponding category type exist.',
+                ) % {'removed_cct': removed_cct}
+                form.add_error('common_category_types', error)
+                messages.validation_error(self.request, self.get_error_message(), form)
+                return self.render_to_response(self.get_context_data(form=form))
+        return super().form_valid(form)


### PR DESCRIPTION
Brought back the Plan settings to the settings menu.

Tried to re-implement this first with snippets, but apparently models cant be registered twice as snippets.

So for now lets go with the original code, and we can think about a possible solution for migrating when needed.

https://app.asana.com/0/1206017643443542/1209138289442280