### PR TITLE
Don't set non-nullable brand_dark_colour to None in initialize_notification_templates. 

### DIFF
--- a/notifications/management/commands/initialize_notifications.py
+++ b/notifications/management/commands/initialize_notifications.py
@@ -31,7 +31,6 @@ def initialize_notification_templates(
         'from_name': plan.name,
         'from_address': settings.DEFAULT_FROM_EMAIL,
         'reply_to': None,
-        'brand_dark_color': None,
         'logo_id': None,
         'font_family': None,
         'font_css_url': None,


### PR DESCRIPTION
Fixes this: https://sentry.kausal.tech/organizations/kausal/issues/10927/?referrer=slack&notification_uuid=70b80f0b-a648-46d4-ae8d-71354ef57229&alert_rule_id=3&alert_type=issue