### PR TITLE
Changelogmessage fixes

### DIFF
--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -666,22 +666,17 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
     related_field_name: str
     success_url_name: str
 
-    @property
-    def session_key(self) -> str:
-        return f'change_log_{self.related_field_name}_id'
-
     def get_related_model(self) -> type[models.Model]:
         return self.model._meta.get_field(self.related_field_name).related_model  # type: ignore[return-value]
 
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        if request.method == 'GET':
-            related_id = request.GET.get(self.related_field_name)
-            if related_id:
-                request.session[self.session_key] = related_id
+    def get_related_id(self) -> str | None:
+        """Get related object ID from GET params or POST data (hidden field)."""
+        if self.request.method == 'POST':
+            return self.request.POST.get(self.related_field_name)
+        return self.request.GET.get(self.related_field_name)
 
     def get_related_object(self) -> models.Model | None:
-        related_id = self.request.session.get(self.session_key)
+        related_id = self.get_related_id()
         if related_id:
             return self.get_related_model().objects.filter(pk=related_id).first()  # type: ignore[attr-defined]
         return None
@@ -709,12 +704,6 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
         form.instance.created_by = self.request.user  # type: ignore[attr-defined]
         return form
 
-    def save_instance(self):
-        instance = super().save_instance()
-        if self.session_key in self.request.session:
-            del self.request.session[self.session_key]
-        return instance
-
     def get_skip_url(self) -> str:
         return reverse(self.success_url_name)
 
@@ -728,6 +717,8 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
         context = super().get_context_data(**kwargs)
         context['skip_url'] = self.get_skip_url()
         context['latest_change_log_message'] = self.get_latest_change_log_message()
+        context['related_field_name'] = self.related_field_name
+        context['related_id'] = self.get_related_id()
         return context
 
     def get_success_url(self):
@@ -791,18 +782,16 @@ class BaseChangeLogMessageViewSet[M: models.Model](WatchViewSet[M]):
 class ActionChangeLogMessageCreateView(BaseChangeLogMessageCreateView[ActionChangeLogMessage]):
     related_field_name = 'action'
     success_url_name = 'actions_action_modeladmin_index'
-    revision_session_key = 'change_log_revision_id'
 
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        if request.method == 'GET':
-            revision_id = request.GET.get('revision')
-            if revision_id:
-                request.session[self.revision_session_key] = revision_id
+    def get_revision_id(self) -> str | None:
+        """Get revision ID from GET params or POST data (hidden field)."""
+        if self.request.method == 'POST':
+            return self.request.POST.get('revision')
+        return self.request.GET.get('revision')
 
     def get_form(self, *args, **kwargs):
         form = super().get_form(*args, **kwargs)
-        revision_id = self.request.session.get(self.revision_session_key)
+        revision_id = self.get_revision_id()
         if revision_id:
             from wagtail.models import Revision
             revision = Revision.objects.filter(pk=revision_id).first()
@@ -810,11 +799,10 @@ class ActionChangeLogMessageCreateView(BaseChangeLogMessageCreateView[ActionChan
                 form.instance.revision = revision
         return form
 
-    def save_instance(self):
-        instance = super().save_instance()
-        if self.revision_session_key in self.request.session:
-            del self.request.session[self.revision_session_key]
-        return instance
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['revision_id'] = self.get_revision_id()
+        return context
 
     def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
         if related_obj is None:

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -742,11 +742,11 @@ class BaseChangeLogMessageEditView[M: models.Model](WatchEditView[M]):
         raise NotImplementedError
 
     def dispatch(self, request, *args, **kwargs):
-        response = super().dispatch(request, *args, **kwargs)
+        self.object = self.get_object()
         related_obj = getattr(self.object, self.related_field_name, None)
         if not self.check_related_object_permission(related_obj):
             raise PermissionDenied
-        return response
+        return super().dispatch(request, *args, **kwargs)
 
     def get_success_url(self):
         assert self.object is not None
@@ -761,11 +761,11 @@ class BaseChangeLogMessageDeleteView[M: models.Model](SnippetDeleteView):
         raise NotImplementedError
 
     def dispatch(self, request, *args, **kwargs):
-        response = super().dispatch(request, *args, **kwargs)
+        self.object = self.get_object()
         related_obj = getattr(self.object, self.related_field_name, None)
         if not self.check_related_object_permission(related_obj):
             raise PermissionDenied
-        return response
+        return super().dispatch(request, *args, **kwargs)
 
 
 class BaseChangeLogMessageViewSet[M: models.Model](WatchViewSet[M]):

--- a/templates/aplans/change_log_message_create.html
+++ b/templates/aplans/change_log_message_create.html
@@ -1,6 +1,16 @@
 {% extends "wagtailsnippets/snippets/create.html" %}
 {% load i18n %}
 
+{% block form_content %}
+    {% if related_id %}
+        <input type="hidden" name="{{ related_field_name }}" value="{{ related_id }}">
+    {% endif %}
+    {% if revision_id %}
+        <input type="hidden" name="revision" value="{{ revision_id }}">
+    {% endif %}
+    {{ block.super }}
+{% endblock %}
+
 {% block before_form %}
     {% if latest_change_log_message %}
         <div style="margin-bottom: 1.5rem; padding: 0.75rem; background-color: var(--w-color-surface-page); border: 2px solid var(--w-color-secondary); border-radius: 0.375rem; max-width: 600px;">


### PR DESCRIPTION
## Description
A couple of fixes for changelogmessages:
- super.dispatch should be called after permissions check
- related_id and revision_id as hidden fields instead of session keys to avoid race conditions

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves reliability and permission flow for change log messages.
> 
> - Replace session-based `related_id`/`revision_id` with `GET/POST`-backed getters and hidden inputs in `change_log_message_create.html` to avoid race conditions
> - Perform permission checks before calling `super().dispatch()` in create/edit/delete views by fetching the related object (or `self.object`) first
> - Provide `related_field_name`, `related_id`, and `revision_id` in context and pre-populate form instances accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebed95ac3c7bd4c2889a403ab50ac11f08255258. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->