### PR TITLE
Remove unused CollectionFilter

### DIFF
--- a/actions/apps.py
+++ b/actions/apps.py
@@ -1,54 +1,16 @@
 from __future__ import annotations
 
 from functools import cache
-from typing import TYPE_CHECKING
 
 from django.apps import AppConfig
-from django.contrib.admin.filters import SimpleListFilter
 from django.utils.translation import gettext_lazy as _
 
 from kausal_common.users import user_or_bust
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
-    from django.http.request import HttpRequest
-    from wagtail.models import Collection
-
-    from wagtail_modeladmin.options import ModelAdmin
-
-    from users.models import User
 
 _wagtail_image_chooser_viewset_permission_policy = None
 _wagtail_get_base_snippet_action_menu_items = None
 _create_deferring_forward_many_to_many_manager  = None  # type: ignore[var-annotated]
-
-
-def _get_collections(user: User) -> Iterable[Collection]:
-    plan = user.get_active_admin_plan()
-    if plan.root_collection is None:
-        return []
-    return plan.root_collection.get_descendants(inclusive=True)
-
-
-class CollectionFilter(SimpleListFilter):
-    title = _('collection')
-    parameter_name = 'collection'
-
-    def lookups(self, request: HttpRequest, model_admin: ModelAdmin) -> list[tuple[str, str]]:
-        user = user_or_bust(request.user)
-        collections = _get_collections(user)
-        return [(str(collection.pk), str(collection)) for collection in collections]
-
-    def queryset(self, request, queryset):
-        if self.value():
-            return queryset.filter(collection=self.value())
-        return None
-
-
-def get_unfiltered_object_list(self):
-    collections = _get_collections(self.request.user)
-    return self.model.objects.filter(collection__in=collections)
 
 
 def monkeypatch_image_chooser_viewset():


### PR DESCRIPTION
The filter was introduced in 8dccd7342af4ccd9ef84af12afeae07070d6a965 to monkeypatch wagtailsvg, but we have since then got rid of wagtailsvg. Remove some remaining code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove unused Wagtail collection filter and helper functions from `actions/apps.py` and drop related imports.
> 
> - **Cleanup**:
>   - Remove unused Wagtail collection filtering code in `actions/apps.py`:
>     - Delete `CollectionFilter`, `_get_collections`, and `get_unfiltered_object_list`.
>     - Drop related type hints and imports (`SimpleListFilter`, `TYPE_CHECKING` block).
> - **Monkeypatches**: `monkeypatch_image_chooser_viewset` and other existing monkeypatch functions remain intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e1a7c953adad10c12acb3c1c7b138b32b2c6a45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->