### PR TITLE
Fix/graceful embed error

### DIFF
--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -111,7 +111,16 @@
   color: var(--w-color-grey-800);
 }
 
-section[role='tabpanel'] .help-block {
+section[role='tabpanel'] .help-block:has(> .field-visibility-label) {
+  /*
+  We are using this to make the "public" vs "non-public" field labels
+  prettier when they are rendered inside a .help-block, which happens
+  when the field in question has its own tab, for example "contant persons".
+  (The label is rendered right below the tab header.)
+
+  We do not want to match other help blocks since they may contain
+  validation errors which we want to be highlighted with colors.
+  */
   background-color: inherit;
   padding-left: 0;
   span.field-visibility-label.w-status--primary {

--- a/pages/blocks.py
+++ b/pages/blocks.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 from uuid import UUID
 
 import graphene
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.embeds.embeds import get_embed
+from wagtail.embeds.exceptions import EmbedUnsupportedProviderException
 from wagtail.images.blocks import ImageChooserBlock
 
+import sentry_sdk
 from grapple.helpers import register_streamfield_block
 from grapple.models import (
     GraphQLBoolean,
@@ -29,6 +31,8 @@ from actions.blocks.choosers import CategoryChooserBlock
 from actions.models.category import Category
 
 if TYPE_CHECKING:
+    from wagtail.embeds.models import Embed
+
     from aplans.graphql_types import GQLInfo
 
 
@@ -88,14 +92,18 @@ def sanitize_iframe(embed_contents: str) -> str:
 
 
 class EmbedHTMLValue(graphene.ObjectType[Any]):
-    html = graphene.String()
+    html: graphene.String = graphene.String()
 
     @staticmethod
-    def resolve_html(parent: dict[str, Any], _info: GQLInfo) -> str:
+    def resolve_html(parent: dict[Literal['height', 'url'], str], _info: GQLInfo) -> str:
         height_key = parent['height']
         url = parent['url']
         css_class = RESPONSIVE_STYLES.get(height_key, next(iter(RESPONSIVE_STYLES.values())))
-        embed = get_embed(url)
+        try:
+            embed: Embed = get_embed(url)
+        except EmbedUnsupportedProviderException as exception:
+            _ = sentry_sdk.capture_exception(exception)
+            return '<div data-error="unsupported-embed-provider"></div>'
         return f"<div data-embed-provider='{embed.provider_name}' class='responsive-object {css_class}'>{embed.html}</div>"
 
 
@@ -105,7 +113,7 @@ class AdaptiveEmbedBlock(blocks.StructBlock):
     # It doesn't support dynamic, configurable sizes.
     # The extra inner field is just to enable the custom
     # resolve_html method
-    embed = blocks.StructBlock(
+    embed: blocks.StructBlock = blocks.StructBlock(
         [('url', blocks.CharBlock(label=_('URL'))),
          # The height value is actually used as a generic size parameter whose interpretation dependends on
          # the type of embed (the provider)
@@ -114,7 +122,7 @@ class AdaptiveEmbedBlock(blocks.StructBlock):
              label=_('Size'),
          ))],
     )
-    full_width = blocks.BooleanBlock(required=False)
+    full_width: blocks.BooleanBlock = blocks.BooleanBlock(required=False)
 
     def clean(self, value: dict[str, Any]):
         result = super().clean(value)

--- a/pages/blocks.py
+++ b/pages/blocks.py
@@ -25,8 +25,9 @@ from grapple.models import (
 from grapple.registry import registry
 from grapple.types.streamfield import ListBlock as GrappleListBlock, StructBlockItem
 
-from aplans.utils import validate_json
 from kausal_common.graphene.grapple import make_grapple_field
+
+from aplans.utils import validate_json
 
 from actions.blocks.choosers import CategoryChooserBlock
 from actions.models.category import Category

--- a/pages/blocks.py
+++ b/pages/blocks.py
@@ -5,9 +5,10 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 from uuid import UUID
 
 import graphene
+from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
-from wagtail.embeds.embeds import get_embed
+from wagtail.embeds.embeds import get_embed, get_finder_for_embed
 from wagtail.embeds.exceptions import EmbedUnsupportedProviderException
 from wagtail.images.blocks import ImageChooserBlock
 
@@ -129,6 +130,11 @@ class AdaptiveEmbedBlock(blocks.StructBlock):
         url = result.get('embed', {}).get('url')
         if url and len(url):
             result['embed']['url'] = sanitize_iframe(url)
+        url = result.get('embed', {}).get('url')
+        try:
+            get_finder_for_embed(url)
+        except EmbedUnsupportedProviderException as e:
+            raise ValidationError(_("The source URL of the embed is invalid or not supported.")) from e
         return result
 
     class Meta:


### PR DESCRIPTION
## Description
Better handle invalid embeds in two places:
1. the adaptive embed block (when editing streamfields in pages etc.)
2. if an invalid embed has somehow ended up in the database, don't crash the page (for example if the allowed embed sources list later changes)

## Screenshots/Videos (if applicable)
<img width="1574" height="606" alt="image" src="https://github.com/user-attachments/assets/396c7f56-806b-417d-a46c-fbe76276726f" />

## Related issue
https://kausaltech.slack.com/archives/C06JRSP39LJ/p1761639186088609?thread_ts=1761635950.522139&cid=C06JRSP39LJ

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)

##### Manual testing instructions
It is very hard to test the first half of this PR but you can test it by checking out a commit which does not yet have the validation in place, and entering a wrong URL, then trying to load the page.

The validation part can be easily tested just by entering an embed block in a streamfield (any page for example) and saving.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
