### PR TITLE
Remove faulty process-specific cache for attribute types

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -784,7 +784,6 @@ class Action(
         return [at for at in attribute_types if at.instance.is_instance_visible_for(user, self.plan, self)]
 
     @classmethod
-    @lru_cache
     def get_attribute_types_for_plan(
         cls, plan: Plan, only_in_reporting_tab: bool = False, unless_in_reporting_tab: bool = False,
     ) -> Sequence[AttributeType[Any]]:

--- a/actions/models/category.py
+++ b/actions/models/category.py
@@ -679,7 +679,6 @@ class Category(ModelWithAttributes, CategoryBase, ClusterableModel, PlanRelatedM
         return self.type.levels.filter(order=level).first()
 
     @classmethod
-    @lru_cache
     def get_attribute_types_for_plan(cls, plan: Plan, only_in_reporting_tab=False, unless_in_reporting_tab=False):
         category_ct = ContentType.objects.get_for_model(cls)
         category_type_content_type = ContentType.objects.get_for_model(CategoryType)

--- a/actions/signals.py
+++ b/actions/signals.py
@@ -49,14 +49,6 @@ def log_email_send_status(sender, message, status, esp_name, **kwargs):
         )
 
 
-@receiver(post_save, sender=AttributeType)
-@receiver(post_delete, sender=AttributeType)
-def invalidate_attribute_type_cache(sender, instance, **kwargs):
-    # Attribute type cache may get stale when creating, editing or deleting attribute types
-    Action.get_attribute_types_for_plan.cache_clear()
-    Category.get_attribute_types_for_plan.cache_clear()
-
-
 @receiver(post_delete, sender=ActionContactPerson)
 def fix_deleted_contact_person_in_draft(sender, instance, **kwargs):
     # When deleting an ActionContactPerson, drafts of that action may reference the deleted instance, which causes an


### PR DESCRIPTION
These class method based caches were misbehaving and were only properly cleared for one process and not all of them.

The performance regressions caused by this were not significant at least where tested.