### PR TITLE
Fix model translation form fields for regional variant languages

### DIFF
--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Callable, Protocol, Sequence, cast
 from urllib.parse import urljoin
 
 import reversion
-from django import forms
 from django.conf import settings
 from django.contrib.admin.utils import quote
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -37,12 +36,13 @@ from wagtail_modeladmin.options import ModelAdmin
 from wagtail_modeladmin.views import CreateView, EditView, IndexView
 from wagtailautocomplete.edit_handlers import AutocompletePanel as WagtailAutocompletePanel
 
+from kausal_common.i18n.helpers import convert_language_code
+
 from aplans.context_vars import ctx_instance, ctx_request
 from aplans.utils import InstancesVisibleForMixin, PlanDefaultsModel, PlanRelatedModel, get_language_from_default_language_field
 
 from actions.models.plan import Plan
 from budget.models import DatasetSchema
-from pages.models import ActionListPage
 
 from .utils import FieldLabelRenderer, admin_req
 
@@ -82,7 +82,7 @@ def insert_model_translation_panels[M: Model](
             continue
 
         for lang_code in plan.other_languages:
-            tf = t_fields.get(lang_code)
+            tf = t_fields.get(convert_language_code(lang_code, "django"))
             if not tf:
                 continue
             out.append(type(p)(tf.name))


### PR DESCRIPTION
This fixes the model form translation fields to be shown also for languages like es-US, de-CH etc.

e.g in plan edit view:
![image](https://github.com/user-attachments/assets/0c93f0e2-5c50-441b-bd9a-7398b8c12466)

Translation works as should in UI:
![image](https://github.com/user-attachments/assets/635ba9f4-8203-41db-80aa-c31bb961da04)

Asana:
https://app.asana.com/0/1206017643443542/1209285235193134