### PR TITLE
Add targetNodeId to CategoryTypeLevelListBlock

### DIFF
--- a/actions/blocks/category_list.py
+++ b/actions/blocks/category_list.py
@@ -79,6 +79,12 @@ class CategoryTypeLevelListBlock(blocks.StructBlock):
     group_by_category_level = CategoryLevelChooserBlock(
         required=False, label= _("Group by level"),
         help_text=_("Use category level for tabbed grouping in the public UI"))
+    paths_target_node_id = blocks.CharBlock(
+        max_length=200,
+        required=False,
+        verbose_name=_('Kausal Paths target node ID'),
+        help_text=_('Kausal Paths target node ID used to calculate action impacts. If not set, the default outcome node will be used.'),
+    )
 
     class Meta:
         label = _("Category level list")
@@ -89,4 +95,5 @@ class CategoryTypeLevelListBlock(blocks.StructBlock):
         GraphQLForeignKey('category_type', CategoryType, required=True),
         GraphQLForeignKey('category_level', CategoryLevel, required=True),
         GraphQLForeignKey('group_by_category_level', CategoryLevel, required=False),
+        GraphQLString('paths_target_node_id', required=False),
     ]


### PR DESCRIPTION
## Description

Summary
Backend Changes (kausal-watch)
Added paths_target_node_id field to CategoryTypeLevelListBlock in /Users/jouni/devel/kausal-watch/actions/blocks/category_list.py:
CharField (max 200 chars, optional)
Help text explains it's for calculating action impacts
Added to GraphQL fields
Frontend Changes (kausal-watch-ui)
Updated CAUSAL_GRID_NODE_FRAGMENT in /Users/jouni/devel/kausal-watch-ui/src/queries/paths/get-paths-node.ts:
Added targetNodeId: $targetNodeId parameter to impactMetric query
Added $targetNodeId: ID variable to GET_NODE_CONTENT query
Updated component chain to pass targetNodeId:
StreamField.tsx: Extracts pathsTargetNodeId from block and passes it to CategoryTypeListBlock
CategoryTypeListBlock.tsx: Accepts targetNodeId prop and passes it to CategoryCard
CategoryCard.tsx: Accepts targetNodeId prop and passes it to PathsNodeSummary
PathsNodeSummary.tsx: Accepts targetNodeId prop and includes it in the GraphQL query variables
Next Steps
You need to:
Create and run the database migration for the new paths_target_node_id field in kausal-watch:
   cd /Users/jouni/devel/kausal-watch   python manage.py makemigrations actions --name add_paths_target_node_id_to_category_type_level_list_block   python manage.py migrate
Regenerate GraphQL types in kausal-watch-ui (if you're using code generation) so TypeScript recognizes the new field.
Test the changes by:
Setting a paths_target_node_id value in the Wagtail admin for a CategoryTypeLevelListBlock
Verifying that action impacts are calculated using the specified target node
The implementation allows each CategoryTypeLevelListBlock to specify its own target node for calculating action impacts, with a fallback to the default outcome node if not specified.

## Requirements, dependencies and related PRs

There is a related PR in kausal-watch-ui. https://github.com/kausaltech/kausal-watch-ui/pull/589
## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional paths_target_node_id to CategoryTypeLevelListBlock and expose it via GraphQL.
> 
> - **CategoryTypeLevelListBlock (`actions/blocks/category_list.py`)**:
>   - Add optional `paths_target_node_id` `CharBlock` (max 200) to configure Kausal Paths target node for impact calculations.
>   - Expose `paths_target_node_id` via GraphQL (`GraphQLString`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5cf1f478e0900a4ee2e806f0146dcdc283b783. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->