### PR TITLE
Fix/report comparison block missing implementations

### DIFF
--- a/aplans/field_registry.py
+++ b/aplans/field_registry.py
@@ -16,6 +16,8 @@ from actions.blocks.column_block_base import ColumnBlockBase, DashboardColumnInt
 from .dynamic_blocks import generate_block_for_field
 
 if typing.TYPE_CHECKING:
+    from typing import Iterator
+
     from django.utils.functional import _StrPromise
     from wagtail import blocks
 
@@ -179,6 +181,9 @@ class ModelFieldRegistry[T: type[Model]]:
 
     def __getitem__(self, name: str) -> ModelFieldProperties:
         return self._registry[name]
+
+    def __iter__(self) -> Iterator[ModelFieldProperties]:
+        yield from self._registry.values()
 
     def register(self, props: ModelFieldProperties) -> None:
         if props.field_name in self._registry:

--- a/reports/graphene_types.py
+++ b/reports/graphene_types.py
@@ -1,13 +1,18 @@
+from __future__ import annotations
+
+import typing
 from dataclasses import dataclass
 from functools import cache
-from typing import Type
 
 import graphene
 
 from grapple.registry import registry as grapple_registry
-from grapple.types.streamfield import StreamFieldBlock
 
 from aplans.graphql_types import register_graphene_node
+
+if typing.TYPE_CHECKING:
+    from grapple.types.streamfield import StreamFieldBlock
+
 
 
 def get_report_field_block() -> StreamFieldBlock | None:
@@ -35,7 +40,8 @@ def generate_graphene_report_value_node_class(
         properties: GrapheneValueClassProperties,
 ) -> type[ActionReportValue]:
     """
-    Generates a class representing a report value, and registers it as graphene node
+    Generate a class representing a report value, and registers it as graphene node.
+
     The class would look something like this if created manually:
 
         @register_graphene_node
@@ -47,15 +53,15 @@ def generate_graphene_report_value_node_class(
     It implements the  ReportValueInterface graphene interface and also has a custom field
     with  a custom name for retrieving  the value of this report field.
     """
