### PR TITLE
Remove redundant setting

### DIFF
--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -717,7 +717,6 @@ IMAGE_CROPPING_JQUERY_URL: str | None = None
 THUMBNAIL_HIGH_RESOLUTION = True
 
 WAGTAIL_SLIM_SIDEBAR = False
-WAGTAIL_WORKFLOW_ENABLED = False
 WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False  # prevents adding superusers to workflow notification recipients
 
 GRAPPLE = {


### PR DESCRIPTION
The same setting is defined again later on in the settings file with the opposite value. Remove the confusing setting that is overridden later on.