### PR TITLE
Fix issues that prevent copying Sunnydale

### DIFF
--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -984,6 +984,12 @@ class DraftAttributes:
                     new_id = clone_visitor.get_copy(models.AttributeType.objects.get(id=id)).id
                 except KeyError:
                     new_id = id
+                except models.AttributeType.DoesNotExist:
+                    logger.warning(
+                        f"Could not replace references in attribute '{value}' for AttributeType {id} because no "
+                        "AttributeType with this ID exists. This attribute will be lost in the copy."
+                    )
+                    continue
                 value.replace_references(clone_visitor)
                 new_values[format][new_id] = value
         self._values = new_values

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1413,7 +1413,8 @@ class ActionRelatedModelTransModelMixin:
                 to_delete.add(field_name)
         for f in to_delete:
             del data[f]
-        del data['action']
+        if 'action' in data:
+            del data['action']
         return model_from_serializable_data(cls, data, check_fks=check_fks, strict_fks=strict_fks)
 
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -42,6 +42,7 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     'action_implementation_phases': {},
     'action_schedules': {},
     'action_statuses': {},
+    'features': {},
     'actions': {
         'action_category_through': {},
         'action_monitoring_quality_points_through': {},
@@ -63,7 +64,6 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     },
     'clients': {},
     # 'domains': {},  # deliberately don't copy domains because hostname + base path should be unique
-    'features': {},
     'general_admins_ordered': {},
     'general_content': {},
     'impact_groups': {},


### PR DESCRIPTION
Issue 1: In `ActionIdentifierSearchMixin`, the field `features` of the copy of the plan is accessed, but the plan's features have not been copied at that point yet, causing an error. I fixed this by copying the features before the actions.

Issue 2: In `DraftAttributes.replace_references()`, we try to get an `AttributeType` by the ID that's stored in the revision. This causes an error because we have some garbage in our database: Some drafts in Sunnydale reference attribute types that seem to have been deleted since the draft has been created. I fixed this by emitting a warning when this is the case and skipping the attribute. At the moment, this concerns three attributes, all referring to the missing `AttributeType` 358.

Issue 3: `ActionRelatedModelTransModelMixin.from_serializable_data()` crashes when getting called for several `ActionTask` instances because it tries to delete `data['action']`, but `data` has no such key. I fixed this by deleting this key only if it exists. I'm not sure why this is an issue, why it is perhaps only sometimes an issue, and if my fix might have unintended consequences.

Finally, when I tried to locally reproduce the issues that we observed in production, I had to fix the collection tree yet again by running `Collection.fix_tree(fix_paths=True)`. I believe we fixed the cause of this already, at least I hope we did. I am surprised, however, that this is necessary on my machine but it did not seem to be an issue in production.