### PR TITLE
Fix permission checking in REST API for indicator values

### DIFF
--- a/indicators/api.py
+++ b/indicators/api.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
-from rest_framework import permissions, serializers, status, viewsets
+from rest_framework import exceptions, permissions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -20,6 +20,7 @@ from kausal_common.users import user_or_none
 from actions.api import plan_router
 from actions.models import Plan
 from people.models import Person
+from users.models import User
 
 from .models import (
     ActionIndicator,
@@ -518,18 +519,39 @@ class IndicatorGoalSerializer(serializers.ModelSerializer, IndicatorDataPointMix
 
 
 class IndicatorEditValuesPermission(permissions.DjangoObjectPermissions):
+    def check_permission(self, user: User, perm: str, indicator: Indicator | None = None):
+        # Check for object permissions first
+        if not user.has_perms([perm]):
+            return False
+        if perm in (
+            'indicators.change_indicatorvalue',
+            'indicators.add_indicatorvalue',
+            'indicators.delete_indicatorvalue',
+        ):
+            if not user.can_modify_indicator(indicator=indicator):
+                return False
+        else:
+            return False
+        return True
+
     def has_permission(self, request, view):
+        indicator_pk = view.kwargs.get('pk')
+        try:
+            indicator = Indicator.objects.get(id=indicator_pk)
+        except Indicator.DoesNotExist as e:
+            raise exceptions.NotFound(detail='Indicator not found') from e
+        if not request.method or not request.user.is_authenticated or not isinstance(request.user, User):
+            return False  # linter bitches below otherwise
         perms = self.get_required_permissions(request.method, IndicatorValue)
-        return request.user.has_perms(perms)
+        return all(self.check_permission(request.user, perm, indicator) for perm in perms)
 
     def has_object_permission(self, request, view, obj):
+        if not request.method or not request.user.is_authenticated or not isinstance(request.user, User):
+            return False  # linter bitches below otherwise
         perms = self.get_required_object_permissions(request.method, IndicatorValue)
         if not perms and request.method in permissions.SAFE_METHODS:
             return True
-        user = request.user
-        if not user.has_perms(perms):
-            return False
-        return user.can_modify_indicator(obj)
+        return all(self.check_permission(request.user, perm, obj) for perm in perms)
 
 
 @extend_schema(

--- a/indicators/tests/factories.py
+++ b/indicators/tests/factories.py
@@ -8,6 +8,7 @@ from factory.django import DjangoModelFactory
 
 import indicators
 from actions.tests.factories import ActionFactory, OrganizationFactory, PlanFactory
+from indicators.models import Indicator
 from pages.tests.factories import PageLinkBlockFactory
 from people.tests.factories import PersonFactory
 
@@ -71,6 +72,15 @@ class IndicatorFactory(DjangoModelFactory):
 
     # created_at = None  # Should be set automatically
     # updated_at = None  # Should be set automatically
+
+    @post_generation
+    @staticmethod
+    def plans(obj: Indicator, create, extracted, **kwargs) -> None:
+        if not create:
+            return
+        if extracted:
+            for plan in extracted:
+                obj.plans.add(plan)
 
 
 class IndicatorLevelFactory(DjangoModelFactory):

--- a/indicators/tests/test_api.py
+++ b/indicators/tests/test_api.py
@@ -81,7 +81,7 @@ def assert_goals_match(indicator, goals):
 
 
 def test_all_values_get_replaced(client, plan, plan_admin_user):
-    indicator = IndicatorFactory()
+    indicator = IndicatorFactory(plans=[plan])
     assert not indicator.values.exists()
     for values in [[VALUE_2019, VALUE_2020], [VALUE_2021, VALUE_2022]]:
         # post_values(indicator, values)
@@ -90,7 +90,7 @@ def test_all_values_get_replaced(client, plan, plan_admin_user):
 
 
 def test_all_goals_get_replaced(client, plan, plan_admin_user):
-    indicator = IndicatorFactory()
+    indicator = IndicatorFactory(plans=[plan])
     assert not indicator.goals.exists()
     for values in [[GOAL_2030, GOAL_2045], [GOAL_2035, GOAL_2040]]:
         post(client, plan, plan_admin_user, 'indicator-goals', indicator, values)
@@ -101,8 +101,8 @@ def test_all_goals_get_replaced(client, plan, plan_admin_user):
 @pytest.mark.parametrize("test_goals_instead", [False, True])
 def test_values_get_normalized(client, plan, plan_admin_user, reverse_request_order, test_goals_instead):
     # Normalize emissions by population
-    emissions = IndicatorFactory()
-    population = IndicatorFactory(organization=emissions.organization)
+    emissions = IndicatorFactory(plans=[plan])
+    population = IndicatorFactory(plans=[plan], organization=emissions.organization)
     normalizator = CommonIndicatorNormalizatorFactory(
         normalizable=emissions.common,
         normalizer=population.common,
@@ -140,7 +140,7 @@ def test_values_get_normalized(client, plan, plan_admin_user, reverse_request_or
 # TODO: these authorization test turned out difficult to implement
 #       without flakiness.
 # def test_contact_person_unauthorized(client, plan, action_contact_person_user):
-#     indicator = IndicatorFactory()
+#     indicator = IndicatorFactory(plans=[plan])
 #     assert not indicator.values.exists()
 #     values = [VALUE_2019, VALUE_2020]
 #     post(client, plan, action_contact_person_user, 'indicator-values', indicator, values, expected_status_code=403)
@@ -148,7 +148,7 @@ def test_values_get_normalized(client, plan, plan_admin_user, reverse_request_or
 
 
 # def test_unauthorized_without_login(client, plan):
-#     indicator = IndicatorFactory()
+#     indicator = IndicatorFactory(plans=[plan])
 #     assert not indicator.values.exists()
 #     values = [VALUE_2019, VALUE_2020]
 #     post(client, plan, None, 'indicator-values', indicator, values, expected_status_code=401)
@@ -156,7 +156,7 @@ def test_values_get_normalized(client, plan, plan_admin_user, reverse_request_or
 
 
 # def test_contact_person_goals_unauthorized(client, plan, action_contact_person_user):
-#     indicator = IndicatorFactory()
+#     indicator = IndicatorFactory(plans=[plan])
 #     assert not indicator.goals.exists()
 #     values = [GOAL_2030, GOAL_2045]
 #     post(client, plan, action_contact_person_user, 'indicator-goals', indicator, values, expected_status_code=403)
@@ -164,7 +164,7 @@ def test_values_get_normalized(client, plan, plan_admin_user, reverse_request_or
 
 
 # def test_goals_unauthorized_without_login(client, plan, post_goals_no_user):
-#     indicator = IndicatorFactory()
+#     indicator = IndicatorFactory(plans=[plan])
 #     assert not indicator.goals.exists()
 #     values = [GOAL_2030, GOAL_2045]
 #     post(client, plan, None, 'indicator-goals', indicator, values, expected_status_code=401)
@@ -172,7 +172,7 @@ def test_values_get_normalized(client, plan, plan_admin_user, reverse_request_or
 
 
 def test_add_first_value_updates_indicator_latest_value(client, plan, plan_admin_user):
-    indicator = IndicatorFactory()
+    indicator = IndicatorFactory(plans=[plan])
     assert not indicator.values.exists()
     assert indicator.latest_value is None
     post(client, plan, plan_admin_user, 'indicator-values', indicator, [VALUE_2019])
@@ -182,7 +182,7 @@ def test_add_first_value_updates_indicator_latest_value(client, plan, plan_admin
 
 
 def test_add_value_updates_indicator_latest_value(client, plan, plan_admin_user):
-    indicator = IndicatorFactory()
+    indicator = IndicatorFactory(plans=[plan])
     post(client, plan, plan_admin_user, 'indicator-values', indicator, [VALUE_2019])
     post(client, plan, plan_admin_user, 'indicator-values', indicator, [VALUE_2020])
     assert not indicator.latest_value.categories.exists()
@@ -191,13 +191,13 @@ def test_add_value_updates_indicator_latest_value(client, plan, plan_admin_user)
 
 
 def test_add_value_keeps_null_due_date(client, plan, plan_admin_user):
-    indicator = IndicatorFactory()
+    indicator = IndicatorFactory(plans=[plan])
     post(client, plan, plan_admin_user, 'indicator-values', indicator, [VALUE_2019])
     assert indicator.updated_values_due_at is None
 
 
 def test_add_value_updates_due_date(client, plan, plan_admin_user):
-    indicator = IndicatorFactory(updated_values_due_at=date(2020, 3, 1))
+    indicator = IndicatorFactory(plans=[plan], updated_values_due_at=date(2020, 3, 1))
     post(client, plan, plan_admin_user, 'indicator-values', indicator, [VALUE_2019])
     assert indicator.updated_values_due_at == date(2021, 3, 1)
 


### PR DESCRIPTION
Previously, any authenticated user could edit the values of any indicator.

## Description
Fixes this. The new code was adapted from other classes like `CategoryPermission`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
https://kausaltech.slack.com/archives/C07R954EV7D/p1759239788664479

## Requirements, dependencies and related PRs
Nope.

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented  
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PR's e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Additional Notes
Any additional information that reviewers should know about this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens REST permissions for editing indicator values by enforcing both global perms and indicator-level modify rights, with proper 404 on missing indicators.
> 
> - **Backend/API**:
>   - **Permissions overhaul for `update_values`**:
>     - Introduce `IndicatorEditValuesPermission.check_permission` to require both `user.has_perms` and `user.can_modify_indicator` for `add/change/delete` on `IndicatorValue`.
>     - `has_permission`: fetch `Indicator` by `pk`; raise `NotFound` if missing; verify authenticated `User`; validate all required perms via `check_permission`.
>     - `has_object_permission`: authenticate and validate perms via `check_permission` on the target indicator.
>   - **Imports**: add `rest_framework.exceptions` and `users.models.User`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 968aa1b66a77e31089640d7cd07f52e022e328f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->