### PR TITLE
Add alert for button saving status

### DIFF
--- a/admin_site/static/admin_site/js/accessibility.js
+++ b/admin_site/static/admin_site/js/accessibility.js
@@ -1,12 +1,15 @@
-(function() {
+(function () {
+  const ACTIONS_STATUS_CLASS = 'actions-status';
+  const WAGTAIL_IS_LOADING_ATTRIBUTE = 'data-w-progress-loading-value';
+  const WAGTAIL_LOADING_TEXT_ATTRIBUTE = 'data-w-progress-active-value';
 
   function waitForElements(selector) {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       if (document.querySelector(selector)) {
         return resolve(document.querySelectorAll(selector));
       }
 
-      const observer = new MutationObserver(mutations => {
+      const observer = new MutationObserver((mutations) => {
         if (document.querySelector(selector)) {
           observer.disconnect();
           resolve(document.querySelectorAll(selector));
@@ -15,7 +18,7 @@
 
       observer.observe(document.body, {
         childList: true,
-        subtree: true
+        subtree: true,
       });
     });
   }
@@ -29,10 +32,9 @@
       }
       el.setAttribute(
         'aria-describedby',
-        hiddenInput.getAttribute('aria-describedby')
+        hiddenInput.getAttribute('aria-describedby'),
       );
     });
-
   }
 
   function addAttributesToNotificationMessages() {
@@ -48,6 +50,72 @@
       if (container.innerText) {
         container.setAttribute('aria-label', container.innerText);
       }
+    });
+  }
+
+  function addAttributesToPublishActions() {
+    const actionsBar = document.querySelector('.actions');
+
+    if (actionsBar == null) {
+      return;
+    }
+
+    const actionsStatus = document.createElement('div');
+
+    actionsStatus.classList.add(ACTIONS_STATUS_CLASS, 'screen-reader-only');
+    actionsStatus.setAttribute('aria-live', 'assertive');
+    actionsStatus.setAttribute('role', 'status');
+    actionsStatus.setAttribute('aria-atomic', 'true');
+    actionsStatus.innerText = '';
+
+    actionsBar.appendChild(actionsStatus);
+  }
+
+  function setupAriaBusyForProgressButtons() {
+    setTimeout(() => {
+      const status = document.querySelector(`.${ACTIONS_STATUS_CLASS}`);
+      status.textContent = 'Saving...';
+      console.log('Testing Saving alert after 5 seconds');
+
+      setTimeout(() => {
+        status.textContent = '';
+      }, 1000);
+    }, 5000);
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === WAGTAIL_IS_LOADING_ATTRIBUTE
+        ) {
+          const status = document.querySelector(`.${ACTIONS_STATUS_CLASS}`);
+          const button = mutation.target;
+
+          const isLoading =
+            button.getAttribute(WAGTAIL_IS_LOADING_ATTRIBUTE) === 'true';
+
+          if (isLoading) {
+            const label = button.getAttribute(WAGTAIL_LOADING_TEXT_ATTRIBUTE);
+
+            setTimeout(() => {
+              status.textContent = label || '';
+              status.setAttribute('aria-label', label || '');
+            }, 100);
+          }
+        }
+      });
+    });
+
+    // Observe all buttons with w-progress controller, for example the save and publish buttons
+    const progressButtons = document.querySelectorAll(
+      "[data-controller*='w-progress']",
+    );
+
+    progressButtons.forEach((button) => {
+      observer.observe(button, {
+        attributes: true,
+        attributeFilter: [WAGTAIL_IS_LOADING_ATTRIBUTE],
+      });
     });
   }
 
@@ -67,18 +135,19 @@
     addActivePlanAccessibilityFlagToBodyClass(accessibilityLevel);
     addAttributesToNotificationMessages();
     fixDraftailDescribedByElements();
+    addAttributesToPublishActions();
+    setupAriaBusyForProgressButtons();
   }
 
   const accessibilityScript = document.currentScript;
-  const accessibilityLevel = accessibilityScript.dataset.activePlanAccessibilityLevel;
+  const accessibilityLevel =
+    accessibilityScript.dataset.activePlanAccessibilityLevel;
 
   if (document.readyState === 'loading') {
-    document.addEventListener(
-      'DOMContentLoaded',
-      (e) => injectAccessibilityFixes(accessibilityLevel)
+    document.addEventListener('DOMContentLoaded', (e) =>
+      injectAccessibilityFixes(accessibilityLevel),
     );
     return;
   }
   injectAccessibilityFixes(activePlan);
-
 })();

--- a/admin_site/static/admin_site/js/accessibility.js
+++ b/admin_site/static/admin_site/js/accessibility.js
@@ -94,7 +94,7 @@
 
     // Observe all buttons with w-progress controller, for example the save and publish buttons
     const progressButtons = document.querySelectorAll(
-      "[data-controller*='w-progress']",
+      "nav.actions [data-controller*='w-progress']",
     );
 
     progressButtons.forEach((button) => {

--- a/admin_site/static/admin_site/js/accessibility.js
+++ b/admin_site/static/admin_site/js/accessibility.js
@@ -53,8 +53,8 @@
     });
   }
 
