### PR TITLE
Reorder search input and button

### DIFF
--- a/admin_site/static/admin_site/js/accessibility.js
+++ b/admin_site/static/admin_site/js/accessibility.js
@@ -85,7 +85,7 @@
       // TODO: Localize this
       searchInput.setAttribute(
         'aria-description',
-        'Please enter a search term',
+        gettext('Please enter a search term'),
       );
     }
 

--- a/admin_site/static/admin_site/js/accessibility.js
+++ b/admin_site/static/admin_site/js/accessibility.js
@@ -3,24 +3,32 @@
   const WAGTAIL_IS_LOADING_ATTRIBUTE = 'data-w-progress-loading-value';
   const WAGTAIL_LOADING_TEXT_ATTRIBUTE = 'data-w-progress-active-value';
 
-  function waitForElements(selector) {
+  function waitForElement(selector, all = true, parent = document.body) {
     return new Promise((resolve) => {
-      if (document.querySelector(selector)) {
-        return resolve(document.querySelectorAll(selector));
+      const element = document.querySelector(selector);
+
+      if (element) {
+        return resolve(all ? document.querySelectorAll(selector) : element);
       }
 
       const observer = new MutationObserver((mutations) => {
-        if (document.querySelector(selector)) {
+        const element = document.querySelector(selector);
+
+        if (element) {
           observer.disconnect();
-          resolve(document.querySelectorAll(selector));
+          resolve(all ? document.querySelectorAll(selector) : element);
         }
       });
 
-      observer.observe(document.body, {
+      observer.observe(parent, {
         childList: true,
         subtree: true,
       });
     });
+  }
+
+  function waitForElements(selector) {
+    return waitForElement(selector, true);
   }
 
   async function fixDraftailDescribedByElements() {
@@ -51,6 +59,41 @@
         container.setAttribute('aria-label', container.innerText);
       }
     });
+  }
+
+  /**
+   * Reorders the search input and button so that the input is before the button.
+   * This is the natural order for screen readers, since the button is used to submit the search.
+   */
+  async function fixSearchInputAccessibility() {
+    const searchForm = await waitForElement(
+      '#wagtail-sidebar form[role="search"]',
+      false,
+      document.getElementById('wagtail-sidebar'),
+    );
+
+    if (!searchForm) {
+      return;
+    }
+
+    const searchButton = searchForm.querySelector('button');
+    const searchInput = searchForm.querySelector('input#menu-search-q');
+    const wrapper = searchInput.parentNode;
+
+    if (searchInput) {
+      searchInput.setAttribute('autocomplete', 'on');
+      // TODO: Localize this
+      searchInput.setAttribute(
+        'aria-description',
+        'Please enter a search term',
+      );
+    }
+
+    if (!searchButton || !searchInput || !wrapper) {
+      return;
+    }
+
+    wrapper.insertBefore(searchInput, searchButton);
   }
 
   function createPublishActionsStatus() {
@@ -123,6 +166,7 @@
     fixDraftailDescribedByElements();
     createPublishActionsStatus();
     createListenersForProgressButtons();
+    fixSearchInputAccessibility();
   }
 
   const accessibilityScript = document.currentScript;
@@ -133,6 +177,7 @@
     document.addEventListener('DOMContentLoaded', (e) =>
       injectAccessibilityFixes(accessibilityLevel),
     );
+
     return;
   }
   injectAccessibilityFixes(activePlan);

--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -200,6 +200,11 @@ section[role='tabpanel'] .help-block {
   border: 0 !important;
 }
 
+/* Accessibility: Ensure form fields wrap on narrow or zoomed in screens */
+.w-slim-header__search-form {
+  flex-wrap: wrap;
+}
+
 /* Intrusive accessibility fixes for customers with plan.features.admin_accessibility_conformance_level == 'high'
 
 In the end, we would like to move away from these and provide fixes compatible

--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -55,6 +55,7 @@
         The more intrusive of the fixes required for some customers are only enabled
         if plan.features.admin_accessibility_conformance_level is "high"
     {% endcomment %}
+    <script src="{% url 'javascript-catalog' %}"></script>
     <script
       src="{% static 'admin_site/js/accessibility.js' %}"
       data-active-plan-accessibility-level="{{ active_plan.features.admin_accessibility_conformance_level|default:"default" }}">

--- a/aplans/urls.py
+++ b/aplans/urls.py
@@ -10,6 +10,7 @@ from django.contrib.auth.views import LogoutView
 from django.urls import include, path, re_path
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import TemplateView
+from django.views.i18n import JavaScriptCatalog
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.admin.views.pages import search
 from wagtail.documents import urls as wagtaildocs_urls
@@ -117,6 +118,7 @@ api_urlconf = [
 urlpatterns = [
     re_path(r'^admin/change-admin-plan/(?:(?P<plan_id>\d+)/)?$', change_admin_plan, name='change-admin-plan'),
     *api_urlconf,
+    path("jsi18n/", JavaScriptCatalog.as_view(), name="javascript-catalog"),
     path('v1/docs/', TemplateView.as_view(
         template_name='swagger-ui.html',
         extra_context={'schema_url': 'openapi-schema'},

--- a/locale/da/LC_MESSAGES/djangojs.po
+++ b/locale/da/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/de/LC_MESSAGES/djangojs.po
+++ b/locale/de/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/de_CH/LC_MESSAGES/djangojs.po
+++ b/locale/de_CH/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/el/LC_MESSAGES/djangojs.po
+++ b/locale/el/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/en_AU/LC_MESSAGES/djangojs.po
+++ b/locale/en_AU/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/es_US/LC_MESSAGES/djangojs.po
+++ b/locale/es_US/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/fi/LC_MESSAGES/djangojs.po
+++ b/locale/fi/LC_MESSAGES/djangojs.po
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: 2025-11-04 10:33+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr "Syötä haettava teksti"

--- a/locale/lv/LC_MESSAGES/djangojs.po
+++ b/locale/lv/LC_MESSAGES/djangojs.po
@@ -1,0 +1,23 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/pt_BR/LC_MESSAGES/djangojs.po
+++ b/locale/pt_BR/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/sv/LC_MESSAGES/djangojs.po
+++ b/locale/sv/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""

--- a/locale/sv_FI/LC_MESSAGES/djangojs.po
+++ b/locale/sv_FI/LC_MESSAGES/djangojs.po
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-11-04 10:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: admin_site/static/admin_site/js/accessibility.js:88
+msgid "Please enter a search term"
+msgstr ""


### PR DESCRIPTION
## Description
Reorder the Wagtail search menu item elements so that the search button is after the search input. This is the natural order of input and submit button and more understandable by screen readers. The style works regardless of element order due to absolute positioning

## Screenshots/Videos (if applicable)

_**Sound on 🔉**_

https://github.com/user-attachments/assets/ea85e2e5-e051-489a-bed9-d00573a09b2c

## Related issue
[🎟️ Asana task](https://app.asana.com/1/1201243246741462/project/1205309956497857/task/1211575003917071?focus=true)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [-] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders the Wagtail sidebar search to place the input before the button with ARIA/ autocomplete tweaks, adds JS i18n support, and allows the search form to wrap.
> 
> - **Admin accessibility (JS)**:
>   - Add `waitForElement()` utility and use it in `fixSearchInputAccessibility()` to reorder `#menu-search-q` before the search button.
>   - Set `autocomplete="on"` and `aria-description` via `gettext('Please enter a search term')`.
>   - Invoke `fixSearchInputAccessibility()` during accessibility setup.
> - **Templates/URLs**:
>   - Include JS i18n catalog in `admin_site/templates/wagtailadmin/base.html`.
>   - Add `path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog')` to `aplans/urls.py`.
> - **Styles**:
>   - Allow wrapping in `.w-slim-header__search-form { flex-wrap: wrap; }` for narrow/zoomed layouts.
> - **Internationalization**:
>   - Add `locale/*/LC_MESSAGES/djangojs.po` entries for "Please enter a search term" (with Finnish translation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf2d1e033dcc41ea757f95eb259abfb33f948d1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->