### PR TITLE
Pass request object to Plan.get_view_url() and similar places

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -81,6 +81,8 @@ if typing.TYPE_CHECKING:
 
     from aplans.cache import PlanSpecificCache, WatchObjectCache
     from aplans.graphql_types import WorkflowStateEnum
+    from aplans.schema_context import WatchGraphQLContext
+    from aplans.types import WatchRequest
 
     from actions.attributes import DraftAttributes
     from actions.models.category import Category, CategoryType
@@ -888,7 +890,7 @@ class Action(
     def generate_identifier(self):
         self.identifier = generate_identifier(self.plan.actions.all(), 'a', 'identifier')
 
-    def get_notification_context(self, plan=None):
+    def get_notification_context(self, plan=None, request=None):
         if plan is None:
             plan = self.plan
         change_url = reverse('actions_action_modeladmin_edit', kwargs=dict(instance_pk=self.id))
@@ -898,7 +900,7 @@ class Action(
             'name': self.name,
             'change_url': change_url,
             'updated_at': self.updated_at,
-            'view_url': self.get_view_url(plan=plan),
+            'view_url': self.get_view_url(plan=plan, request=request),
             'order': self.order,
         }
 
@@ -914,11 +916,16 @@ class Action(
         active_tasks = [task for task in self.tasks.all() if task_active(task)]
         return len(active_tasks)
 
-    def get_view_url(self, plan: Plan | None = None, client_url: str | None = None) -> str:
+    def get_view_url(
+        self,
+        plan: Plan | None = None,
+        client_url: str | None = None,
+        request: WatchRequest | WatchGraphQLContext | None = None,
+    ) -> str:
         if plan is None:
             plan = self.plan
         return '%s/actions/%s' % (
-            plan.get_view_url(client_url=client_url, active_locale=translation.get_language()),
+            plan.get_view_url(client_url=client_url, active_locale=translation.get_language(), request=request),
             self.identifier,
         )
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -738,7 +738,12 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
             return ''
         return next((f'/{lang}' for lang in self.other_languages if lang.lower() == locale.lower()), '')
 
-    def get_view_url(self, client_url: str | None = None, active_locale: str | None = None) -> str:  # noqa: C901, PLR0912
+    def get_view_url(  # noqa: C901, PLR0912
+        self,
+        client_url: str | None = None,
+        active_locale: str | None = None,
+        request: WatchRequest | WatchGraphQLContext | None = None,
+    ) -> str:
         """
         Return an URL for the homepage of the plan.
 
@@ -768,7 +773,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
 
         base_path = None
         if hostname:
-            _, wildcard_hostname = get_plan_identifier_from_wildcard_domain(hostname)
+            _, wildcard_hostname = get_plan_identifier_from_wildcard_domain(hostname, request=request)
             if wildcard_hostname:
                 hostname = '%s.%s' % (self.identifier, wildcard_hostname)
                 base_path = '/'

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -410,13 +410,13 @@ class PlanNode(DjangoNode[Plan]):
         return None
 
     @staticmethod
-    def resolve_view_url(root: Plan, _info: GQLInfo, client_url: str | None = None):
+    def resolve_view_url(root: Plan, info: GQLInfo, client_url: str | None = None):
         if client_url:
             try:
                 urlparse(client_url)
             except Exception:
                 raise GraphQLError('clientUrl must be a valid URL') from None
-        return root.get_view_url(client_url=client_url, active_locale=get_language())
+        return root.get_view_url(client_url=client_url, active_locale=get_language(), request=info.context)
 
     @staticmethod
     def resolve_admin_url(root: Plan, info: GQLInfo):
@@ -1303,8 +1303,8 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode[Action
     @gql_optimizer.resolver_hints(
         model_field=('plan', 'identifier'),
     )
-    def resolve_view_url(root: Action, _info: GQLInfo, client_url: str | None = None):
-        return root.get_view_url(client_url=client_url)
+    def resolve_view_url(root: Action, info: GQLInfo, client_url: str | None = None):
+        return root.get_view_url(client_url=client_url, request=info.context)
 
     @staticmethod
     @gql_optimizer.resolver_hints(

--- a/admin_site/wagtail.py
+++ b/admin_site/wagtail.py
@@ -410,11 +410,12 @@ class AplansButtonHelper(ButtonHelper):
     def view_live_button(self, obj, classnames_add=None, classnames_exclude=None):
         if obj is None or not hasattr(obj, 'get_view_url'):
             return None
+        request = admin_req(self.request)
         if isinstance(obj, Plan):
-            url = obj.get_view_url()
+            url = obj.get_view_url(request=request)
         else:
             user = user_or_bust(self.request.user)
-            url = obj.get_view_url(plan=user.get_active_admin_plan())
+            url = obj.get_view_url(plan=user.get_active_admin_plan(), request=request)
         if not url:
             return None
 

--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -46,6 +46,9 @@ if typing.TYPE_CHECKING:
     from kausal_common.models.types import FK, M2M, RevMany
     from kausal_common.users import UserOrAnon
 
+    from aplans.schema_context import WatchGraphQLContext
+    from aplans.types import WatchRequest
+
     from actions.models import Action
     from actions.models.category import Category, CategoryType
     from actions.models.plan import Plan, PlanQuerySet
@@ -431,7 +434,7 @@ class Indicator(ClusterableModel, index.Indexed, ModificationTracking, PlanDefau
     def has_data(self):
         return self.latest_value_id is not None
 
-    def get_notification_context(self, plan):
+    def get_notification_context(self, plan, request=None):
         edit_values_url = reverse('indicators_indicator_modeladmin_edit_values', kwargs=dict(instance_pk=self.id))
         return {
             'id': self.id,
@@ -439,14 +442,20 @@ class Indicator(ClusterableModel, index.Indexed, ModificationTracking, PlanDefau
             'edit_values_url': edit_values_url,
             'updated_at': self.updated_at,
             'updated_values_due_at': self.updated_values_due_at,
-            'view_url': self.get_view_url(plan),
+            'view_url': self.get_view_url(plan, request=request),
         }
 
-    def get_view_url(self, plan: Plan | None = None, client_url: str | None = None) -> str:
+    def get_view_url(
+        self,
+        plan: Plan | None = None,
+        client_url: str | None = None,
+        request: WatchRequest | WatchGraphQLContext | None = None,
+    ) -> str:
         if plan is None:
             plan = self.plans.first()
         assert plan is not None
-        return '%s/indicators/%s' % (plan.get_view_url(client_url=client_url, active_locale=translation.get_language()), self.id)
+        plan_url = plan.get_view_url(client_url=client_url, active_locale=translation.get_language(), request=request)
+        return '%s/indicators/%s' % (plan_url, self.id)
 
     def clean(self):
         if self.updated_values_due_at:

--- a/pages/schema.py
+++ b/pages/schema.py
@@ -78,7 +78,7 @@ class PageMenuItemNode(graphene.ObjectType[MenuItemBase]):
             return None
         if not client_url:
             client_url = info.variable_values.get('clientUrl')
-        view_url = plan.get_view_url(client_url=client_url)
+        view_url = plan.get_view_url(client_url=client_url, request=info.context)
         return view_url
 
 

--- a/search/schema.py
+++ b/search/schema.py
@@ -70,12 +70,12 @@ class SearchHit(graphene.ObjectType[SearchHitObj]):
         search_hit_object = root.object
         page = root.page
         if search_hit_object is not None:
-            return search_hit_object.get_view_url(plan=plan, client_url=client_url)
+            return search_hit_object.get_view_url(plan=plan, client_url=client_url, request=info.context)
         if page is not None:
             parts = page.get_url_parts(request=info.context)
             if parts is None:
                 return None
-            return '%s%s' % (plan.get_view_url(client_url=client_url), parts[2])
+            return '%s%s' % (plan.get_view_url(client_url=client_url, request=info.context), parts[2])
         return None
 
 


### PR DESCRIPTION
This fixes an issue with wrong view URLs being generated due to the `X-Wildcard-Domains` header not being passed to
`get_plan_identifier_from_wildcard_domain()`.

## Screenshots/Videos (if applicable)
See link to Bug report on Slack below.

## Related issue
[Bug report on Slack](https://kausaltech.slack.com/archives/C029WNCMF0T/p1763461140023459)
[Discussion on Slack on how to solve it](https://kausaltech.slack.com/archives/C07R954EV7D/p1763471616007699)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates the request/context into URL generation so `Plan.get_view_url()` (and callers) build correct view URLs with wildcard domains across models, GraphQL, admin, and search.
> 
> - **URL generation**
>   - `actions/models/plan.py`: `Plan.get_view_url()` now accepts `request` and passes it to `get_plan_identifier_from_wildcard_domain()`; wildcard detection reads `request.wildcard_domains`.
>   - `actions/models/action.py`, `indicators/models/indicator.py`: `get_view_url()` and `get_notification_context()` accept/forward `request` to `Plan.get_view_url()`.
> - **GraphQL resolvers**
>   - `actions/schema.py`, `pages/schema.py`, `search/schema.py`: Forward `info.context` as `request` to `get_view_url()` for `Plan`, `Action`, menu items, and search hit URLs.
> - **Admin**
>   - `admin_site/wagtail.py`: `View live` button now passes admin `request` to `get_view_url()` for `Plan` and other objects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e42e5aeab94e1e4886ed2c51cc0df9ee116e40fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->