### PR TITLE
POC: Preserve published action when changing related actions in draft

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -20,6 +20,7 @@ from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,
     MultiFieldPanel,
+    MultipleChooserPanel,
     ObjectList,
 )
 from wagtail.admin.panels.base import Panel
@@ -749,14 +750,15 @@ class ActionAdmin(AplansModelAdmin):
         CustomizableBuiltInFieldPanel('image'),
     )
     basic_related_panels_general_admin: list[Panel[Any]] = [
-        CustomizableBuiltInFieldPanel(
-            'related_actions',
-            widget=autocomplete.ModelSelect2Multiple(
-                url='action-autocomplete',
-                forward=(
-                    dal_forward.Const(True, 'related_plans'),
-                ),
-            ),
+        # TODO: Allow customizability like in CustomizableBuiltInFieldPanel
+        MultipleChooserPanel(
+            'related_actions_through',
+            chooser_field_name='to_action',
+            heading=_("Related actions"),
+            label=_("Related action"),
+            panels=[
+                FieldPanel('to_action', widget=ActionChooser, heading=_("Action")),
+            ],
         ),
         CustomizableBuiltInFieldPanel('merged_with', widget=ActionChooser),
         CustomizableBuiltInFieldPanel('visibility'),

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1098,7 +1098,7 @@ class ActionScheduleThrough(models.Model):
 
 
 class RelatedActionsThrough(models.Model):
-    from_action = models.ForeignKey(Action, on_delete=models.CASCADE, related_name='related_actions_through')
+    from_action = ParentalKey(Action, on_delete=models.CASCADE, related_name='related_actions_through')
     to_action = models.ForeignKey(Action, on_delete=models.CASCADE)
 
     class Meta:


### PR DESCRIPTION
## Description

This makes `RelatedActionsThrough` an inline model of `Action` and replaces the autocomplete field for related actions by an inline panel -- a `MultipleChooserPanel` to be precise.

This fixes the buggy behavior that changing related actions and clicking "save draft" updates the related actions of the published action, not just the draft. In fact, action drafts previously did not contain any information about related actions but took that information straight from the published version.

While this commit may fix the logic, it arguably makes the UX worse -- that is, if we disregard the fact that changing a published action without actually wanting to do so is pretty bad UX to begin with. Also, the current excess of headings and labels of the inline panel should be improved.

As another task to do in the future, the new `MultipleChooserPanel` is not customizable like many other fields are by means of the `CustomizableBuiltInFieldPanel`. The autocomplete version used `CustomizableBuiltInFieldPanel`, but I have not verified if this used to work.

So far, this is a proof-of-concept. The problem persists for other many-to-many relationships as well; for example, action categories. A similar fix still would need to be applied to those cases.

## Related issue
See https://github.com/kausaltech/kausal-watch-private/pull/414
Related issues / tasks are listed there.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
