### PR TITLE
Update document and image references in rich text fields

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,7 @@ from actions.models.attributes import AttributeType
 from actions.tests import factories as actions_factories
 from admin_site.tests import factories as admin_site_factories
 from content.tests import factories as content_factories
+from documents.tests import factories as documents_factories
 from images.tests import factories as images_factories
 from indicators.tests import factories as indicators_factories
 from notifications.tests import factories as notifications_factories
@@ -101,6 +102,7 @@ register(actions_factories.PlanDomainFactory)
 # register(admin_site_factories.ClientPlanFactory)
 register(admin_site_factories.BuiltInFieldCustomizationFactory)
 register(content_factories.SiteGeneralContentFactory)
+register(documents_factories.AplansDocumentFactory)
 register(images_factories.AplansImageFactory)
 register(indicators_factories.CommonIndicatorFactory)
 register(indicators_factories.CommonIndicatorNormalizatorFactory)

--- a/copying/main.py
+++ b/copying/main.py
@@ -717,7 +717,7 @@ def get_cluster_related_objects(instance: Model) -> Generator[tuple[str, Model]]
             assert isinstance(child_relation.remote_field, ParentalKey)
             field_name = child_relation.get_accessor_name()
             manager = getattr(instance, field_name)
-            for x in manager.all():
+            for x in manager.get_object_list():
                 yield field_name, x
 
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -16,7 +16,7 @@ from django.core.files.base import ContentFile
 from django.db.models import Field, ForeignKey, Manager, ManyToOneRel, Model, Q, signals
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
-from wagtail.fields import StreamField
+from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Page, Revision, Site
 from wagtail.models.media import Collection
 from wagtail.models.reference_index import ReferenceIndex
@@ -30,7 +30,13 @@ from actions.models.category import Category, CategoryType
 from actions.models.plan import Plan
 from actions.signals import create_notification_settings, create_plan_features
 from content.apps import create_site_general_content
-from copying.utils import get_foreign_keys, get_generic_foreign_keys, temp_disconnect_signal, update_streamfield_block
+from copying.utils import (
+    get_foreign_keys,
+    get_generic_foreign_keys,
+    temp_disconnect_signal,
+    update_rich_text_reference,
+    update_streamfield_block,
+)
 from documentation.models import DocumentationRootPage
 from documents.models import AplansDocument
 from images.models import AplansImage
@@ -545,6 +551,18 @@ class UpdateReferencesVisitor(AbstractVisitor):
             # Foreign keys should have been already taken care of in a previous call to `self.update_foreign_keys()`
             assert getattr(from_object, source_field.name) is copy
             return False
+
+        if isinstance(source_field, RichTextField):
+            field_name, *content_path_rest = content_path.split('.')
+            assert field_name == source_field.name
+            assert content_path_rest == ['']
+            update_rich_text_reference(
+                instance=from_object,
+                field_name=field_name,
+                old_referenced_object=to_object,
+                new_referenced_object=self.clone_visitor.get_copy(to_object),
+            )
+            return True
 
         raise TypeError("Unexpected source field type")
 

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -6,6 +6,10 @@ import pytest
 
 from actions.tests.factories import ActionContactFactory, WorkflowFactory
 from copying.main import copy_plan
+from documents.models import AplansDocument
+from documents.tests.factories import AplansDocumentFactory
+from images.models import AplansImage
+from images.tests.factories import AplansImageFactory
 from pages.tests.factories import CategoryTypePageLevelLayoutFactory
 
 pytestmark = pytest.mark.django_db
@@ -15,6 +19,18 @@ def get_page_copy(page, plan_copy):
     page_copy = plan_copy.root_page.get_children().get(url_path=page.url_path).specific
     assert type(page_copy) is type(page)
     return page_copy
+
+
+def html_with_references(doc1, doc2, image1, image2):
+    """Return HTML with references as Wagtail would produce it in a rich-text field."""
+    return f"""
+<p data-block-key="foo">
+<a linktype="document" id="{doc1.pk}">doc1</a>
+<a linktype="document" id="{doc2.pk}">doc2</a>
+<embed embedtype="image" format="fullwidth-zoomable" id="{image1.pk}" alt="image1"/>
+<embed embedtype="image" format="fullwidth-zoomable" id="{image2.pk}" alt="image2"/>
+</p>'
+""".replace('\n', '')
 
 
 def test_publish_copied_action_does_not_steal_contact_persons(plan_with_pages, action, user):
