### PR TITLE
Copy indicator category assignment when copying plans

### DIFF
--- a/copying/main.py
+++ b/copying/main.py
@@ -72,7 +72,9 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     },
     'built_in_field_customizations': {},
     'category_types': {
-        'categories': {},
+        'categories': {
+            'indicator_category_through': {},  # We don't copy the indicators themselves
+        },
         'levels': {},
     },
     'clients': {},

--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -614,8 +614,16 @@ class Indicator(ClusterableModel, index.Indexed, ModificationTracking, PlanDefau
 
 
 class IndicatorCategoryThrough(models.Model):
-    indicator = models.ForeignKey('indicators.Indicator', on_delete=models.CASCADE, related_name='indicator_category_through')
-    category = models.ForeignKey('actions.Category', on_delete=models.CASCADE)
+    indicator = models.ForeignKey(
+        'indicators.Indicator',
+        on_delete=models.CASCADE,
+        related_name='indicator_category_through',
+    )
+    category = models.ForeignKey(
+        'actions.Category',
+        on_delete=models.CASCADE,
+        related_name='indicator_category_through',
+    )
 
     class Meta:
         db_table = 'indicators_indicator_categories'


### PR DESCRIPTION
We designed the plan copying feature so that indicators are not copied. They are supposed to be shared between the original plan and the copy. While categories themselves were copied, the association between indicators and the copies of their categories was not made, which caused some issues.

This fixes that. We may want to optionally copy indicators too, even though we'll have to be careful due to them being shared between plans in general.

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
