### PR TITLE
Fix placement of modeladmin action buttons for non-editable instances

### DIFF
--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -161,6 +161,10 @@ section[role="tabpanel"] .help-block {
   height: auto;
   float: inline-start;
 }
+/* Hack to fix https://app.asana.com/0/1206017643443542/1208668942052483 */
+.modeladmin .result-list ul {
+  width: 100%;
+}
 /* Need to repeat this here from modeladmin's CSS because our custom React-based components won't use that file */
 .modeladmin .listing tbody tr:hover ul.actions {
   visibility: visible;


### PR DESCRIPTION
In a modeladmin index view, when a row corresponding to an instance that is not editable is displayed, the action buttons appear in front of the text in the row. For editable rows, the action buttons appear underneath the text, which in this case is a link.

This CSS hack tries to fix this by setting the width of the action buttons `<ul>` element to 100 %.

Asana task, containing video illustrating the issue: https://app.asana.com/0/1206017643443542/1208668942052483