### PR TITLE
Fix saving categories through action spreadsheet

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -855,6 +855,8 @@ class Action(
         for cat in new_cats - existing_cats:
             self.categories.add(cat)
 
+        self.save()
+
     def set_responsible_parties(self, data: list[ResponsiblePartyDict]):
         existing_orgs = {p.organization for p in self.responsible_parties.all()}
         new_orgs = {d['organization'] for d in data}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure category updates are saved by calling save() after modifying `categories` in `Action.set_categories`.
> 
> - **Models**:
>   - `Action.set_categories` now calls `save()` after adjusting `categories` to persist changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6742766908f1de36a9562a490bcbe5dc41716f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->