### PR TITLE
Add github-hosted plotly charts to allowed embed list

### DIFF
--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -615,7 +615,7 @@ WAGTAILEMBEDS_FINDERS = [
     {
         'class': f'{PROJECT_NAME}.wagtail_embed_finders.GenericFinder',
         'provider': 'Plotly Chart Studio',
-        'domain_whitelist': ('chart-studio.plotly.com',),
+        'domain_whitelist': ('kausaltech.github.io',),
         'title': 'Chart',
     },
     {


### PR DESCRIPTION
## Description

Nathan from Plotly helped me set up self hosted Plotly charts on GH pages. This approach will allow `Phase 0` of the Plotly migration to match previous charts as much as possible and overcomes other issues with exporting and layout changes.

This PR introduces the management command update_plotly_embeds that migrates all Plotly Studio embeds to the new `kausaltech.github.io/exported-plotly-charts/<owner>_<id>` format, handling plain fields, RichText, and StreamField content inside a transaction.

This also updates the Plotly embed allowlist to use the GH pages URL.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Plotly Chart Studio allowlist with `kausaltech.github.io` for Wagtail embeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a033c324fb374d9845786e2e7c61623b2044014a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->