### PR TITLE
Fix capitalization of model field block labels

### DIFF
--- a/aplans/field_registry.py
+++ b/aplans/field_registry.py
@@ -4,10 +4,12 @@ import importlib
 import re
 import textwrap
 import typing
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from django.db.models import Model
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import Field, Model
 
 from aplans.utils import underscore_to_camelcase
 
@@ -114,10 +116,15 @@ class ModelFieldProperties:
             return _import(cfg.block_class)
         return None
 
-    def get_block_class_kwargs(self, block_context: BlockContext) -> dict[str, Any]:
+    def get_block_class_kwargs(self, block_context: BlockContext, model: type[Model]) -> dict[str, Any]:
         result: dict[str, Any] = {'params': {}}
         if self.custom_label:
             result['params']['label'] = self.custom_label
+        else:
+            with suppress(FieldDoesNotExist):
+                field = model._meta.get_field(self.field_name)
+                if isinstance(field, Field):
+                    result['params']['label'] = field.verbose_name
 
         if block_context == 'dashboard':
             class_name = self.dashboard_column_block_class_name
@@ -204,7 +211,7 @@ class ModelFieldRegistry[T: type[Model]]:
         if cls_ is not None:
             return cls_
 
-        kwargs = props.get_block_class_kwargs(block_context)
+        kwargs = props.get_block_class_kwargs(block_context, self.model)
         value = None
         if block_context != 'dashboard':
             value = self._common_block_class_cache.get(field_name)


### PR DESCRIPTION
In many languages, upper-case letters may occur in places other than the beginning of a sentence. For a Wagtail streamfield block, unless an explicit label is given, Wagtail's standard behavior is to take the implicit label (given by, e.g., the translated name of a model field) and then apply `capfirst` to it. This transforms some upper-case letters to lower case.

We fix this for the blocks we generate for model fields by always supplying an explicit label.

## Example

### Before:

<img width="861" height="735" alt="Screenshot From 2025-07-24 13-29-23" src="https://github.com/user-attachments/assets/22e565ac-d90c-461b-8bec-6f1eb9775e9a" />

### After:

<img width="861" height="735" alt="Screenshot From 2025-07-24 13-29-39" src="https://github.com/user-attachments/assets/44db496e-ba51-476d-b2e0-4261e24ec8b4" />

## Caveats

Note that now it's important that the capitalization in the translated verbose name is as it should appear here. In the example given in the second screenshot, as indicated with greenish yellow, this is currently perhaps not ideal.

Personally I would probably start these German strings with upper-case letters as it's the beginning of the label -- but since the labels are not sentences and the respective words are not nouns, it's at least not incorrect. But perhaps we could update these translations at some point.

Perhaps it would be good to set up a policy to have the translations for verbose names always start with a capital letter (or, more generally, since this may not be correct for all languages, have the translations in such a way that they can stand alone as a label).