### PR TITLE
Fix syncing of all plan-related permissions when saving plan

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -49,7 +49,6 @@ from aplans.utils import (
     PlanRelatedModel,
 )
 
-from actions import perms
 from actions.permission_policy import PlanPermissionPolicy
 from indicators.models import Indicator, IndicatorDimension, IndicatorLevel, IndicatorLevelQuerySet, RelatedIndicator
 from orgs.models import Organization
@@ -644,7 +643,6 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         if update_fields:
             super().save(update_fields=update_fields)
 
-        perms.sync_all_group_permissions_for_plan(self)
         return ret
 
     def get_site_notification_context(self):

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -812,12 +812,14 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         name: str,
         primary_language: str,
         organization: Organization,
-        other_languages: Sequence[str] = (),
+        other_languages: list[str] | None = None,
         short_name: str | None = None,
         base_path: str | None = None,
         hostname: str | None = None,
         client_name: str | None = None,
     ) -> Plan:
+        if other_languages is None:
+            other_languages = []
         plan = Plan(
             identifier=identifier,
             name=name,

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -49,6 +49,7 @@ from aplans.utils import (
     PlanRelatedModel,
 )
 
+from actions import perms
 from actions.permission_policy import PlanPermissionPolicy
 from indicators.models import Indicator, IndicatorDimension, IndicatorLevel, IndicatorLevelQuerySet, RelatedIndicator
 from orgs.models import Organization
@@ -642,6 +643,8 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
 
         if update_fields:
             super().save(update_fields=update_fields)
+
+        perms.sync_all_group_permissions_for_plan(self)
         return ret
 
     def get_site_notification_context(self):

--- a/actions/perms.py
+++ b/actions/perms.py
@@ -322,36 +322,41 @@ def get_or_create_plan_admin_group(force_perm_sync: bool = False) -> Group:
     return group
 
 
-def _sync_plan_admin_group_permissions() -> None:
-    wagtail_perms = get_wagtail_plan_admin_perms()
-    for plan in Plan.objects.exclude(admin_group__isnull=True):
-        group = plan.admin_group
-        assert group is not None
-        if plan.root_collection is not None:
-            _sync_group_collection_perms(plan.root_collection, group, wagtail_perms)
-        root_pages = set()
-        if plan.site and plan.site.root_page:
-            root_pages |= set(plan.site.root_page.get_translations(inclusive=True))
-        root_pages |= set(plan.documentation_root_pages.all())
-        _sync_group_page_perms(root_pages, group)
+def sync_plan_admin_group_permissions(plan: Plan, perms: QuerySet[Permission] | None = None) -> None:
+    if perms is None:
+        perms = get_wagtail_plan_admin_perms()
+    group = plan.admin_group
+    assert group is not None
+    if plan.root_collection is not None:
+        _sync_group_collection_perms(plan.root_collection, group, perms)
+    root_pages = set()
+    if plan.site and plan.site.root_page:
+        root_pages |= set(plan.site.root_page.get_translations(inclusive=True))
+    root_pages |= set(plan.documentation_root_pages.all())
+    _sync_group_page_perms(root_pages, group)
 
 
-def _sync_contact_person_group_permissions() -> None:
-    wagtail_perms = Permission.objects.filter(get_wagtail_contact_person_q())
-
-    for plan in Plan.objects.filter(contact_person_group__isnull=False, root_collection__isnull=False):
-        assert plan.contact_person_group is not None
-        group = plan.contact_person_group
-        assert plan.root_collection is not None
-        _sync_group_collection_perms(plan.root_collection, group, wagtail_perms)
+def sync_contact_person_group_permissions(plan: Plan, perms: QuerySet[Permission] | None = None) -> None:
+    if perms is None:
+        perms = Permission.objects.filter(get_wagtail_contact_person_q())
+    assert plan.contact_person_group is not None
+    group = plan.contact_person_group
+    assert plan.root_collection is not None
+    _sync_group_collection_perms(plan.root_collection, group, perms)
 
 
 def sync_group_permissions() -> None:
     get_or_create_action_contact_person_group(force_perm_sync=True)
     get_or_create_indicator_contact_person_group(force_perm_sync=True)
     get_or_create_plan_admin_group(force_perm_sync=True)
-    _sync_plan_admin_group_permissions()
-    _sync_contact_person_group_permissions()
+
+    wagtail_perms = get_wagtail_plan_admin_perms()
+    for plan in Plan.objects.exclude(admin_group__isnull=True):
+        sync_plan_admin_group_permissions(plan, wagtail_perms)
+
+    wagtail_perms = Permission.objects.filter(get_wagtail_contact_person_q())
+    for plan in Plan.objects.filter(contact_person_group__isnull=False, root_collection__isnull=False):
+        sync_contact_person_group_permissions(plan, wagtail_perms)
 
 
 def _sync_plan_admin_groups(user: UserModel) -> None:

--- a/actions/perms.py
+++ b/actions/perms.py
@@ -345,11 +345,15 @@ def sync_contact_person_group_permissions(plan: Plan, perms: QuerySet[Permission
     _sync_group_collection_perms(plan.root_collection, group, perms)
 
 
+def sync_all_group_permissions_for_plan(plan: Plan):
+    sync_plan_admin_group_permissions(plan)
+    sync_contact_person_group_permissions(plan)
+
+
 def sync_group_permissions() -> None:
     get_or_create_action_contact_person_group(force_perm_sync=True)
     get_or_create_indicator_contact_person_group(force_perm_sync=True)
     get_or_create_plan_admin_group(force_perm_sync=True)
-
     wagtail_perms = get_wagtail_plan_admin_perms()
     for plan in Plan.objects.exclude(admin_group__isnull=True):
         sync_plan_admin_group_permissions(plan, wagtail_perms)

--- a/actions/signals.py
+++ b/actions/signals.py
@@ -18,7 +18,7 @@ from .mail import (
 )
 from .models import Action, ActionContactPerson, ActionResponsibleParty, Category, GeneralPlanAdmin, Plan, PlanFeatures
 from .models.attributes import AttributeType
-from .perms import get_people_with_login_rights
+from .perms import get_people_with_login_rights, sync_all_group_permissions_for_plan
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +30,16 @@ def create_notification_settings(sender, instance, created, **kwargs):
 
 
 @receiver(post_save, sender=Plan)
-def create_plan_features(sender, instance, created, **kwargs):
+def create_plan_features_and_sync_group_permissions(sender, instance, created, **kwargs):
     if created:
         PlanFeatures.objects.create(plan=instance)
+        return
+    # post_save is called twice for Plans
+    # since super() is called twice in Plan.save.
+    # During the first call the admin_group and such
+    # are not saved yet. Make sure created is false
+    # before the following call:
+    sync_all_group_permissions_for_plan(instance)
 
 
 @receiver(pre_send)
@@ -47,7 +54,6 @@ def log_email_send_status(sender, message, status, esp_name, **kwargs):
             f"Email send status '{recipient_status.status}' (message ID {recipient_status.message_id}) from {esp_name} for "
             f"email with subject '{message.subject}' to recipient {email}",
         )
-
 
 @receiver(post_delete, sender=ActionContactPerson)
 def fix_deleted_contact_person_in_draft(sender, instance, **kwargs):

--- a/actions/tests/test_sync_group_permissions.py
+++ b/actions/tests/test_sync_group_permissions.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from wagtail.models import GroupPagePermission
+
+import pytest
+
+from actions.models import Plan
+from actions.perms import get_wagtail_plan_admin_perms, sync_group_permissions
+
+pytestmark = pytest.mark.django_db
+
+
+def test_sync_group_permissions_creates_required_groups_for_plans(organization_factory):
+    """Test that sync_group_permissions creates and syncs groups for multiple plans."""
+    # Create two plans using create_with_defaults
+    org = organization_factory()
+    plan1 = Plan.create_with_defaults(
+        identifier='test-plan-1',
+        name='Test Plan 1',
+        primary_language='en',
+        organization=org,
+    )
+    plan2 = Plan.create_with_defaults(
+        identifier='test-plan-2',
+        name='Test Plan 2',
+        primary_language='en',
+        organization=org,
+    )
+
+    # Verify plans have root collections (created automatically by create_with_defaults)
+    assert plan1.root_collection is not None
+    assert plan2.root_collection is not None
+
+    # Plans should have their groups created automatically
+    assert plan1.admin_group is not None
+    assert plan1.contact_person_group is not None
+    assert plan2.admin_group is not None
+    assert plan2.contact_person_group is not None
+
+    # Store group IDs before sync
+    plan1_admin_group_id = plan1.admin_group.pk
+    plan1_contact_group_id = plan1.contact_person_group.pk
+    plan2_admin_group_id = plan2.admin_group.pk
+    plan2_contact_group_id = plan2.contact_person_group.pk
+
+    # Run sync_group_permissions
+    sync_group_permissions()
+
+    # Verify the groups still exist
+    assert Group.objects.filter(id=plan1_admin_group_id).exists()
+    assert Group.objects.filter(id=plan1_contact_group_id).exists()
+    assert Group.objects.filter(id=plan2_admin_group_id).exists()
+    assert Group.objects.filter(id=plan2_contact_group_id).exists()
+
+    # Verify the global groups exist
+    assert Group.objects.filter(name='Action contact persons').exists()
+    assert Group.objects.filter(name='Indicator contact persons').exists()
+    assert Group.objects.filter(name='Plan admins').exists()
+
+    # Verify the plan admin groups have page permissions if root pages exist
+    plan1.refresh_from_db()
+    plan2.refresh_from_db()
+
+    if plan1.site and plan1.site.root_page:
+        root_pages = set(plan1.site.root_page.get_translations(inclusive=True))
+        assert GroupPagePermission.objects.filter(
+            group=plan1.admin_group,
+            page__in=root_pages
+        ).exists()
+
+    if plan2.site and plan2.site.root_page:
+        root_pages = set(plan2.site.root_page.get_translations(inclusive=True))
+        assert GroupPagePermission.objects.filter(
+            group=plan2.admin_group,
+            page__in=root_pages
+        ).exists()
+
+    # Verify the plan admin groups have collection permissions
+    from wagtail.models.media import GroupCollectionPermission
+    wagtail_perms = get_wagtail_plan_admin_perms()
+
+    assert GroupCollectionPermission.objects.filter(
+        group=plan1.admin_group,
+        collection=plan1.root_collection,
+        permission__in=wagtail_perms
+    ).exists()
+
+    assert GroupCollectionPermission.objects.filter(
+        group=plan2.admin_group,
+        collection=plan2.root_collection,
+        permission__in=wagtail_perms
+    ).exists()

--- a/actions/tests/test_sync_group_permissions.py
+++ b/actions/tests/test_sync_group_permissions.py
@@ -6,7 +6,7 @@ from wagtail.models import GroupPagePermission
 import pytest
 
 from actions.models import Plan
-from actions.perms import get_wagtail_plan_admin_perms, sync_group_permissions
+from actions.perms import get_wagtail_plan_admin_perms
 
 pytestmark = pytest.mark.django_db
 
@@ -43,9 +43,6 @@ def test_sync_group_permissions_creates_required_groups_for_plans(organization_f
     plan1_contact_group_id = plan1.contact_person_group.pk
     plan2_admin_group_id = plan2.admin_group.pk
     plan2_contact_group_id = plan2.contact_person_group.pk
-
-    # Run sync_group_permissions
-    sync_group_permissions()
 
     # Verify the groups still exist
     assert Group.objects.filter(id=plan1_admin_group_id).exists()

--- a/copying/main.py
+++ b/copying/main.py
@@ -28,7 +28,7 @@ from actions.models.action import Action
 from actions.models.attributes import AttributeType
 from actions.models.category import Category, CategoryType
 from actions.models.plan import Plan
-from actions.signals import create_notification_settings, create_plan_features
+from actions.signals import create_notification_settings, create_plan_features_and_sync_group_permissions
 from content.apps import create_site_general_content
 from copying.utils import (
     get_foreign_keys,
@@ -827,7 +827,7 @@ def copy_plan(
     with ExitStack() as stack:
         # Disconnect signals to prevent creating related model instances when saving the plan
         stack.enter_context(temp_disconnect_signal(signals.post_save, create_notification_settings, Plan))
-        stack.enter_context(temp_disconnect_signal(signals.post_save, create_plan_features, Plan))
+        stack.enter_context(temp_disconnect_signal(signals.post_save, create_plan_features_and_sync_group_permissions, Plan))
         stack.enter_context(temp_disconnect_signal(
             signals.post_save, create_site_general_content, Plan, 'create_site_general_content'
         ))


### PR DESCRIPTION
## Description
Make sure that all the required plan-specifc permissions are synced after creating the plan (or copying) 

## Screenshots/Videos (if applicable)
<img width="1750" height="943" alt="image (6)" src="https://github.com/user-attachments/assets/a5733ff8-0d19-48d4-a67a-d192ca2b191f" />

Screenshot showing the bug as it appeared.

## Related issue
P-2504


## Requirements, dependencies and related PRs
None

## Additional Notes
Bug introduced in 90d9b67a988f278574eba275da8ec8b3118842ed


------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Has been extensively tested manually so no need for that  anymore since the pytests are there.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)

If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
