### PR TITLE
GraphQL field and annotation for action.has_dependency_relationships

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -15,7 +15,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.core.validators import URLValidator
 from django.db import models
-from django.db.models import Count, IntegerField, Max, Q, QuerySet
+from django.db.models import Count, Exists, IntegerField, Max, OuterRef, Q, QuerySet
 from django.db.models.functions import Cast
 from django.db.models.options import Options
 from django.urls import reverse
@@ -55,6 +55,7 @@ from users.models import User
 from ..action_status_summary import ActionStatusSummaryIdentifier, ActionTimelinessIdentifier, SummaryContext
 from ..attributes import AttributeFieldPanel, AttributeType
 from ..monitoring_quality import determine_monitoring_quality
+from .action_deps import ActionDependencyRelationship
 from .attributes import AttributeType as AttributeTypeModel, ModelWithAttributes
 from .features import PlanFeatures
 
@@ -71,7 +72,6 @@ if typing.TYPE_CHECKING:
     from aplans.types import UserOrAnon
 
     from actions.attributes import DraftAttributes
-    from actions.models.action_deps import ActionDependencyRelationship
     from actions.models.category import Category
     from people.models import Person
 
@@ -149,6 +149,10 @@ class ActionQuerySet(SearchableQuerySetMixin, MultilingualQuerySet['Action']):
                     related_indicators__indicator__in=Indicator.objects.qs.available_for_plan(plan).visible_for_public().filter(
                         goals__isnull=False))),
                 )
+
+    def annotate_has_dependency_relationships(self) -> Self:
+        dep_qs = ActionDependencyRelationship.objects.filter(Q(preceding=OuterRef('pk')) | Q(dependent=OuterRef('pk')))
+        return self.annotate(has_dependencies=Exists(dep_qs))
 
 if TYPE_CHECKING:
     class ActionManager(MLModelManager['Action', ActionQuerySet]): ...

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1067,6 +1067,7 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode):
     status_summary = graphene.Field('actions.schema.ActionStatusSummaryNode', required=True)
     timeliness = graphene.Field('actions.schema.ActionTimelinessNode', required=True)
     color = graphene.String(required=False)
+    has_dependency_relationships = graphene.Boolean()
     all_dependency_relationships = graphene.List(
         graphene.NonNull('actions.schema.ActionDependencyRelationshipNode'), required=True,
     )
@@ -1232,6 +1233,21 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode):
         return root.get_timeliness()
 
     @staticmethod
+    def resolve_has_dependency_relationships(root: Action, info: GQLInfo) -> bool:
+        cache = info.context.watch_cache.for_plan_id(root.plan_id)
+        if not cache.plan_has_action_dependency_roles:
+            return False
+        if not hasattr(root, 'has_dependencies'):
+            message = (
+                "[Performance issue] Calling action.resolve_has_dependency_relationships "
+                "on action which has not been annotated in queryset"
+             )
+            logger.warning(message)
+            _ = sentry_sdk.capture_message(message)
+            return root.dependent_relationships.exists() or root.preceding_relationships.exists()
+        return root.has_dependencies
+
+    @staticmethod
     def resolve_all_dependency_relationships(root: Action, info: GQLInfo):
         cache = info.context.watch_cache.for_plan_id(root.plan_id)
         if not cache.plan_has_action_dependency_roles:
@@ -1378,6 +1394,7 @@ def plans_actions_queryset(plans, category, first, order_by, user, restrict_to_p
     qs = order_queryset(qs, ActionNode, order_by)
     if not order_by:
         qs = qs.order_by('plan', 'order')
+    qs = qs.annotate_has_dependency_relationships()
     if first is not None:
         qs = qs[0:first]
     return qs

--- a/actions/tests/factories.py
+++ b/actions/tests/factories.py
@@ -51,6 +51,7 @@ from actions.models import (
     PlanFeatures,
     Scenario,
 )
+from actions.models.action_deps import ActionDependencyRelationship, ActionDependencyRole
 from images.tests.factories import AplansImageFactory
 from orgs.tests.factories import OrganizationFactory
 from people.tests.factories import PersonFactory
@@ -96,6 +97,12 @@ class PlanFeaturesFactory(ModelFactory[PlanFeatures]):
 class PlanDomainFactory(ModelFactory[PlanDomain]):
     plan = SubFactory(PlanFactory, _domain=None)
     hostname = Sequence(lambda i: f'plandomain{i}.example.org')
+
+
+class ActionDependencyRoleFactory(ModelFactory[ActionDependencyRole]):
+    plan = SubFactory(PlanFactory)
+    name = Sequence(lambda i: f"Action dependency role {i}")
+    order = Sequence(lambda i: i)
 
 
 class ActionStatusFactory(ModelFactory[ActionStatus]):
@@ -376,6 +383,11 @@ class ActionContactFactory(ModelFactory[ActionContactPerson]):
     action = SubFactory(ActionFactory)
     person = SubFactory(PersonFactory, organization=SelfAttribute('..action.plan.organization'))
     role = ActionContactPerson.Role.MODERATOR
+
+
+class ActionDependencyRelationshipFactory(ModelFactory[ActionDependencyRelationship]):
+    preceding = SubFactory(ActionFactory)
+    dependent = SubFactory(ActionFactory, plan=SelfAttribute('..preceding.plan'))
 
 
 class ActionListBlockFactory(StructBlockFactory):

--- a/actions/tests/test_graphql_planactions.py
+++ b/actions/tests/test_graphql_planactions.py
@@ -120,3 +120,110 @@ def test_planactions(graphql_client_query_data):
         }],
     }
     assert data == expected
