### PR TITLE
Add fairfield to embed whitelist

### DIFF
--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -628,6 +628,12 @@ WAGTAILEMBEDS_FINDERS = [
         # If we leave the provider out, the "default" provider will be used
         'domain_whitelist': ('klimadashboard.de', ),
         'title': 'Chart',
+    },
+    {
+        'class': f'{PROJECT_NAME}.wagtail_embed_finders.GenericFinder',
+        # If we leave the provider out, the "default" provider will be used
+        'domain_whitelist': ('gis.fairfield-city.org', ),
+        'title': 'Map',
     }
 
 ]


### PR DESCRIPTION
## Description
Allow gis.fairfield-city.org for embeds

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
Slack thread: https://kausaltech.slack.com/archives/C09FBBT201J/p1759401969481199

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Embed the url found in the slack thread to e.g. action description.
    Check watch ui

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented  
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PR's e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
<img width="978" height="982" alt="image" src="https://github.com/user-attachments/assets/98b3e1f0-a9ce-47f0-9a52-ce918a1c27f4" />

## Additional Notes
Any additional information that reviewers should know about this PR.
