### PR TITLE
Monkey-patch modelcluster bug and take fix for related actions back into use

### DIFF
--- a/actions/apps.py
+++ b/actions/apps.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 _wagtail_image_chooser_viewset_permission_policy = None
 _wagtail_get_base_snippet_action_menu_items = None
+_create_deferring_forward_many_to_many_manager  = None  # type: ignore[var-annotated]
 
 
 def _get_collections(user: User) -> Iterable[Collection]:
@@ -175,6 +176,30 @@ def monkeypatch_snippet_action_menu():
         action_menu.get_base_snippet_action_menu_items = get_base_snippet_action_menu_items
 
 
+def monkeypatch_deferring_forward_many_to_many_manager():
+    # This should be removed once https://github.com/wagtail/django-modelcluster/pull/203 is merged and taken into use
+    import modelcluster.fields
+    assert hasattr(modelcluster.fields, 'create_deferring_forward_many_to_many_manager')
+    global _create_deferring_forward_many_to_many_manager  # noqa: PLW0603
+
+    if _create_deferring_forward_many_to_many_manager is None:
+        _create_deferring_forward_many_to_many_manager = (
+            modelcluster.fields.create_deferring_forward_many_to_many_manager  # pyright:ignore[reportAttributeAccessIssue]
+        )
+
+    def patched_function(rel, original_manager_cls):  # noqa: ANN202
+        assert _create_deferring_forward_many_to_many_manager is not None
+        manager = _create_deferring_forward_many_to_many_manager(rel, original_manager_cls)
+
+        def patched_method(self, queryset):  # noqa: ANN202
+            return queryset._next_is_sticky().all()
+
+        manager._apply_rel_filters = patched_method
+        return manager
+
+    modelcluster.fields.create_deferring_forward_many_to_many_manager = patched_function  # pyright:ignore[reportAttributeAccessIssue]
+
+
 class ActionsConfig(AppConfig):
     name = 'actions'
     verbose_name = _('Actions')
@@ -185,3 +210,4 @@ class ActionsConfig(AppConfig):
         monkeypatch_snippet_action_menu()
         import actions.signals
         actions.signals.register_signal_handlers()
+        monkeypatch_deferring_forward_many_to_many_manager()

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -20,7 +20,7 @@ from django.db.models.functions import Cast
 from django.urls import reverse
 from django.utils import timezone, translation
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
-from modelcluster.fields import ParentalKey
+from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel, model_from_serializable_data
 from modeltrans.fields import TranslatedVirtualField, TranslationField
 from modeltrans.manager import MultilingualQuerySet
@@ -350,7 +350,7 @@ class Action(
         on_delete=models.SET_NULL,
         verbose_name=_('decision-making level'),
     )
-    categories: models.ManyToManyField[Category, Category] = models.ManyToManyField(
+    categories: ParentalManyToManyField[Category, Category] = ParentalManyToManyField(
         'actions.Category',
         blank=True,
         verbose_name=_('categories'),
@@ -364,7 +364,7 @@ class Action(
         through='indicators.ActionIndicator',
         related_name='actions',
     )
-    related_actions: M2M[Self, Any] = models.ManyToManyField(
+    related_actions: ParentalManyToManyField[Self, Self] = ParentalManyToManyField(
         'self',
         blank=True,
         verbose_name=_('related actions'),


### PR DESCRIPTION
## Description
We recently changed `related_actions` of the `Action` model to a `ParentalManyToManyField` in order to fix the bug that related actions were not saved. While this fixed the bug, it made the action list in the frontend behave in an odd way. (The actions were no longer grouped by categories.) Closer investigation showed that this is due to a bug in django-modelcluster. I made a PR: https://github.com/wagtail/django-modelcluster/pull/203

Until that PR to modelcluster is merged and taken into use, we can use the monkey-patch proposed by the current PR.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211588710979857?focus=true

## Testing
A unit test has been included in my PR to modelcluster.