-  function addAttributesToPublishActions() {
-    const actionsBar = document.querySelector('.actions');
+  function createPublishActionsStatus() {
+    const actionsBar = document.querySelector('nav.actions');
 
     if (actionsBar == null) {
       return;
@@ -64,24 +64,13 @@
 
     actionsStatus.classList.add(ACTIONS_STATUS_CLASS, 'screen-reader-only');
     actionsStatus.setAttribute('aria-live', 'assertive');
-    actionsStatus.setAttribute('role', 'status');
     actionsStatus.setAttribute('aria-atomic', 'true');
     actionsStatus.innerText = '';
 
     actionsBar.appendChild(actionsStatus);
   }
 
-  function setupAriaBusyForProgressButtons() {
-    setTimeout(() => {
-      const status = document.querySelector(`.${ACTIONS_STATUS_CLASS}`);
-      status.textContent = 'Saving...';
-      console.log('Testing Saving alert after 5 seconds');
-
-      setTimeout(() => {
-        status.textContent = '';
-      }, 1000);
-    }, 5000);
-
+  function createListenersForProgressButtons() {
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (
@@ -96,11 +85,8 @@
 
           if (isLoading) {
             const label = button.getAttribute(WAGTAIL_LOADING_TEXT_ATTRIBUTE);
-
-            setTimeout(() => {
-              status.textContent = label || '';
-              status.setAttribute('aria-label', label || '');
-            }, 100);
+            button.setAttribute('aria-busy', 'true');
+            status.textContent = label || '';
           }
         }
       });
@@ -135,8 +121,8 @@
     addActivePlanAccessibilityFlagToBodyClass(accessibilityLevel);
     addAttributesToNotificationMessages();
     fixDraftailDescribedByElements();
-    addAttributesToPublishActions();
-    setupAriaBusyForProgressButtons();
+    createPublishActionsStatus();
+    createListenersForProgressButtons();
   }
 
   const accessibilityScript = document.currentScript;

--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -1,7 +1,7 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700;800&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700;800&display=swap');
 
 :root {
-  --w-font-sans: "Inter";
+  --w-font-sans: 'Inter';
   /*--w-font-mono: Inconsolata;*/
   --w-color-primary-hue: 160;
   --w-color-secondary-hue: 160;
@@ -111,7 +111,7 @@
   color: var(--w-color-grey-800);
 }
 
-section[role="tabpanel"] .help-block {
+section[role='tabpanel'] .help-block {
   background-color: inherit;
   padding-left: 0;
   span.field-visibility-label.w-status--primary {
@@ -175,7 +175,7 @@ section[role="tabpanel"] .help-block {
 }
 /* Fix space between action buttons */
 .listing .actions > li {
-  margin: 0 0 .5em;
+  margin: 0 0 0.5em;
 }
 /* Fix text being cropped when action buttons have long texts */
 .actions .button {
@@ -183,10 +183,27 @@ section[role="tabpanel"] .help-block {
   min-height: 2em; /* adding this to make sure things don't change for short texts */
 }
 /* Fix weird inline block issues on, e.g., category list (unfiltered by category type) */
-.listing .title .title-wrapper, .listing .title h2 {
+.listing .title .title-wrapper,
+.listing .title h2 {
   display: block;
 }
 
+.screen-reader-only {
+  /* Temporary debug style */
+  background-color: yellow;
+  color: red;
+  border: 2px solid red;
+
+  /* position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important; */
+}
 
 /* Intrusive accessibility fixes for customers with plan.features.admin_accessibility_conformance_level == 'high'
 

--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -189,12 +189,7 @@ section[role='tabpanel'] .help-block {
 }
 
 .screen-reader-only {
-  /* Temporary debug style */
-  background-color: yellow;
-  color: red;
-  border: 2px solid red;
-
-  /* position: absolute !important;
+  position: absolute !important;
   width: 1px !important;
   height: 1px !important;
   padding: 0 !important;
@@ -202,7 +197,7 @@ section[role='tabpanel'] .help-block {
   overflow: hidden !important;
   clip: rect(0, 0, 0, 0) !important;
   white-space: nowrap !important;
-  border: 0 !important; */
+  border: 0 !important;
 }
 
 /* Intrusive accessibility fixes for customers with plan.features.admin_accessibility_conformance_level == 'high'


### PR DESCRIPTION
## Description
Announce the saving text of wagtail publish/ save buttons to screen readers:

1. Inject a new hidden alert div on document loaded if publish actions (`nav.actions`) are present on the page
2. Add listeners to Wagtail progress buttons (used by create and edit views)
3. When the progress value of those buttons change (e.g. if the button is "Saving"), reflect that in the alert for the screen reader.

## Screenshots/Videos (if applicable)
https://github.com/user-attachments/assets/43ed1ffe-107f-4863-9faf-6fb109b002aa


## Related issue
[🎟️ Asana](https://app.asana.com/1/1201243246741462/project/1205309956497857/task/1211575003917065?focus=true)
## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here
