### PR TITLE
Fix issues with attribute visibility in our APIs

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -32,7 +32,7 @@ from aplans.rest_api import PlanRelatedModelSerializer
 from aplans.utils import generate_identifier, public_fields
 
 from actions.models.action import ActionContactPerson, ActionImplementationPhase
-from actions.models.attributes import AttributeType, ModelWithAttributes
+from actions.models.attributes import Attribute, AttributeType, ModelWithAttributes
 from orgs.models import Organization
 from pages.apps import post_reorder_categories
 from people.models import Person, PersonQuerySet
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from rest_framework.request import Request
     from rest_framework.routers import BaseRouter
 
-    from aplans.types import WatchAdminRequest
+    from aplans.types import WatchAdminRequest, WatchAPIRequest
 
     from actions.models.plan import PlanQuerySet
     from users.models import User
@@ -475,6 +475,14 @@ class AttributesSerializerMixin:
     context: dict[str, Any]
     attribute_formats: tuple[AttributeType.AttributeFormat, ...]
 
+    def is_attribute_visible(self, attribute: Attribute) -> bool:
+        request: WatchAPIRequest | None = self.context.get('request')
+        if request is None or not hasattr(request, 'get_active_admin_plan'):
+            return False
+        plan = request.get_active_admin_plan()
+        attribute_holder = attribute.content_object
+        return attribute.type.is_instance_visible_for(request.user, plan, attribute_holder)
+
     # In the serializer, set `attribute_formats` to a tuple of values from `AttributeType.AttributeFormat`
     # (usually just one element)
     def get_fields(self):
@@ -485,12 +493,15 @@ class AttributesSerializerMixin:
             plan = user.get_active_admin_plan()
             attribute_types = plan.action_attribute_types.filter(format__in=self.attribute_formats)
             for attribute_type in attribute_types:
+                if not attribute_type.is_instance_visible_for(user, plan, None):
+                    continue
                 if attribute_type.instance_editability_is_action_specific:
                     # Editability is specific to an action and we don't have one here
                     instances_editable = True
                 else:
                     # Editability is not action-specific, so it's safe to call this
                     instances_editable = attribute_type.is_instance_editable_by(user, plan, None)
