### PR TITLE
Fix saving of action categories

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -234,6 +234,8 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
         if hasattr(self.instance, 'updated_at'):
             self.instance.updated_at = timezone.now()
 
+        obj: Action = super().save(commit)
+
         for _cls, relation_name, __, ___ in MODELS_WITH_ROLES:
             formsets = {}
             # There is a corresponding formset for a role if and only if we can edit objects of that role.
@@ -241,9 +243,8 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
                 formset = cast('dict', self.formsets).pop(f'{relation_name}_{role}', None)
                 if formset:
                     formsets[role] = formset
-            manager = getattr(self.instance, relation_name)
+            manager = getattr(obj, relation_name)
             original_objects = manager.get_object_list().copy()
-            obj: Action = super().save(commit)
             self.save_related_objects_with_role(manager, formsets, original_objects, commit)
 
         # Update categories
@@ -254,6 +255,11 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
                 continue
             cat_type = field.category_type
             obj.set_categories(cat_type, field_data)
+
+        if commit:
+            # The instance was saved already when we called `super().save()`, but things like the categories may have
+            # changed afterwards without being committed.
+            obj.save()
 
         user = self._user
         # If we are serializing a draft (which happens when `commit` is false), we should include all attributes, i.e.,


### PR DESCRIPTION
Since we changed the `categories` field to a `ParentalManyToManyField`, the categories did not get saved when saving the action. This was because we relied on `action.categories.add()` committing the changes right away, which stopped being the case.

This commit fixes that by calling `Action.save()` on the action instance yet again after updating the categories. Perhaps one of our two calls to `save()` is now redundant, but I'm not sure which one, if any.

In the course of that I also pulled the call to `super().save()` out of the loop in `ActionAdminForm.save()`. I don't know what the idea was behind putting it into the loop in the first place. It seems like a bad idea though because one of the things `super().save()` does is add a method `save_m2m` to the form that's meant to be called later on, and I think we should not assume that this method will be exactly the same every time we call `super().save()`.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1202960757879747/task/1211804598641491?focus=true)
[Slack discussion](https://kausaltech.slack.com/archives/C057MEVG13Q/p1762152888667459)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure action categories are saved by re-saving the object after category updates and refactor save flow to call super().save() once outside the roles loop.
> 
> - **Admin form save flow (`actions/action_admin.py`)**
>   - Call `super().save(commit)` once, store as `obj`, and reuse it instead of repeatedly saving inside the roles loop.
>   - Use `getattr(obj, relation_name)` when processing role-based related formsets; preserve and reconcile original objects.
>   - Update categories via `obj.set_categories(...)`; when `commit` is true, call `obj.save()` to persist `ParentalManyToMany` changes.
>   - Continue attribute persistence via `attribute_type.on_form_save(...)` with commit-awareness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f483e155b7809ca1165776ba8b67362be914864. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->