### PR TITLE
Validate contact persons and responsible parties in REST API

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1065,12 +1065,36 @@ class ActionSerializer(
         editable_roles = get_editable_roles(action, user)
         return [role for role in roles_with_changes if role not in editable_roles]
 
+    def _get_editable_roles_with_customization[Role](
+        self,
+        action: Action,
+        user: User,
+        field_name: str,
+        get_user_editable_roles: Callable[[User, Action], Iterable[Role]],
+    ) -> Iterable[Role]:
+        """Get editable roles, respecting BuiltInFieldCustomization restrictions."""
+        try:
+            customization = BuiltInFieldCustomization.objects.get(
+                plan=self.plan,
+                content_type=ContentType.objects.get_for_model(Action),
+                field_name=field_name,
+            )
+            is_editable = customization.is_instance_editable_by(user, self.plan, action)
+        except BuiltInFieldCustomization.DoesNotExist:
+            is_editable = True
+        if is_editable:
+            return get_user_editable_roles(user, action)
+        return []
+
     def validate_contact_persons(self, value):
         violating_roles = self._roles_violating_edit_permissions(
             value=value,
             fk_name='person',
             get_existing_objects=lambda action: action.contact_persons.all(),
-            get_editable_roles=lambda action, user: user.get_editable_contact_person_roles(action),
+            get_editable_roles=lambda action, user: self._get_editable_roles_with_customization(
+                action, user, 'contact_persons',
+                lambda u, a: u.get_editable_contact_person_roles(a),
+            ),
         )
         if violating_roles:
             raise serializers.ValidationError(_(
@@ -1079,25 +1103,14 @@ class ActionSerializer(
         return value
 
     def validate_responsible_parties(self, value):
-        def get_editable_roles(action: Action, user: User) -> Iterable[ActionResponsibleParty.Role | None]:
-            try:
-                customization = BuiltInFieldCustomization.objects.get(
-                    plan=self.plan,
-                    content_type=ContentType.objects.get_for_model(Action),
-                    field_name='responsible_parties',
-                )
-                is_editable = customization.is_instance_editable_by(user, self.plan, action)
-            except BuiltInFieldCustomization.DoesNotExist:
-                is_editable = True
-            if is_editable:
-                return user.get_editable_responsible_party_roles(action)
-            return []
-
         violating_roles = self._roles_violating_edit_permissions(
             value=value,
             fk_name='organization',
             get_existing_objects=lambda action: action.responsible_parties.all(),
-            get_editable_roles=get_editable_roles,
+            get_editable_roles=lambda action, user: self._get_editable_roles_with_customization(
+                action, user, 'responsible_parties',
+                lambda u, a: u.get_editable_responsible_party_roles(a),
+            ),
         )
         if violating_roles:
             raise serializers.ValidationError(_(

--- a/actions/api.py
+++ b/actions/api.py
@@ -38,6 +38,7 @@ from aplans.utils import generate_identifier, public_fields
 
 from actions.models.action import ActionContactPerson, ActionImplementationPhase, ActionQuerySet
 from actions.models.attributes import Attribute, AttributeType, ModelWithAttributes
+from admin_site.models import BuiltInFieldCustomization
 from audit_logging.utils import BulkActionModelList
 from orgs.models import Organization
 from pages.apps import post_reorder_categories
@@ -61,7 +62,7 @@ from .models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from django.db.models import Model, QuerySet
     from django.views.generic import View
@@ -1032,6 +1033,76 @@ class ActionSerializer(
         if value in self.context['seen_identifiers']:
             raise serializers.ValidationError(_('Identifier already exists'))
         self.context['seen_identifiers'].append(value)
+        return value
+
+    def _roles_violating_edit_permissions[Role](
+        self,
+        value: list[dict[str, Any]],
+        fk_name: str,
+        get_existing_objects: Callable[[Action], QuerySet],
+        get_editable_roles: Callable[[Action, User], Iterable[Role]],
+    ) -> list[Role]:
+        request: Request | None = self.context.get('request')
+        action = self._instance
+        if request is None or action is None:
+            return []
+        assert isinstance(action, Action)
+        user = user_or_none(request.user)
+        if user is None:
+            return []
+        existing_objects_by_role: dict[Role, list[Model]] = {}
+        for obj in get_existing_objects(action):
+            existing_related_obj = getattr(obj, fk_name)
+            existing_objects_by_role.setdefault(obj.role, []).append(existing_related_obj)
+        new_objects_by_role: dict[Role, list[Model]] = {}
+        for d in value:
+            new_objects_by_role.setdefault(d['role'], []).append(d[fk_name])
+        roles_with_changes = [
+            role
+            for role in existing_objects_by_role.keys() | new_objects_by_role.keys()
+            if set(existing_objects_by_role.get(role, [])) != set(new_objects_by_role.get(role, []))
+        ]
+        editable_roles = get_editable_roles(action, user)
+        return [role for role in roles_with_changes if role not in editable_roles]
+
+    def validate_contact_persons(self, value):
+        violating_roles = self._roles_violating_edit_permissions(
+            value=value,
+            fk_name='person',
+            get_existing_objects=lambda action: action.contact_persons.all(),
+            get_editable_roles=lambda action, user: user.get_editable_contact_person_roles(action),
+        )
+        if violating_roles:
+            raise serializers.ValidationError(_(
+                'You do not have permission to change contact persons with role "%(role)s" on action "%(action)s."'
+            ) % {'role': violating_roles[0], 'action': self._instance})
+        return value
+
+    def validate_responsible_parties(self, value):
+        def get_editable_roles(action: Action, user: User) -> Iterable[ActionResponsibleParty.Role | None]:
+            try:
+                customization = BuiltInFieldCustomization.objects.get(
+                    plan=self.plan,
+                    content_type=ContentType.objects.get_for_model(Action),
+                    field_name='responsible_parties',
+                )
+                is_editable = customization.is_instance_editable_by(user, self.plan, action)
+            except BuiltInFieldCustomization.DoesNotExist:
+                is_editable = True
+            if is_editable:
+                return user.get_editable_responsible_party_roles(action)
+            return []
+
+        violating_roles = self._roles_violating_edit_permissions(
+            value=value,
+            fk_name='organization',
+            get_existing_objects=lambda action: action.responsible_parties.all(),
+            get_editable_roles=get_editable_roles,
+        )
+        if violating_roles:
+            raise serializers.ValidationError(_(
+                'You do not have permission to change responsible parties with role "%(role)s" on action "%(action)s."'
+            ) % {'role': violating_roles[0], 'action': self._instance})
         return value
 
     def create(self, validated_data: dict):

--- a/actions/tests/test_api.py
+++ b/actions/tests/test_api.py
@@ -737,3 +737,87 @@ def test_bulk_action_task_put_creates_individual_log_entries(
     for task in tasks:
         total_logs = count_log_entries(instance=task, plan=plan)
         assert total_logs >= 1, f"Expected at least 1 log entry for task {task.name}"
+
+
+@pytest.mark.parametrize(('field_name', 'role'), [
+    ('contact_persons', 'editor'),  # ActionContactPerson requires a role (no blank allowed)
+    ('responsible_parties', None),  # ActionResponsibleParty allows blank/None role
+])
+def test_action_field_customization_restricts_editing(
+    api_client, plan, action, field_name, role
+):
+    """
+    Test that BuiltInFieldCustomization restrictions are respected in the REST API.
+
+    When a BuiltInFieldCustomization restricts editing of contact_persons or responsible_parties
+    to plan_admins only, regular contact persons should not be able to modify those fields.
+    """
+    from aplans.utils import InstancesEditableByMixin
+
+    from admin_site.tests.factories import BuiltInFieldCustomizationFactory
+
+    # Create a contact person for this action (not a plan admin)
+    contact = ActionContactFactory.create(action=action)
+    user = contact.person.user
+
+    # Create a customization that restricts editing to plan admins only
+    BuiltInFieldCustomizationFactory.create(
+        plan=plan,
+        field_name=field_name,
+        instances_editable_by=InstancesEditableByMixin.EditableBy.PLAN_ADMINS,
+    )
+
+    api_client.force_login(user)
+    url = reverse('action-detail', kwargs={'plan_pk': plan.pk, 'pk': action.pk})
+
+    # Attempt to modify the restricted field
+    if field_name == 'contact_persons':
+        new_person = PersonFactory.create(organization=plan.organization)
+        new_value = [{'person': new_person.pk, 'role': role}]
+    else:  # responsible_parties
+        new_value = [{'organization': plan.organization.pk, 'role': role}]
+
+    response = api_client.patch(url, data={field_name: new_value})
+
+    # Should be rejected because user is only a contact person, not a plan admin
+    assert response.status_code == 400
+    assert 'do not have permission' in response.json_data[field_name][0].lower()
+
+
+@pytest.mark.parametrize(('field_name', 'role'), [
+    ('contact_persons', 'editor'),  # ActionContactPerson requires a role (no blank allowed)
+    ('responsible_parties', None),  # ActionResponsibleParty allows blank/None role
+])
+def test_action_field_customization_allows_plan_admin(
+    api_client, plan, action, field_name, role
+):
+    """Test that plan admins can edit fields even when BuiltInFieldCustomization restricts to plan_admins."""
+
+    from aplans.utils import InstancesEditableByMixin
+
+    from admin_site.tests.factories import BuiltInFieldCustomizationFactory
+
+    # Create a plan admin
+    admin_person = PersonFactory.create(general_admin_plans=[plan])
+
+    # Create a customization that restricts editing to plan admins only
+    BuiltInFieldCustomizationFactory.create(
+        plan=plan,
+        field_name=field_name,
+        instances_editable_by=InstancesEditableByMixin.EditableBy.PLAN_ADMINS,
+    )
+
+    api_client.force_login(admin_person.user)
+    url = reverse('action-detail', kwargs={'plan_pk': plan.pk, 'pk': action.pk})
+
+    # Attempt to modify the restricted field
+    if field_name == 'contact_persons':
+        new_person = PersonFactory.create(organization=plan.organization)
+        new_value = [{'person': new_person.pk, 'role': role}]
+    else:  # responsible_parties
+        new_value = [{'organization': plan.organization.pk, 'role': role}]
+
+    response = api_client.patch(url, data={field_name: new_value})
+
+    # Should succeed because user is a plan admin
+    assert response.status_code == 200


### PR DESCRIPTION
This adds validation to prevent users from changing contact persons or responsible parties without permission.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new permission validation paths on `ActionSerializer` updates/patches; mistakes could inadvertently block legitimate edits or allow unauthorized role changes depending on customization and role-diff logic.
> 
> **Overview**
> Enforces **field-level edit restrictions** for `Action` relationship fields `contact_persons` and `responsible_parties` in the REST API by validating that the user is allowed to modify the specific *roles* being changed.
> 
> The serializer now compares existing vs incoming related objects per role and rejects updates for roles outside the user’s editable set, additionally honoring `BuiltInFieldCustomization` so fields can be made editable only for certain users (e.g., plan admins). Tests cover both rejection for non-admin contact persons and success for plan admins when such customizations are enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 786706ded058ae783f7be4260b6fd4f3061ea82e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->