### PR TITLE
Save related actions when saving action (published or draft)

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -243,6 +243,8 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
                     formsets[role] = formset
             manager = getattr(self.instance, relation_name)
             original_objects = manager.get_object_list().copy()
+            # FIXME: 281d32c15 moved the call to `super().save()` into this `for` loop. Linters rightly complain after
+            # this loop that `obj` may be unbound. In any case, it's weird that we call `super().save()` multiple times.
             obj: Action = super().save(commit)
             self.save_related_objects_with_role(manager, formsets, original_objects, commit)
 
@@ -254,6 +256,9 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
                 continue
             cat_type = field.category_type
             obj.set_categories(cat_type, field_data)
+
+        related_actions = self.cleaned_data.get('related_actions', [])
+        obj.related_actions.set(related_actions)
 
         user = self._user
         # If we are serializing a draft (which happens when `commit` is false), we should include all attributes, i.e.,


### PR DESCRIPTION
Saving related actions of an action used to be broken. When creating an action, related actions could be set, but after creation, any attempt to edit the related actions would be ignored.

This is because the relationship between an action and the related action is not "parental" (we use `ManyToManyField`) and there is no code that puts this relation into the revision.

While investigating this issue, I realized that other relationships are in principle also affected. For example, the categories of an action. There, however, we made the questionable decision to set the categories of the `Action` instance persisted in the database even when only saving a draft. That is, the published action's categories are affected when clicking "save draft".

This commit "fixes" the bug that changes to the related actions are ignored by handling it in the same way as categories. Note that now for related actions we have the same arguably buggy behavior as we have for action categories. However, I believe it is better to have one bug instead of two. We can, and should, fix the other bug as soon as possible.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211588710979857?focus=true)
[Bug report in Slack](https://kausaltech.slack.com/archives/C01AZ2V3656/p1759999193381159)
[Discussion about action categories and how this relates to the current bug](https://kausaltech.slack.com/archives/C07R954EV7D/p1760020563984749)