### PR TITLE
Remove customized name for Admin UI "Actions" menu item

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -630,23 +630,6 @@ class ActionCreateView(InitializeFormWithInitialPlanMixin, AplansCreateView):
                 self.instance.primary_org = default_org
 
 
-class ActionIndexView(IndexView):
-    request: WatchAdminRequest
-
-    def get_page_title(self):
-        plan = self.request.user.get_active_admin_plan()
-        return plan.general_content.get_action_term_display_plural()
-
-
-class ActionMenuItem(ModelAdminMenuItem):
-    def render_component(self, request):
-        link_menu_item = super().render_component(request)
-        plan = request.user.get_active_admin_plan()
-        # Change label to the configured term for "Action"
-        link_menu_item.label = plan.general_content.get_action_term_display_plural()
-        return link_menu_item
-
-
 class ActionButtonHelper(AplansButtonHelper):
     mark_as_complete_button_classnames: list[str] = []
 
@@ -736,7 +719,6 @@ class ActionEditView(InitializeFormWithInitialPlanMixin, SnippetsEditViewCompati
 class ActionAdmin(AplansModelAdmin):
     model = Action
     create_view_class = ActionCreateView
-    index_view_class = ActionIndexView
     edit_view_class = ActionEditView
     menu_icon = 'kausal-action'
     menu_order = 10
@@ -1080,9 +1062,6 @@ class ActionAdmin(AplansModelAdmin):
         qs = qs.filter(plan=plan)
         qs = qs.select_related('plan').prefetch_related('categories')
         return qs
-
-    def get_menu_item(self, order=None):
-        return ActionMenuItem(self, order or self.get_menu_order())
 
     def mark_action_as_complete_view(self, request, action_pk, report_pk):
         return MarkActionAsCompleteView.as_view(

--- a/e2e-tests/tests/actions.spec.ts
+++ b/e2e-tests/tests/actions.spec.ts
@@ -14,3 +14,20 @@ test.describe('Test admin', () => {
     await expect(page.getByLabel('Filter actions')).toBeVisible();
   });
 })
+
+
+test.describe('Test admin after customizing Action term', () => {
+  const baseUrl = 'http://localhost:8000';
+
+  test.beforeAll(async () => {
+  })
+  test('list actions', async ({ page }) => {
+    await page.goto(`${baseUrl}/admin/`);
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+    await page.getByRole('link', { name: 'Site settings', exact: true }).click();
+    await page.locator('#id_action_term').selectOption('strategy');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.getByRole('link', { name: 'Actions', exact: true }).click();
+    await expect(page.getByLabel('Filter actions')).toBeVisible();
+  });
+})


### PR DESCRIPTION
The reasoning is that since the term "Action" is so pervasive to Watch and is used in many locations, and since it's too large a task to make all of those locations customizable, we prefer to be consistent and just use the built-in term in the Admin UI as a general rule. The customizations only apply to the Public UI.

Also, remove the ActionIndexView for the same reason (but notice it wasn't actually used anyway since the extended version from extensions is in use instead).

## Description
Remove the plan-specific custom term chosen for "Action" from the Admin UI main menu.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue

https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210888916813081/comment/1211391919079794?focus=true

https://kausaltech.slack.com/archives/C01AZ2V3656/p1758272932716589?thread_ts=1758205458.277679&cid=C01AZ2V3656



## Requirements, dependencies and related PRs
N/A
------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated) **cannot be unit tested**
- [X] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
N/A

### Dependencies
N/A
-----

## Screenshots/Videos (if applicable)
Before
<img width="698" height="313" alt="Screenshot from 2025-09-19 14-29-05" src="https://github.com/user-attachments/assets/8eb13e81-bc15-4f93-9ddf-f4b0dbbb83d6" />

After
<img width="698" height="313" alt="Screenshot from 2025-09-19 14-29-22" src="https://github.com/user-attachments/assets/e06ff47d-bb43-49c1-b554-cfbb52399de8" />


## Additional Notes
None