### PR TITLE
Remove unused dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "kausal-watch"
 requires-python = ">= 3.13"
 version = "1.0.0"
 dependencies = [
-    "aniso8601",
     "asgi-cors",
     "babel",
     "celery",

--- a/uv.lock
+++ b/uv.lock
@@ -23,15 +23,6 @@ wheels = [
 ]
 
 [[package]]
-name = "aniso8601"
-version = "10.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/3f/dc8a28fa6dc72c13d8c158b01f8975f240e9e72c336cc1ae00f424e2d7ce/aniso8601-10.0.0.tar.gz", hash = "sha256:ff1d0fc2346688c62c0151547136ac30e322896ed8af316ef7602c47da9426cf", size = 47008, upload-time = "2025-01-10T02:04:14.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/bf/d5cde2cb7cdc2cb1770d974418d169a79c3187bd962cb752b9fd617848ca/aniso8601-10.0.0-py2.py3-none-any.whl", hash = "sha256:3c943422efaa0229ebd2b0d7d223effb5e7c89e24d2267ebe76c61a2d8e290cb", size = 52767, upload-time = "2025-01-10T02:04:11.77Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1480,7 +1471,6 @@ name = "kausal-watch"
 version = "1.0.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aniso8601", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "asgi-cors", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "babel", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "celery", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1630,7 +1620,6 @@ prod = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aniso8601" },
     { name = "asgi-cors" },
     { name = "babel" },
     { name = "celery" },


### PR DESCRIPTION
Remove some dependencies that seem unused. Some are a bit risky deletes, review with care!

The tool I'm using (`deptry`) gave these as well, but I didn't have the guts to delete these (for some I confirmed they are in use somehow, e.g. in extensions):
```
pyproject.toml: DEP002 'babel' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'cryptography' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'django-extensions' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'django-npm' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'django-parler' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'django-redis' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'dnspython' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'elasticsearch' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pillow' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pycryptodome' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pygithub' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pygments-graphql' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pytest-cov' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pytest-env' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pytest-html' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'pyyaml' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 's3cmd' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'setuptools' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'social-auth-app-django' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'strawberry-graphql-django' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'tzdata' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'unidecode' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'uritemplate' defined as a dependency but not used in the codebase
pyproject.toml: DEP002 'uuid-utils' defined as a dependency but not used in the codebase
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `aniso8601` from `pyproject.toml` and purges it and its references from `uv.lock`.
> 
> - **Dependencies**:
>   - Remove `aniso8601` from `project.dependencies` in `pyproject.toml`.
>   - Update `uv.lock`:
>     - Drop `[[package]]` entry for `aniso8601`.
>     - Remove `aniso8601` from `kausal-watch` `dependencies` and `package.metadata.requires-dist`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 903eaf7212eca8a84ba97f8c898820704cb06ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->