### PR TITLE
Add Tableau to embed whitelist and allow empty provider name

### DIFF
--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -610,6 +610,13 @@ WAGTAILEMBEDS_FINDERS = [
         'domain_whitelist': ('sharepoint.com', ),
         'title': 'Document',
     },
+    {
+        'class': f'{PROJECT_NAME}.wagtail_embed_finders.GenericFinder',
+        # If we leave the provider out, the "default" provider will be used
+        'domain_whitelist': ('public.tableau.com', ),
+        'title': 'Chart',
+    }
+
 ]
 WAGTAIL_SITE_NAME = 'Kausal Watch'
 WAGTAIL_ENABLE_UPDATE_CHECK = False

--- a/aplans/wagtail_embed_finders.py
+++ b/aplans/wagtail_embed_finders.py
@@ -3,6 +3,9 @@ import re
 from wagtail.embeds.finders.base import EmbedFinder
 
 
+DEFAULT_PROVIDER_NAME = 'default'
+
+
 def get_thumbnail_url(provider, url):
     if provider == 'Plotly Chart Studio':
         return url.replace('.embed', '.png')
@@ -12,7 +15,7 @@ def get_thumbnail_url(provider, url):
 class GenericFinder(EmbedFinder):
 
     def __init__(self, **options):
-        self.provider = options['provider']
+        self.provider = options.get('provider', DEFAULT_PROVIDER_NAME)
         self.domain_whitelist = options['domain_whitelist']
         self.title = options['title']
         self.acceptable_url_re = re.compile(


### PR DESCRIPTION
Make specifying providers optional, so we can reuse a "default" style in the embed css styles when no provider-specific customization is needed.