@@ -96,3 +112,19 @@ def test_update_references_in_page_draft(plan_with_pages, category_type_page, at
     layout_copy = draft_copy.level_layouts.get()
     block_copy_attribute_type = layout_copy.layout_main_top[0].value['attribute_type']
     assert block_copy_attribute_type.scope == category_type_copy
+
+
+def test_rich_text_field_references(plan_with_pages, action):
+    doc1 = AplansDocumentFactory(collection=plan_with_pages.root_collection, title='doc1')
+    doc2 = AplansDocumentFactory(collection=plan_with_pages.root_collection, title='doc2')
+    image1 = AplansImageFactory(collection=plan_with_pages.root_collection, title='image1')
+    image2 = AplansImageFactory(collection=plan_with_pages.root_collection, title='image2')
+    action.description = html_with_references(doc1, doc2, image1, image2)
+    action.save(update_fields=['description'])
+    plan_copy = copy_plan(plan_with_pages)
+    doc1_copy = AplansDocument.objects.get(collection=plan_copy.root_collection, title=doc1.title)
+    doc2_copy = AplansDocument.objects.get(collection=plan_copy.root_collection, title=doc2.title)
+    image1_copy = AplansImage.objects.get(collection=plan_copy.root_collection, title=image1.title)
+    image2_copy = AplansImage.objects.get(collection=plan_copy.root_collection, title=image2.title)
+    action_copy = plan_copy.actions.get()
+    assert action_copy.description == html_with_references(doc1_copy, doc2_copy, image1_copy, image2_copy)

--- a/copying/utils.py
+++ b/copying/utils.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import re
 import typing
 from typing import Any
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from wagtail.blocks import StreamValue
+
+from documents.models import AplansDocument
+from images.models import AplansImage
 
 if typing.TYPE_CHECKING:
     from collections.abc import Generator
@@ -94,3 +98,30 @@ def update_streamfield_block(
     # once the BoundBlock representation has been accessed, any changes to fields within raw data will not
     # propagate back to the BoundBlock
     setattr(instance, field_name, StreamValue(stream_value.stream_block, stream_value.raw_data, is_lazy=True))
+
+
+def update_rich_text_reference(
+    instance: Model,
+    field_name: str,
+    old_referenced_object: Model,
+    new_referenced_object: Model,
+) -> None:
+    """Update a reference to an image or document in a given rich text field."""
+    assert type(old_referenced_object) is type(new_referenced_object)
+    if isinstance(old_referenced_object, AplansDocument):
+        pattern = r'<a\s+[^>]*linktype="document"[^>]*>'
+    elif isinstance(old_referenced_object, AplansImage):
+        pattern = r'<embed\s+[^>]*embedtype="image"[^>]*/>'
+    else:
+        raise TypeError(f"old_referenced_object has unexpected type {type(old_referenced_object)}")
+
+    old_id = old_referenced_object.pk
+    new_id = new_referenced_object.pk
+
+    def replace_id_in_html_tag(match: re.Match) -> str:
+        return re.sub(rf'\bid="{old_id}"', f'id="{new_id}"', match.group(0))
+
+    old_value: str = getattr(instance, field_name)
+    new_value = re.sub(pattern, replace_id_in_html_tag, old_value)
+    assert new_value != old_value
+    setattr(instance, field_name, new_value)

--- a/documents/tests/factories.py
+++ b/documents/tests/factories.py
@@ -1,0 +1,6 @@
+from wagtail.test.utils.wagtail_factories import DocumentFactory
+
+
+class AplansDocumentFactory(DocumentFactory):
+    class Meta:
+        model = 'documents.AplansDocument'


### PR DESCRIPTION
Enables copying of plans where some rich text field references an image or document.

Fixes this issue: https://kausaltech.slack.com/archives/C05RGQS52LA/p1758696334218529