-    Meta_ = type('Meta', (), {'interfaces': (ReportValueInterface,)})
-    Class = type(
+    meta_ = type('Meta', (), {'interfaces': (ReportValueInterface,)})
+    class_ = type(
         properties.class_name,
         (ActionReportValue,),
         {
-            'Meta': Meta_,
+            'Meta': meta_,
             properties.value_field_name: graphene.Field(properties.value_field_type),
         },
     )
-    globals()[properties.class_name] = Class
-    register_graphene_node(Class)
-    return Class
+    globals()[properties.class_name] = class_
+    register_graphene_node(class_)
+    return class_

--- a/reports/report_formatters.py
+++ b/reports/report_formatters.py
@@ -111,7 +111,8 @@ class ActionSimpleFieldFormatter(ReportFieldFormatter):
     """A simple field is a field whose value is trivial to convert to a string with str."""
 
     def value_for_action_snapshot(self, block_value, snapshot) -> ValueType:
-        value = snapshot.action_version.field_dict[block_value.get('field_name')]
+        field_name = self.block.meta.field_name
+        value = snapshot.action_version.field_dict[field_name]
         return value
 
     def extract_action_values(

--- a/reports/schema.py
+++ b/reports/schema.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import graphene
 from graphql.error import GraphQLError
 
 from grapple.registry import registry as grapple_registry
+from loguru import logger
 
 from aplans.graphql_types import DjangoNode, register_django_node
 from aplans.utils import public_fields
@@ -39,11 +42,18 @@ class ReportNode(DjangoNode):
             snapshot = action.get_latest_snapshot(root)
         except ActionSnapshot.DoesNotExist:
             return None
-        return [
-            field.block.graphql_value_for_action_snapshot(field, snapshot)
-            for field in root.type.fields
-            if hasattr(field.block, 'graphql_value_for_action_snapshot')
-        ]
+        values = []
+        for field in root.type.fields:
+            if not hasattr(field.block, 'graphql_value_for_action_snapshot'):
+                logger.warning(f'No functional graphql_value_for_action_snapshot method for {type(field.block)}')
+                continue
+            try:
+                value = field.block.graphql_value_for_action_snapshot(field, snapshot)
+            except NotImplementedError:
+                logger.warning(f'No functional graphql_value_for_action_snapshot method for {type(field.block)}')
+            else:
+                values.append(value)
+        return values
 
 
 @register_django_node

--- a/reports/tests/factories.py
+++ b/reports/tests/factories.py
@@ -45,17 +45,26 @@ class ReportFieldBlockFactory(StreamBlockFactory):
     responsible_party = SubFactory(ActionResponsiblePartyReportFieldBlockFactory)
 
 
+def get_report_blocks():
+    from actions.action_fields import action_registry
+    blocks = {
+        'implementation_phase': SubFactory(ActionImplementationPhaseReportFieldBlockFactory),
+        'attribute': SubFactory(ActionAttributeTypeReportFieldBlockFactory),
+        'responsible_parties': SubFactory(ActionResponsiblePartyReportFieldBlockFactory),
+        'categories': SubFactory(ActionCategoryReportFieldBlockFactory),
+    }
+    for field in action_registry:
+        if field.has_report_block and field.field_name not in blocks:
+            blocks[field.field_name] = SubFactory(StructBlockFactory)
+    return blocks
+
+
 class ReportTypeFactory(DjangoModelFactory):
     class Meta:
         model = reports.models.ReportType
     plan = SubFactory(PlanFactory)
     name = Sequence(lambda i: f'Report type {i}')
-    fields = StreamFieldFactory({
-        'implementation_phase': SubFactory(ActionImplementationPhaseReportFieldBlockFactory),
-        'attribute': SubFactory(ActionAttributeTypeReportFieldBlockFactory),
-        'responsible_parties': SubFactory(ActionResponsiblePartyReportFieldBlockFactory),
-        'categories': SubFactory(ActionCategoryReportFieldBlockFactory),
-    })
+    fields = StreamFieldFactory(get_report_blocks())
 
 
 class ReportFactory(DjangoModelFactory):

--- a/reports/tests/fixtures.py
+++ b/reports/tests/fixtures.py
@@ -51,6 +51,22 @@ def report_type_with_all_attributes(
         fields__7__attribute__attribute_type=action_attribute_type__category_choice,
         fields__8__categories__category_type=category_type,
         fields__9__attribute__attribute_type=action_attribute_type__unordered_choice,
+        fields__10='description',
+        # TODO: enable the fields below one by one and fix
+        # the missing implementations for the ReportComparisonBlock
+        #
+        # fields__11='related_indicators',
+        # fields__12='tasks',
+        # fields__13='end_date',
+        # fields__14='start_date',
+        # fields__15='identifier',
+        # fields__16='name',
+        # fields__17='schedule_continuous',
+        # fields__18='start_date',
+        # fields__19='updated_at',
+        # fields__20='primary_org',
+        # fields__21='status',
+        # fields__22='manual_status_reason',
     )
 
 

--- a/reports/tests/test_report_fields.py
+++ b/reports/tests/test_report_fields.py
@@ -1,0 +1,25 @@
+import pytest
+
+from actions.action_fields import action_registry
+
+from .fixtures import *  # noqa: F403
+
+pytestmark = pytest.mark.django_db
+
+
+def test_graphql_value_for_action_snapshot(report_with_all_attributes, user):
+    """Test that calling graphql_value_for_action_snapshot does not crash."""
+    report_type_with_all_attributes = report_with_all_attributes.type
+    plan = report_type_with_all_attributes.plan
+    actions = []
+    for action in plan.actions.all():
+        actions.append(action)
+        action.mark_as_complete_for_report(report_with_all_attributes, user)
+    for field in report_type_with_all_attributes.fields:
+        field_name = field.block.name
+        report_block = action_registry.get_block('report', field_name)
+        for action in actions:
+            value = report_block.graphql_value_for_action_snapshot(  # type: ignore[attr-defined]
+                field, action.get_latest_snapshot(report_with_all_attributes)
+            )
+            assert value


### PR DESCRIPTION
The report comparison block crashed for description report fields. This is the first step towards ensuring it crashes for no fields.