+                # FIXME: Why the hell is this a FloatField?
                 fields[attribute_type.identifier] = rest_framework.fields.FloatField(
                     label=attribute_type.name,
                     read_only=not instances_editable,
@@ -578,7 +589,7 @@ class ChoiceAttributesSerializer(AttributesSerializerMixin, serializers.Serializ
     def to_representation(self, value):
         cached = self.get_cached_values()
         values = cached if cached is not None else value.all()
-        return {v.type.identifier: v.choice_id for v in values}
+        return {v.type.identifier: v.choice_id for v in values if self.is_attribute_visible(v)}
 
     def to_internal_value(self, data):
         return data
@@ -596,7 +607,9 @@ class ChoiceWithTextAttributesSerializer(AttributesSerializerMixin, serializers.
     def to_representation(self, value):
         cached = self.get_cached_values()
         values = cached if cached is not None else value.all()
-        return {v.type.identifier: {'choice': v.choice_id, 'text': v.text} for v in values}
+        return {
+            v.type.identifier: {'choice': v.choice_id, 'text': v.text} for v in values if self.is_attribute_visible(v)
+        }
 
     def to_internal_value(self, data):
         return data
@@ -620,7 +633,7 @@ class NumericValueAttributesSerializer(AttributesSerializerMixin, serializers.Se
     def to_representation(self, value):
         cached = self.get_cached_values()
         values = cached if cached is not None else value.all()
-        return {v.type.identifier: v.value for v in values}
+        return {v.type.identifier: v.value for v in values if self.is_attribute_visible(v)}
 
     def to_internal_value(self, data):
         return data
@@ -640,7 +653,7 @@ class TextAttributesSerializer(AttributesSerializerMixin, serializers.Serializer
     def to_representation(self, value):
         cached = self.get_cached_values()
         values = cached if cached is not None else value.all()
-        return {v.type.identifier: v.text for v in values}
+        return {v.type.identifier: v.text for v in values if self.is_attribute_visible(v)}
 
     def to_internal_value(self, data):
         return data
@@ -657,7 +670,7 @@ class RichTextAttributesSerializer(AttributesSerializerMixin, serializers.Serial
     def to_representation(self, value):
         cached = self.get_cached_values()
         values = cached if cached is not None else value.all()
-        return {v.type.identifier: v.text for v in values}
+        return {v.type.identifier: v.text for v in values if self.is_attribute_visible(v)}
 
     def to_internal_value(self, data):
         return data
@@ -674,7 +687,9 @@ class CategoryChoiceAttributesSerializer(AttributesSerializerMixin, serializers.
     def to_representation(self, value):
         cached = self.get_cached_values()
         values = cached if cached is not None else value.all()
-        return {v.type.identifier: [cat.id for cat in v.categories.all()] for v in values}
+        return {
+            v.type.identifier: [cat.id for cat in v.categories.all()] for v in values if self.is_attribute_visible(v)
+        }
 
     def to_internal_value(self, data):
         return data

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -468,8 +468,10 @@ class PlanNode(DjangoNode[Plan]):
         return qs
 
     @staticmethod
-    def resolve_action_attribute_types(root: Plan, _info: GQLInfo):
-        return root.action_attribute_types.order_by('pk')
+    def resolve_action_attribute_types(root: Plan, info: GQLInfo):
+        user = info.context.user
+        attribute_types = root.action_attribute_types.order_by('pk')
+        return [at for at in attribute_types if at.is_instance_visible_for(user, root, None)]
 
     @staticmethod
     def resolve_primary_orgs(root: Plan, _info: GQLInfo) -> OrganizationQuerySet:

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -376,15 +376,8 @@ class InstancesEditableByMixin(models.Model):
         action_specific_values = [self.EditableBy.CONTACT_PERSONS, self.EditableBy.MODERATORS]
         return self.instances_editable_by in action_specific_values
 
-    def is_instance_editable_by(self, user: UserOrAnon, plan: Plan, instance: Model | None):
+    def is_instance_editable_by(self, user: UserOrAnon, plan: Plan, attribute_holder: Model | None):
         from actions.models.action import Action, ActionContactPerson
-        # `action` may only be None if `self.instances_editable_by` is not action-specific
-        if __debug__ and self.instance_editability_is_action_specific and instance is None:
-            msg = (
-                f"instances_editable_by has action-specific value '{self.instances_editable_by}', "
-                                 "but no action has been supplied."
-            )
-            raise AssertionError(msg)
 
         if not user.is_authenticated:  # need to handle this case first, otherwise user does not have expected methods
             return False
@@ -398,12 +391,12 @@ class InstancesEditableByMixin(models.Model):
         if self.instances_editable_by == self.EditableBy.PLAN_ADMINS:
             return is_plan_admin
         if self.instances_editable_by == self.EditableBy.CONTACT_PERSONS:
-            assert isinstance(instance, Action)
-            is_contact_person = user.is_contact_person_for_action(instance)
+            assert isinstance(attribute_holder, Action) or attribute_holder is None
+            is_contact_person = user.is_contact_person_for_action(attribute_holder)
             return is_contact_person or is_plan_admin
         if self.instances_editable_by == self.EditableBy.MODERATORS:
-            assert isinstance(instance, Action)
-            is_moderator = user.has_contact_person_role_for_action(ActionContactPerson.Role.MODERATOR, instance)
+            assert isinstance(attribute_holder, Action) or attribute_holder is None
+            is_moderator = user.has_contact_person_role_for_action(ActionContactPerson.Role.MODERATOR, attribute_holder)
             return is_moderator or is_plan_admin
         if self.instances_editable_by == self.EditableBy.AUTHENTICATED:
             assert user.is_authenticated  # checked above
@@ -451,15 +444,8 @@ class InstancesVisibleForMixin(models.Model):
         action_specific_values = [self.VisibleFor.CONTACT_PERSONS, self.VisibleFor.MODERATORS]
         return self.instances_visible_for in action_specific_values
 
-    def is_instance_visible_for(self, user: UserOrAnon, plan: Plan, instance: Model | None) -> bool:
+    def is_instance_visible_for(self, user: UserOrAnon, plan: Plan, attribute_holder: Model | None) -> bool:
         from actions.models.action import Action, ActionContactPerson
-        # `action` may only be None if `self.instances_visible_for` is not action-specific
-        if __debug__ and self.instance_visibility_is_action_specific and instance is None:
-            msg = (
-                f"instances_visible_for has action-specific value '{self.instances_visible_for}', "
-                                 "but no action has been supplied."
-            )
-            raise AssertionError(msg)
 
         if not user.is_authenticated:  # need to handle this case first, otherwise user does not have expected methods
             return self.instances_visible_for == self.VisibleFor.PUBLIC
@@ -473,12 +459,12 @@ class InstancesVisibleForMixin(models.Model):
         if self.instances_visible_for == self.VisibleFor.PLAN_ADMINS:
             return is_plan_admin
         if self.instances_visible_for == self.VisibleFor.CONTACT_PERSONS:
-            assert isinstance(instance, Action)
-            is_contact_person = user.is_contact_person_for_action(instance)
+            assert isinstance(attribute_holder, Action) or attribute_holder is None
+            is_contact_person = user.is_contact_person_for_action(attribute_holder)
             return is_contact_person or is_plan_admin
         if self.instances_visible_for == self.VisibleFor.MODERATORS:
-            assert isinstance(instance, Action)
-            is_moderator = user.has_contact_person_role_for_action(ActionContactPerson.Role.MODERATOR, instance)
+            assert isinstance(attribute_holder, Action) or attribute_holder is None
+            is_moderator = user.has_contact_person_role_for_action(ActionContactPerson.Role.MODERATOR, attribute_holder)
             return is_moderator or is_plan_admin
         if self.instances_visible_for == self.VisibleFor.PUBLIC:
             return True


### PR DESCRIPTION
The GraphQL field `actionAttributeTypes` in `PlanNode` returned all attribute types, even those whose instances are not visible for the user. In order to avoid showing a column for these attribute types in, e.g., the action grid editor, This commit removes them from `actionAttributeTypes`, which I think is better than filtering in the UI.

In the REST API, our attribute serializers included invisible attributes, which leaks information. This commit fixes that.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters attribute types/values by visibility in REST and GraphQL to prevent exposing invisible attributes.
> 
> - **REST API (actions/api.py)**:
>   - Add `is_attribute_visible()` to `AttributesSerializerMixin` and use it to filter attribute values in all attribute serializers (`choice`, `choice_with_text`, `numeric`, `text`, `rich_text`, `category_choice`).
>   - In `get_fields()`, skip non-visible attribute types and respect editability; expose fields only when visible/editable.
>   - Import `Attribute` and typing for `WatchAPIRequest`.
> - **GraphQL (actions/schema.py)**:
>   - `PlanNode.resolve_action_attribute_types` now returns only attribute types visible to the user/plan.
> - **Core utils (aplans/utils.py)**:
>   - Update `InstancesEditableByMixin.is_instance_editable_by` and `InstancesVisibleForMixin.is_instance_visible_for` signatures to use `attribute_holder` and allow `None`; adjust role checks accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09c978a39cfbe0357fb50ecb37acf62d739b24cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->