### PR TITLE
Feature/raw visualizations in pages

### DIFF
--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import json
 import logging
 import random
 import re
@@ -556,6 +557,13 @@ def validate_css_color(s):
             _('%(color)s is not a CSS color (e.g., "#112233", "red" or "rgb(0, 255, 127)")'),
             params={'color': s},
         )
+
+
+def validate_json(value: str) -> None:
+    try:
+        json.loads(value)
+    except json.JSONDecodeError as e:
+        raise ValidationError(_('Invalid JSON value')) from e
 
 
 class HasI18n(Protocol):

--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import typing
 import uuid
 from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
@@ -34,6 +33,7 @@ from aplans.utils import (
     PlanDefaultsModel,
     RestrictedVisibilityModel,
     get_available_variants_for_language,
+    validate_json,
 )
 
 from indicators.models.common_indicator import CommonIndicatorNormalizator
@@ -81,12 +81,6 @@ if TYPE_CHECKING:
 else:
     IndicatorManager = MLModelManager.from_queryset(IndicatorQuerySet)
 
-
-def validate_json(value: str) -> None:
-    try:
-        json.loads(value)
-    except json.JSONDecodeError as e:
-        raise ValidationError(_('Invalid JSON value')) from e
 
 @reversion.register(follow=('goals',))
 class Indicator(ClusterableModel, index.Indexed, ModificationTracking, PlanDefaultsModel, RestrictedVisibilityModel):

--- a/pages/blocks.py
+++ b/pages/blocks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 from uuid import UUID
 
 import graphene
@@ -22,6 +22,7 @@ from grapple.models import (
 from grapple.registry import registry
 from grapple.types.streamfield import ListBlock as GrappleListBlock, StructBlockItem
 
+from aplans.utils import validate_json
 from kausal_common.graphene.grapple import make_grapple_field
 
 from actions.blocks.choosers import CategoryChooserBlock
@@ -129,6 +130,29 @@ class AdaptiveEmbedBlock(blocks.StructBlock):
         GraphQLField('embed', EmbedHTMLValue),
         GraphQLBoolean('full_width'),
     ]
+
+@register_streamfield_block
+class RawVisualizationBlock(blocks.TextBlock):
+    def __init__(self,
+        required: bool = True,
+        help_text: str | None = None,
+        rows: int = 1,
+        max_length: int | None = None,
+        min_length: int | None = None,
+        search_index: bool = True,
+        validators: tuple[Callable[[str], None]] = (validate_json,),
+        **kwargs: dict[str, Any],
+    ):
+        super().__init__(
+            required=required,
+            help_text=help_text,
+            rows=rows,
+            max_length=max_length,
+            min_length=min_length,
+            search_index=search_index,
+            validators=validators,
+            **kwargs,
+        )
 
 
 @register_streamfield_block

--- a/pages/models.py
+++ b/pages/models.py
@@ -86,6 +86,7 @@ from .blocks import (
     FrontPageHeroBlock,
     LargeImageBlock,
     QuestionAnswerBlock,
+    RawVisualizationBlock,
 )
 
 PAGE_TRANSLATED_FIELDS = ['title', 'slug', 'url_path']
@@ -289,6 +290,7 @@ class PlanRootPage(DefaultSlugForCopyingMixin, AplansPage):  # type: ignore[misc
         ('large_image', LargeImageBlock()),
         ('embed', AdaptiveEmbedBlock()),
         ('paths_outcome', PathsOutcomeBlock()),
+        ('raw_visualization', RawVisualizationBlock()),
     ])
 
     content_panels = [
@@ -351,6 +353,7 @@ class StaticPage(AplansPage):
         ('embed', AdaptiveEmbedBlock()),
         ('category_tree_map', CategoryTreeMapBlock()),
         ('large_image', LargeImageBlock()),
+        ('raw_visualization', RawVisualizationBlock()),
         *get_body_blocks('StaticPage'),
     ], null=True, blank=True)
 
@@ -536,6 +539,7 @@ class CategoryPage(AplansPage):
         ('category_list', CategoryListBlock()),
         ('action_list', ActionListBlock()),
         ('embed', AdaptiveEmbedBlock()),
+        ('raw_visualization', RawVisualizationBlock()),
     ], null=True, blank=True)
 
     content_panels: Sequence[Panel[Any]] = [


### PR DESCRIPTION
## Description
Previously, the ability to add raw JSON data via stremafield block  into Indicators was added. Here, we do the same thing for two page types. 

## Screenshots/Videos (if applicable)
<img width="1544" height="610" alt="image" src="https://github.com/user-attachments/assets/8dee3600-7258-4238-8ed1-0ee1e50063e1" />


------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