+
+
+def test_action_has_dependency_relationships(
+    graphql_client_query_data, plan, action_factory, action_dependency_role_factory, action_dependency_relationship_factory
+):
+    """Test the has_dependency_relationships field in the planActions GraphQL query."""
+    action_dependency_role_factory(plan=plan)
+
+    action1 = action_factory(plan=plan)
+    action2 = action_factory(plan=plan)
+    action3 = action_factory(plan=plan)
+
+    action_dependency_relationship_factory(preceding=action1, dependent=action2)
+
+    data = graphql_client_query_data(
+        """
+        query($plan: ID!) {
+          planActions(plan: $plan) {
+            id
+            identifier
+            hasDependencyRelationships
+          }
+        }
+        """,
+        variables=dict(plan=plan.identifier),
+    )
+
+    actions_data = {action['identifier']: action for action in data['planActions']}
+    assert actions_data[action1.identifier]['hasDependencyRelationships'] is True
+    assert actions_data[action2.identifier]['hasDependencyRelationships'] is True
+    assert actions_data[action3.identifier]['hasDependencyRelationships'] is False
+
+
+def test_action_has_dependency_relationships_no_roles(
+    graphql_client_query_data, plan_factory, action_factory
+):
+    """Test that has_dependency_relationships returns False when plan has no dependency roles."""
+    # Setup: Create a plan without any dependency roles
+    plan_without_roles = plan_factory()
+
+    # Create actions in the plan
+    action1 = action_factory(plan=plan_without_roles)
+    action2 = action_factory(plan=plan_without_roles)
+    action3 = action_factory(plan=plan_without_roles)
+
+    # Query for actions with has_dependency_relationships field
+    data = graphql_client_query_data(
+        """
+        query($plan: ID!) {
+          planActions(plan: $plan) {
+            id
+            identifier
+            hasDependencyRelationships
+          }
+        }
+        """,
+        variables=dict(plan=plan_without_roles.identifier),
+    )
+
+    # Extract the results for easier assertion
+    actions_data = {action['identifier']: action for action in data['planActions']}
+
+    # Assertions - all actions should have hasDependencyRelationships=False
+    # since the plan has no dependency roles configured
+    assert actions_data[action1.identifier]['hasDependencyRelationships'] is False
+    assert actions_data[action2.identifier]['hasDependencyRelationships'] is False
+    assert actions_data[action3.identifier]['hasDependencyRelationships'] is False
+
+
+def test_action_has_dependency_relationships_via_plan(
+    graphql_client_query_data, plan, action_factory, action_dependency_role_factory, action_dependency_relationship_factory
+):
+    """Test has_dependency_relationships via plan { actions } GraphQL query."""
+    # Setup: Create plan with action dependency roles to enable dependency relationships
+    action_dependency_role_factory(plan=plan)
+
+    # Create actions
+    action1 = action_factory(plan=plan)
+    action2 = action_factory(plan=plan)
+    action3 = action_factory(plan=plan)
+
+    # Create a dependency relationship between action1 and action2
+    action_dependency_relationship_factory(preceding=action1, dependent=action2)
+
+    # Query for actions with has_dependency_relationships field using plan.actions
+    data = graphql_client_query_data(
+        """
+        query($plan: ID!) {
+          plan(id: $plan) {
+            actions {
+              id
+              identifier
+              hasDependencyRelationships
+            }
+          }
+        }
+        """,
+        variables=dict(plan=plan.identifier),
+    )
+
+    # Extract the results for easier assertion
+    actions_data = {action['identifier']: action for action in data['plan']['actions']}
+
+    # Assertions - same as before, but queried through plan.actions
+    assert actions_data[action1.identifier]['hasDependencyRelationships'] is True
+    assert actions_data[action2.identifier]['hasDependencyRelationships'] is True
+    assert actions_data[action3.identifier]['hasDependencyRelationships'] is False

--- a/conftest.py
+++ b/conftest.py
@@ -55,6 +55,8 @@ class JSONAPIClient(APIClient):
 
 
 register(actions_factories.ActionContactFactory, 'action_contact')
+register(actions_factories.ActionDependencyRoleFactory)
+register(actions_factories.ActionDependencyRelationshipFactory)
 register(actions_factories.ActionFactory)
 register(actions_factories.ActionImpactFactory)
 register(actions_factories.ActionImplementationPhaseFactory)


### PR DESCRIPTION
Used in big listings to prevent actually querying the dependency details for each action.