### PR TITLE
Clean up mentions of old names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# aplans
+# Kausal Watch
 
-aplans is a service for administrating and monitoring action plans. It has the following components:
+Kausal Watch is a service for administrating and monitoring action plans. It has the following components:
 
 - admin UI for modifying action plan content
 - REST API for distributing the information

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Build the Kausal extensions:
 
 1. Clone the [kausal-extensions](https://github.com/kausaltech/kausal-extensions) repo
 2. Follow the [kausal-extensions instructions](https://github.com/kausaltech/kausal-extensions#building) to build the client
-3. Create a symlink in the root of kausal-watch-private
+3. Create a symlink in the root of kausal-watch
    ```shell
    ln -s ../kausal-extensions/watch/kausal_watch_extensions .
    ```

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -491,7 +491,7 @@ class RelatedModelWithRolePanel(MultiFieldPanel):
         else:
             for role in _cls.get_roles():
                 # Only show panel for "unspecified" role if there are instances with an unspecified role
-                # https://github.com/kausaltech/kausal-watch-private/pull/111#issuecomment-1896291423
+                # https://github.com/kausaltech/kausal-watch/pull/111#issuecomment-1896291423
                 if role is None and not getattr(action, relation_name).filter(role__isnull=True).exists():
                     continue
                 if role in editable_roles:


### PR DESCRIPTION
Clean up mentions of `kausal-watch-private` and `aplans`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames project references to Kausal Watch, updates README instructions, and fixes an internal comment link.
> 
> - **Docs**:
>   - Rename `aplans` to `Kausal Watch` throughout `README.md` and adjust installation/setup text.
>   - Update symlink instruction to point to `kausal-watch` repo root.
> - **Code**:
>   - Update comment URL in `actions/action_admin.py` to reference `kausal-watch` PR link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd7374f4026741dbf6257e24a759b8652efc1ea0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->