### PR TITLE
Fix ordering categories through spreadsheets

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -35,6 +35,7 @@ from aplans.utils import generate_identifier, public_fields, register_view_helpe
 from actions.models.action import ActionContactPerson, ActionImplementationPhase
 from actions.models.attributes import AttributeType, ModelWithAttributes
 from orgs.models import Organization
+from pages.apps import post_reorder_categories
 from people.models import Person
 from users.models import User
 
@@ -1337,6 +1338,11 @@ class CategoryViewSet(ViewSetWithPlanContext, HandleProtectedErrorMixin, BulkMod
             return Category.objects.none()
         category_type_pk = self.kwargs['category_type_pk']
         return Category.objects.filter(type=category_type_pk).select_related("type")
+
+    def bulk_update(self, request, *args, **kwargs):
+        result = super().bulk_update(request, *args, **kwargs)
+        post_reorder_categories(sender=None, queryset=self.get_queryset())
+        return result
 
 
 category_type_router.register('categories', CategoryViewSet, basename='category')

--- a/actions/models/category.py
+++ b/actions/models/category.py
@@ -549,14 +549,17 @@ class Category(ModelWithAttributes, CategoryBase, ClusterableModel, PlanRelatedM
                 parent.add_child(instance=page)
             else:
                 current_parent = page.get_parent()
-                update_page_parent = current_parent is None or current_parent.specific != parent
+                update_page_parent = current_parent is None or current_parent.specific != parent.specific
                 prev_cat = Category.objects.filter(type=self.type, parent=self.parent, order__lt=self.order).last()
                 if prev_cat is None:
                     prev_cat_page = None
                     update_page_sibling = page.get_prev_sibling() is not None
                 else:
                     prev_cat_page = prev_cat.category_pages.filter(locale=parent.locale).first()
-                    update_page_sibling = page.get_prev_sibling() != prev_cat_page
+                    prev_sibling = page.get_prev_sibling()
+                    if prev_sibling is not None:
+                        prev_sibling = prev_sibling.specific
+                    update_page_sibling = prev_sibling != prev_cat_page
                 if update_page_parent or update_page_sibling:
                     if prev_cat_page:
                         page.move(prev_cat_page, 'right')
@@ -566,11 +569,20 @@ class Category(ModelWithAttributes, CategoryBase, ClusterableModel, PlanRelatedM
                     # treebeard
                     refreshed_page: CategoryPage | CategoryTypePage = Page.objects.get(pk=page.pk).specific  # pyright: ignore
                     page = refreshed_page
-                page.title = self.name_i18n
-                page.draft_title = self.name_i18n
-                page.show_in_menus = is_root
-                page.show_in_footer = is_root
-                page.save()
+
+                is_changed = (
+                    page.title != self.name_i18n or
+                    page.draft_title != self.name_i18n or
+                    page.show_in_menus != is_root or
+                    page.show_in_footer != is_root
+                )
+                if is_changed:
+                    page.title = self.name_i18n
+                    page.draft_title = self.name_i18n
+                    page.show_in_menus = is_root
+                    page.show_in_footer = is_root
+                    page.save()
+
         return page
 
     @transaction.atomic()


### PR DESCRIPTION
When categories were ordered using the spreadsheet functionality, the
corresponding category pages would not follow the ordering. Use the
pre-existing method to synchronize the pages as well.

Also make some fixes to the ordering logic, as by comparing Pages to
CategoryPages the method did not recognise some pages to be identical
and moved pages needlessly. Use Page.specific to be sure to compare
CategoryPages to CategoryPages.

Additionally, avoid some SQL queries by only saving the page if the
relevant attributes have been changed.