### PR TITLE
Implement new REST API for action tasks

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -9,6 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, permissions, serializers, viewsets
+from rest_framework.relations import RelatedField
 from rest_framework.routers import SimpleRouter
 
 from drf_spectacular.types import OpenApiTypes
@@ -19,6 +20,7 @@ from kausal_common.api.bulk import BulkListSerializer, BulkModelViewSet, BulkSer
 from kausal_common.api.exceptions import HandleProtectedErrorMixin
 from kausal_common.api.tree import PrevSiblingField, TreebeardModelSerializerMixin
 from kausal_common.api.utils import RegisteredAPIView, register_view_helper
+from kausal_common.datasets.api import I18nFieldSerializerMixin
 from kausal_common.model_images import (
     ModelWithImageSerializerMixin,
     ModelWithImageViewMixin,
@@ -1627,23 +1629,101 @@ class PersonViewSet(ModelWithImageViewMixin, BulkModelViewSet[Person]):
         return queryset.available_for_plan(plan, include_contact_persons=True)
 
 
-class ActionTaskSerializer(serializers.HyperlinkedModelSerializer):
-    included_serializers = {
-        'action': ActionTask,
-    }
-
+class ActionTaskSerializer(I18nFieldSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = ActionTask
-        exclude = ('completed_by',)
+        list_serializer_class = BulkListSerializer
+        fields = public_fields(ActionTask)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        plan = self.context.get('plan')
+        action_field = self.fields.get('action')
+        if plan and action_field:
+            assert isinstance(action_field, RelatedField)
+            action_field.queryset = Action.objects.filter(plan=plan)
 
 
 @register_view
-class ActionTaskViewSet(viewsets.ModelViewSet):
+class ActionTaskViewSet(ViewSetWithPlanContext, BulkModelViewSet[ActionTask]):
     queryset = ActionTask.objects.all()
     serializer_class = ActionTaskSerializer
-    filterset_fields = {
-        'action': ('exact',),
-    }
+
+    def get_permissions(self):
+        permission_classes: list[type[permissions.BasePermission]]
+        if self.action == 'list':
+            permission_classes = [AnonReadOnly]
+        else:
+            permission_classes = [ActionTaskPermission]
+        return [permission() for permission in permission_classes]
+
+    def get_queryset(self):
+        if getattr(self, 'swagger_fake_view', False):
+            # Called during schema generation
+            return ActionTask.objects.none()
+        plan_pk = self.kwargs['plan_pk']
+        plan = PlanViewSet.get_available_plans(request=self.request).filter(id=plan_pk).first()
+        if plan is None:
+            raise exceptions.NotFound(detail='Plan not found')
+        qs = ActionTask.objects.filter(action__plan=plan_pk)
+        action_id = self.request.query_params.get('action')
+        if action_id:
+            qs = qs.filter(action_id=action_id)
+        return qs
+
+
+plan_router.register(
+    'action-tasks',
+    ActionTaskViewSet,
+    basename='action-task',
+)
+action_task_router = NestedBulkRouter(plan_router, 'action-tasks', lookup='action_task')
+all_routers.append(action_task_router)
+
+
+class ActionTaskPermission(permissions.DjangoObjectPermissions):
+    def check_permission(self, user: User, perm: str, plan: Plan, task: ActionTask | None = None):
+        # Check for object permissions first
+        if not user.has_perms([perm]):
+            return False
+        if task:
+            action = task.action
+        else:
+            action = None
+        if perm in (f'actions.{op}_actiontask' for op in ('change', 'add', 'delete')):
+            if not user.can_modify_action(action=action, plan=plan):
+                return False
+        else:
+            return False
+        return True
+
+    def has_permission(self, request: Request, view):
+        plan_pk = view.kwargs.get('plan_pk')
+        if plan_pk:
+            plan = Plan.objects.filter(id=plan_pk).first()
+            if plan is None:
+                raise exceptions.NotFound(detail='Plan not found')
+        else:
+            plan = Plan.objects.get_queryset().live().first()
+            assert plan is not None
+        if request.method is None:
+            return False
+        perms = self.get_required_permissions(request.method, ActionTask)
+        user = user_or_none(request.user)
+        if user is None:
+            return False
+        return all(self.check_permission(user, perm, plan) for perm in perms)
+
+    def has_object_permission(self, request, view, obj):
+        if request.method is None:
+            return False
+        perms = self.get_required_object_permissions(request.method, ActionTask)
+        if not perms and request.method in permissions.SAFE_METHODS:
+            return True
+        user = user_or_none(request.user)
+        if user is None:
+            return False
+        return all(self.check_permission(user, perm, obj.action.plan, obj) for perm in perms)
 
 
 class ScenarioSerializer(serializers.HyperlinkedModelSerializer):

--- a/actions/api.py
+++ b/actions/api.py
@@ -8,6 +8,8 @@ import rest_framework.fields
 from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from modeltrans.translator import get_i18n_field
+from modeltrans.utils import build_localized_fieldname
 from rest_framework import exceptions, permissions, serializers, viewsets
 from rest_framework.relations import RelatedField
 from rest_framework.routers import SimpleRouter
@@ -1629,7 +1631,38 @@ class PersonViewSet(ModelWithImageViewMixin, BulkModelViewSet[Person]):
         return queryset.available_for_plan(plan, include_contact_persons=True)
 
 
-class ActionTaskSerializer(I18nFieldSerializerMixin, serializers.ModelSerializer):
+# FIXME: This is very similar to kausal_common.datasets.api.I18nFieldSerializerMixin
+class I18nFieldPlanLanguagesSerializerMixin:
+    """
+    Add fields for translated strings to serializers whose context contains a plan.
+
+    This adds a field `<field>_<lang>` for every translatable field `<field>` and every language `<lang>` supported by
+    the plan except the primary language (for which there is `<field>`).
+    """
+
+    context: dict[str, Any]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        i18n_field = get_i18n_field(self.Meta.model)  # type: ignore[attr-defined]
+        if not i18n_field:
+            return
+        plan = self.context.get('plan')
+        if not plan:
+            return
+        assert isinstance(plan, Plan)
+        for source_field in i18n_field.fields:
+            if source_field not in self.Meta.fields:  # type: ignore[attr-defined]
+                continue
+            # Add field with language suffix for every non-primary language supported by the plan
+            for lang in plan.other_languages:
+                translated_field = build_localized_fieldname(source_field, lang)
+                self.fields[translated_field] = serializers.CharField(  # type: ignore[attr-defined]
+                    required=False,
+                )
+
+
+class ActionTaskSerializer(I18nFieldPlanLanguagesSerializerMixin, serializers.ModelSerializer):
     class Meta:
         model = ActionTask
         list_serializer_class = BulkListSerializer

--- a/actions/api.py
+++ b/actions/api.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from modeltrans.translator import get_i18n_field
-from modeltrans.utils import build_localized_fieldname
+from modeltrans.utils import build_localized_fieldname, get_available_languages
 from rest_framework import exceptions, permissions, serializers, viewsets
 from rest_framework.relations import RelatedField
 from rest_framework.routers import SimpleRouter
@@ -22,7 +22,6 @@ from kausal_common.api.bulk import BulkListSerializer, BulkModelViewSet, BulkSer
 from kausal_common.api.exceptions import HandleProtectedErrorMixin
 from kausal_common.api.tree import PrevSiblingField, TreebeardModelSerializerMixin
 from kausal_common.api.utils import RegisteredAPIView, register_view_helper
-from kausal_common.datasets.api import I18nFieldSerializerMixin
 from kausal_common.model_images import (
     ModelWithImageSerializerMixin,
     ModelWithImageViewMixin,
@@ -1648,14 +1647,19 @@ class I18nFieldPlanLanguagesSerializerMixin:
         if not i18n_field:
             return
         plan = self.context.get('plan')
-        if not plan:
-            return
-        assert isinstance(plan, Plan)
+        if getattr(self.context.get('view'), 'swagger_fake_view', False):
+            # Called during schema generation
+            assert not plan
+            # Add field with language suffix for every language known to this app
+            languages = get_available_languages()
+        else:
+            assert isinstance(plan, Plan)
+            # Add field with language suffix for every non-primary language supported by the plan
+            languages = plan.other_languages
         for source_field in i18n_field.fields:
             if source_field not in self.Meta.fields:  # type: ignore[attr-defined]
                 continue
-            # Add field with language suffix for every non-primary language supported by the plan
-            for lang in plan.other_languages:
+            for lang in languages:
                 translated_field = build_localized_fieldname(source_field, lang)
                 self.fields[translated_field] = serializers.CharField(  # type: ignore[attr-defined]
                     required=False,
@@ -1663,6 +1667,8 @@ class I18nFieldPlanLanguagesSerializerMixin:
 
 
 class ActionTaskSerializer(I18nFieldPlanLanguagesSerializerMixin, serializers.ModelSerializer):
+    """Serializer for the ActionTask model."""
+
     class Meta:
         model = ActionTask
         list_serializer_class = BulkListSerializer

--- a/actions/api.py
+++ b/actions/api.py
@@ -1683,7 +1683,6 @@ class ActionTaskSerializer(I18nFieldPlanLanguagesSerializerMixin, serializers.Mo
             action_field.queryset = Action.objects.filter(plan=plan)
 
 
-@register_view
 class ActionTaskViewSet(ViewSetWithPlanContext, BulkModelViewSet[ActionTask]):
     queryset = ActionTask.objects.all()
     serializer_class = ActionTaskSerializer

--- a/users/models.py
+++ b/users/models.py
@@ -441,13 +441,14 @@ class User(AbstractUser):
             else:
                 plan = action.plan
 
-        if plan is not None and self.is_general_admin_for_plan(plan):
+        # At this point, `plan` is guaranteed to not be None
+        if self.is_general_admin_for_plan(plan):
             return True
         if action is not None and action.is_merged():
             # Merged actions can only be edited by admins
             return False
-        return self.is_contact_person_for_action(action) \
-            or self.is_organization_admin_for_action(action)
+        return self.is_contact_person_for_action_in_plan(plan, action) \
+            or self.is_organization_admin_for_action(action, plan)
 
     def can_create_action(self, plan: Plan):
         assert plan is not None

--- a/users/models.py
+++ b/users/models.py
@@ -115,7 +115,8 @@ class UserRelatedModelsCache:
     _corresponding_person: Person | None
     _active_admin_plan: Plan
     _adminable_plans: PlanQuerySet
-    _org_admin_for_actions: ActionQuerySet
+    # Key: plan ID (or None to consider actions from all plans)
+    _org_admin_for_actions: dict[int | None, ActionQuerySet]
     _org_admin_for_indicators: IndicatorQuerySet
     _contact_for_actions: set[int]
     _contact_for_indicators: set[int]
@@ -153,7 +154,8 @@ class User(AbstractUser):
     _adminable_plans: models.QuerySet[Plan]
     _instance_visibility_perms: set[InstancesVisibleForMixin.VisibleFor]
     _instance_editable_perms: set[InstancesEditableByMixin.EditableBy]
-    _org_admin_for_actions: ActionQuerySet
+    # Key: plan ID (or None to consider actions from all plans)
+    _org_admin_for_actions: dict[int | None, ActionQuerySet]
     _org_admin_for_indicators: IndicatorQuerySet
     _contact_for_actions: set[int]
     _contact_for_actions_by_role: dict[ActionContactPerson.Role, set[int]]
@@ -305,15 +307,18 @@ class User(AbstractUser):
 
     def is_organization_admin_for_action(self, action: Action | None = None, plan: Plan | None = None):
         cache = self.get_cache()
-        if hasattr(cache, '_org_admin_for_actions'):
-            actions = cache._org_admin_for_actions
+        if not hasattr(cache, '_org_admin_for_actions'):
+            cache._org_admin_for_actions = {}
+        plan_key = plan.id if plan else None
+        if plan_key in cache._org_admin_for_actions:
+            actions = cache._org_admin_for_actions[plan_key]
         else:
             from actions.models import Action
             actions = Action.objects.get_queryset()
             if plan:
                 actions = actions.filter(plan=plan)
             actions = actions.user_is_org_admin_for(self)
-            cache._org_admin_for_actions = actions
+            cache._org_admin_for_actions[plan_key] = actions
         # Ensure below that the actions queryset is evaluated to make
         # the cache efficient (it will use queryset's cache)
         if action is None:
@@ -403,7 +408,7 @@ class User(AbstractUser):
             q = Q(actions__in=self.perms.contact_for_actions)
             q |= Q(indicators__in=self.perms.contact_for_indicators)
             q |= Q(id__in=cache._general_admin_for_plans)
-            q |= Q(actions__in=cache._org_admin_for_actions)
+            q |= Q(actions__in=cache._org_admin_for_actions[None])
             q |= Q(indicators__in=cache._org_admin_for_indicators)
             plans = Plan.objects.qs.filter(q).distinct()
         cache._adminable_plans = plans

--- a/users/models.py
+++ b/users/models.py
@@ -303,13 +303,16 @@ class User(AbstractUser):
         orgs = person.organization_plan_admins.values_list('organization')
         return Organization.objects.filter(id__in=orgs)
 
-    def is_organization_admin_for_action(self, action: Action | None = None):
+    def is_organization_admin_for_action(self, action: Action | None = None, plan: Plan | None = None):
         cache = self.get_cache()
         if hasattr(cache, '_org_admin_for_actions'):
             actions = cache._org_admin_for_actions
         else:
             from actions.models import Action
-            actions = Action.objects.get_queryset().user_is_org_admin_for(self)
+            actions = Action.objects.get_queryset()
+            if plan:
+                actions = actions.filter(plan=plan)
+            actions = actions.user_is_org_admin_for(self)
             cache._org_admin_for_actions = actions
         # Ensure below that the actions queryset is evaluated to make
         # the cache efficient (it will use queryset's cache)


### PR DESCRIPTION
## Description

While writing the action task view set, I noticed that contact persons for a plan can create tasks for actions in a different plan. This seemed to be a problem with the permission code in the `User` class. I included two commits that hopefully fix this without breaking anything else.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce REST endpoints for action tasks with plan-filtered access and translations, and tighten User permission checks to be plan-specific.
> 
> - **API (Backend)**:
>   - **Action Tasks**: Add `ActionTaskSerializer` (bulk-enabled, plan-filtered `action` field) and `ActionTaskViewSet` with list/detail, plan scoping, optional `action` filter, and nested routes under `plan`.
>   - **i18n**: Introduce `I18nFieldPlanLanguagesSerializerMixin` to expose translated fields (`<field>_<lang>`) per plan-supported languages; applied to `ActionTaskSerializer`.
> - **Authorization/Permissions**:
>   - Add `ActionTaskPermission` enforcing `can_modify_action` for add/change/delete within the plan.
>   - Make organization-admin checks plan-aware: cache `_org_admin_for_actions` per plan in `User`, filter by plan, and update `get_adminable_plans` accordingly.
>   - Tighten `User.can_modify_action` to require contact/org-admin status within the specific plan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0deedfa12d1a7ce705ccf98f870d659f5774508b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->