### PR TITLE
Don't use client_url for only_other_plans search

### DIFF
--- a/search/schema.py
+++ b/search/schema.py
@@ -40,6 +40,12 @@ class SearchHit(graphene.ObjectType):
         object = root.get('object')
         page = root.get('page')
         plan = root['plan']
+
+        # Check if this is a search result from other plans, we want to use the site_url for these.
+        only_other_plans = getattr(info.context, 'only_other_plans', False)
+        if only_other_plans:
+            client_url = None
+
         if object is not None:
             return object.get_view_url(plan=plan, client_url=client_url)
         elif page is not None:
@@ -161,4 +167,8 @@ class Query:
 
         all_results = list(chain(*results))
         all_results.sort(key=lambda x: x.relevance, reverse=True)
+
+        # Store only_other_plans in the context for use in resolve_url
+        info.context.only_other_plans = only_other_plans
+
         return dict(hits=all_results)


### PR DESCRIPTION
Don't use `client_url `for `only_other_plans` search, so that search hits contain the prod site url.

[P-1538](https://app.asana.com/0/1206017643443542/1209893130530964)