### PR TITLE
Avoid redundant save() calls when setting action categories

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -852,12 +852,16 @@ class Action(
                 cat = all_cats[cat]  # noqa: PLW2901
             new_cats.add(cat)
 
+        changed = False
         for cat in existing_cats - new_cats:
             self.categories.remove(cat)
+            changed = True
         for cat in new_cats - existing_cats:
             self.categories.add(cat)
+            changed = True
 
-        self.save()
+        if changed:
+            self.save()
 
     def set_responsible_parties(self, data: list[ResponsiblePartyDict]):
         existing_orgs = {p.organization for p in self.responsible_parties.all()}


### PR DESCRIPTION
## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only call save() in Action.set_categories when category assignments actually change, avoiding redundant saves.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 158fc9eccc9d7add6debcbe9d8cc8339cc9d61fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->