### PR TITLE
Publish/Unpublish plan as superuser

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import zoneinfo
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import cache
 from typing import TYPE_CHECKING, ClassVar, Self, cast
 from urllib.parse import urlparse
@@ -743,11 +743,12 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         return self.PublicationState.PUBLIC
 
     @property
-    def publication_status_tooltip(self) -> str:
+    def publication_status_description(self) -> str:
         if self.published_at is None:
             return str(self.PublicationState.INTERNAL.label)
 
-        formatted_date = f"{self.published_at.strftime('%Y-%m-%d %H:%M')} (UTC)"
+        utc_time = self.published_at.astimezone(UTC)
+        formatted_date = f"{date_format(utc_time, 'SHORT_DATETIME_FORMAT')} (UTC)"
         now = timezone.now()
 
         if self.published_at > now:

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -728,10 +728,24 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         now = self.now_in_local_timezone()
         return self.published_at is not None and self.published_at <= now and self.archived_at is None
 
+    class PublicationState(models.TextChoices):
+        INTERNAL = 'internal', _('Internal')
+        PUBLIC = 'public', _('Public')
+        SCHEDULED = 'scheduled', _('Scheduled')
+
     @property
-    def publication_status(self) -> str:
+    def publication_state(self) -> PublicationState:
         if self.published_at is None:
-            return str(_('Not published'))
+            return self.PublicationState.INTERNAL
+        now = timezone.now()
+        if self.published_at > now:
+            return self.PublicationState.SCHEDULED
+        return self.PublicationState.PUBLIC
+
+    @property
+    def publication_status_tooltip(self) -> str:
+        if self.published_at is None:
+            return str(self.PublicationState.INTERNAL.label)
 
         formatted_date = f"{self.published_at.strftime('%Y-%m-%d %H:%M')} (UTC)"
         now = timezone.now()
@@ -748,7 +762,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
             else:
                 minutes = delta.seconds // 60
                 time_remaining = _('in %(minutes)d minutes') % {'minutes': minutes}
-            return str(_('Scheduled at: %(date)s, %(remaining)s') % {'date': formatted_date, 'remaining': time_remaining})
+            return str(_('Scheduled at: %(date)s (%(remaining)s)') % {'date': formatted_date, 'remaining': time_remaining})
 
         return formatted_date
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -735,7 +735,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
 
     @property
     def publication_state(self) -> PublicationState:
-        if self.published_at is None:
+        if self.published_at is None or self.archived_at is not None:
             return self.PublicationState.INTERNAL
         now = timezone.now()
         if self.published_at > now:
@@ -744,7 +744,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
 
     @property
     def publication_status_description(self) -> str:
-        if self.published_at is None:
+        if self.published_at is None or self.archived_at is not None:
             return str(self.PublicationState.INTERNAL.label)
 
         utc_time = self.published_at.astimezone(UTC)

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -728,6 +728,30 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         now = self.now_in_local_timezone()
         return self.published_at is not None and self.published_at <= now and self.archived_at is None
 
+    @property
+    def publication_status(self) -> str:
+        if self.published_at is None:
+            return str(_('Not published'))
+
+        formatted_date = f"{self.published_at.strftime('%Y-%m-%d %H:%M')} (UTC)"
+        now = timezone.now()
+
+        if self.published_at > now:
+            delta = self.published_at - now
+            days = delta.days
+            hours = delta.seconds // 3600
+            if days > 0:
+                time_remaining = _('in %(days)d days %(hours)d hours') % {'days': days, 'hours': hours}
+            elif hours > 0:
+                minutes = (delta.seconds % 3600) // 60
+                time_remaining = _('in %(hours)d hours %(minutes)d minutes') % {'hours': hours, 'minutes': minutes}
+            else:
+                minutes = delta.seconds // 60
+                time_remaining = _('in %(minutes)d minutes') % {'minutes': minutes}
+            return str(_('Scheduled at: %(date)s, %(remaining)s') % {'date': formatted_date, 'remaining': time_remaining})
+
+        return formatted_date
+
     def is_visible_for_user(self, user: UserOrAnon | None) -> bool:
         """Use permission policy to check visibility."""
         if self.features.expose_unpublished_plan_only_to_authenticated_user is False:

--- a/actions/tests/test_models.py
+++ b/actions/tests/test_models.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.utils import timezone, translation
+from django.utils.formats import date_format
 from wagtail.models import Locale
 
 import pytest
@@ -559,37 +560,39 @@ class TestPlanPublicationStatus:
         plan.published_at = timezone.now() + timedelta(days=1)
         assert plan.publication_state == Plan.PublicationState.SCHEDULED
 
-    def test_publication_status_tooltip_internal_when_not_published(self, plan):
+    def test_publication_status_description_internal_when_not_published(self, plan):
         plan.published_at = None
-        assert plan.publication_status_tooltip == 'Internal'
+        assert plan.publication_status_description == 'Internal'
 
-    def test_publication_status_tooltip_shows_date_when_published(self, plan):
+    def test_publication_status_description_shows_date_when_published(self, plan):
         plan.published_at = datetime(2025, 6, 15, 14, 30, tzinfo=UTC)
-        assert '2025-06-15 14:30' in plan.publication_status_tooltip
-        assert '(UTC)' in plan.publication_status_tooltip
+        expected_date = date_format(plan.published_at, 'SHORT_DATETIME_FORMAT')
+        assert plan.publication_status_description == f'{expected_date} (UTC)'
+        with translation.override('en'):
+            assert plan.publication_status_description == '06/15/2025 2:30 p.m. (UTC)'
 
-    def test_publication_status_tooltip_shows_time_remaining_days(self, plan):
+    def test_publication_status_description_shows_time_remaining_days(self, plan):
         now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         plan.published_at = now + timedelta(days=2, hours=5)
         with patch('django.utils.timezone.now', return_value=now):
-            tooltip = plan.publication_status_tooltip
+            tooltip = plan.publication_status_description
             assert 'Scheduled at:' in tooltip
             assert '2 days' in tooltip
             assert '5 hours' in tooltip
 
-    def test_publication_status_tooltip_shows_time_remaining_hours(self, plan):
+    def test_publication_status_description_shows_time_remaining_hours(self, plan):
         now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         plan.published_at = now + timedelta(hours=3, minutes=45)
         with patch('django.utils.timezone.now', return_value=now):
-            tooltip = plan.publication_status_tooltip
+            tooltip = plan.publication_status_description
             assert 'Scheduled at:' in tooltip
             assert '3 hours' in tooltip
             assert '45 minutes' in tooltip
 
-    def test_publication_status_tooltip_shows_time_remaining_minutes(self, plan):
+    def test_publication_status_description_shows_time_remaining_minutes(self, plan):
         now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         plan.published_at = now + timedelta(minutes=30)
         with patch('django.utils.timezone.now', return_value=now):
-            tooltip = plan.publication_status_tooltip
+            tooltip = plan.publication_status_description
             assert 'Scheduled at:' in tooltip
             assert '30 minutes' in tooltip

--- a/actions/tests/test_models.py
+++ b/actions/tests/test_models.py
@@ -1,10 +1,11 @@
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
-from django.utils import translation
+from django.utils import timezone, translation
 from wagtail.models import Locale
 
 import pytest
@@ -12,7 +13,7 @@ import pytest
 from aplans.utils import InstancesEditableByMixin, InstancesVisibleForMixin
 
 from actions.attributes import AttributeType
-from actions.models import Action, ActionContactPerson
+from actions.models import Action, ActionContactPerson, Plan
 from actions.tests.factories import (
     ActionContactFactory,
     ActionFactory,
@@ -543,3 +544,52 @@ def test_synchronizing_plan_root_collection(plan_factory):
     plan.save()
     new_plan = plan_factory(name='D')
     new_plan.save()
+
+
+class TestPlanPublicationStatus:
+    def test_publication_state_internal_when_not_published(self, plan):
+        plan.published_at = None
+        assert plan.publication_state == Plan.PublicationState.INTERNAL
+
+    def test_publication_state_public_when_published_in_past(self, plan):
+        plan.published_at = timezone.now() - timedelta(days=1)
+        assert plan.publication_state == Plan.PublicationState.PUBLIC
+
+    def test_publication_state_scheduled_when_published_in_future(self, plan):
+        plan.published_at = timezone.now() + timedelta(days=1)
+        assert plan.publication_state == Plan.PublicationState.SCHEDULED
+
+    def test_publication_status_tooltip_internal_when_not_published(self, plan):
+        plan.published_at = None
+        assert plan.publication_status_tooltip == 'Internal'
+
+    def test_publication_status_tooltip_shows_date_when_published(self, plan):
+        plan.published_at = datetime(2025, 6, 15, 14, 30, tzinfo=UTC)
+        assert '2025-06-15 14:30' in plan.publication_status_tooltip
+        assert '(UTC)' in plan.publication_status_tooltip
+
+    def test_publication_status_tooltip_shows_time_remaining_days(self, plan):
+        now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        plan.published_at = now + timedelta(days=2, hours=5)
+        with patch('django.utils.timezone.now', return_value=now):
+            tooltip = plan.publication_status_tooltip
+            assert 'Scheduled at:' in tooltip
+            assert '2 days' in tooltip
+            assert '5 hours' in tooltip
+
+    def test_publication_status_tooltip_shows_time_remaining_hours(self, plan):
+        now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        plan.published_at = now + timedelta(hours=3, minutes=45)
+        with patch('django.utils.timezone.now', return_value=now):
+            tooltip = plan.publication_status_tooltip
+            assert 'Scheduled at:' in tooltip
+            assert '3 hours' in tooltip
+            assert '45 minutes' in tooltip
+
+    def test_publication_status_tooltip_shows_time_remaining_minutes(self, plan):
+        now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        plan.published_at = now + timedelta(minutes=30)
+        with patch('django.utils.timezone.now', return_value=now):
+            tooltip = plan.publication_status_tooltip
+            assert 'Scheduled at:' in tooltip
+            assert '30 minutes' in tooltip

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, override
+from typing import TYPE_CHECKING, Any, ClassVar, override
 
 from django.contrib.admin.utils import quote
 from django.core.exceptions import PermissionDenied, ValidationError

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Protocol, override
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, override
 
+from django.contrib.admin.utils import quote
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import models, transaction
 from django.db.models import ProtectedError
-from django.urls import re_path, reverse
+from django.shortcuts import redirect
+from django.urls import path, re_path, reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
+from django.views.generic import TemplateView
+from wagtail.admin import messages
 from wagtail.admin.filters import WagtailFilterSet
 from wagtail.admin.messages import validation_error
 from wagtail.admin.panels import (
@@ -18,8 +23,15 @@ from wagtail.admin.panels import (
     TabbedInterface,
 )
 from wagtail.admin.ui.tables import BulkActionsCheckboxColumn, Column
+from wagtail.admin.views.generic.base import (
+    BaseObjectMixin,
+    WagtailAdminTemplateMixin,
+)
+from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.admin.widgets.button import ButtonWithDropdown
 from wagtail.coreutils import capfirst
+from wagtail.log_actions import log
+from wagtail.snippets import widgets as wagtailsnippets_widgets
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import DeleteView as SnippetDeleteView, IndexView, SnippetViewSet
 
@@ -568,6 +580,8 @@ class PlanIndexView(IndexView[Plan]):
     # FIXME: in yet unreleased Wagtail 6.2.X this is the default, so this line can be deleted
     any_permission_required = ['add', 'change', 'delete', 'view']
     permission_required = 'view'
+    publish_url_name: str | None = None
+    unpublish_url_name: str | None = None
     additional_fields_cache: list[str] | None = None
 
     def _get_additional_fields(self) -> list[str]:
@@ -606,6 +620,44 @@ class PlanIndexView(IndexView[Plan]):
     def columns(self):  # type: ignore[override]
         return [c for c in super().columns if not isinstance(c, BulkActionsCheckboxColumn)]
 
+    def get_publish_url(self, instance: Plan) -> str:
+        return reverse(self.publish_url_name, kwargs={'pk': quote(instance.pk)})
+
+    def get_unpublish_url(self, instance: Plan) -> str:
+        return reverse(self.unpublish_url_name, kwargs={'pk': quote(instance.pk)})
+
+    def publish_button(self, instance: Plan):
+        return wagtailsnippets_widgets.SnippetListingButton(
+            url=self.get_publish_url(instance),
+            label=_('Publish'),
+            icon_name='upload',
+            attrs={'aria-label': _('Publish this plan')},
+        )
+
+    def unpublish_button(self, instance: Plan):
+        return wagtailsnippets_widgets.SnippetListingButton(
+            url=self.get_unpublish_url(instance),
+            label=_('Unpublish'),
+            icon_name='download',
+            attrs={'aria-label': _('Unpublish this plan')},
+        )
+
+    def get_list_more_buttons(self, instance: Plan):
+        buttons = list(super().get_list_more_buttons(instance))
+        user = user_or_bust(self.request.user)
+        # TODO: Enable for general admins once ready for customer use
+        # if not user.is_general_admin_for_plan(instance):
+        #     return buttons
+        if not user.is_superuser:
+            return buttons
+
+        if instance.is_live():
+            buttons.append(self.unpublish_button(instance))
+        else:
+            buttons.append(self.publish_button(instance))
+
+        return buttons
+
 
 def clients_for_request(request: HttpRequest):
     if request is None or request.user.is_anonymous:
@@ -627,16 +679,104 @@ class PlanFilter(WagtailFilterSet):
         fields = ['clients__client']
 
 
+class PlanPublishView(
+    BaseObjectMixin[Plan],
+    PermissionCheckedMixin,
+    WagtailAdminTemplateMixin,
+    TemplateView,
+):
+    model = Plan
+    permission_required = 'publish'
+    publish = True
+    template_name = 'aplans/plan_publish_confirmation.html'
+    index_url_name: ClassVar[str | None] = None
+
+    def user_has_permission(self, permission: str) -> bool:
+        user = user_or_bust(self.request.user)
+        # TODO: Enable for general admins once ready for customer use
+        # return user.is_general_admin_for_plan(self.object)
+        return user.is_superuser
+
+    def get_page_title(self):
+        if self.publish:
+            return _("Publish plan")
+        return _("Unpublish plan")
+
+    def get_meta_title(self):
+        if self.publish:
+            msg = _("Confirm publishing %(plan)s")
+        else:
+            msg = _("Confirm unpublishing %(plan)s")
+        return msg % {'plan': self.object}
+
+    def confirmation_message(self):
+        if self.publish:
+            return _("Do you want to publish the plan '%(plan)s'? This will make it publicly accessible.") % {
+                'plan': self.object
+            }
+        return _(
+            "Do you want to unpublish the plan '%(plan)s'? "
+            "This will make it inaccessible to the public."
+        ) % {'plan': self.object}
+
+    def do_publish(self):
+        if self.object.is_live():
+            raise ValueError(_("The plan is already published."))
+        self.object.published_at = timezone.now()
+        self.object.save(update_fields=['published_at'])
+        log(
+            instance=self.object,
+            action='plan.publish',
+            user=self.request.user,
+        )
+
+    def do_unpublish(self):
+        if not self.object.is_live():
+            raise ValueError(_("The plan is already unpublished."))
+        self.object.published_at = None
+        self.object.save(update_fields=['published_at'])
+        log(
+            instance=self.object,
+            action='plan.unpublish',
+            user=self.request.user,
+        )
+
+    def post(self, request, *args, **kwargs):
+        try:
+            if self.publish:
+                self.do_publish()
+            else:
+                self.do_unpublish()
+        except ValueError as e:
+            messages.error(request, str(e))
+            return redirect(self.index_url)
+        if self.publish:
+            msg = _("Plan '%(plan)s' has been published.")
+        else:
+            msg = _("Plan '%(plan)s' has been unpublished.")
+        messages.success(request, msg % {'plan': self.object})
+        return redirect(self.index_url)
+
+    @cached_property
+    def index_url(self):
+        return reverse(self.index_url_name)
+
+
 class PlanViewSet(SnippetViewSet[Plan]):
     model = Plan
     add_to_admin_menu = True
     icon = 'kausal-plan'
     menu_label = _('Plans')
     menu_order = 9000
-    list_display = ['name', 'version_name', 'parent', 'organization', 'clients_as_string']
+    list_display = [
+        'name', 'version_name', 'parent', 'organization', 'clients_as_string',
+        Column('publication_status', label=_('Published at')),
+    ]
     filterset_class = PlanFilter
     list_per_page = None  # disable pagination
     index_view_class = PlanIndexView
+    publish_url_name = 'publish'
+    unpublish_url_name = 'unpublish'
     # Note that we can't use PlanCopyView as copy_view_class because it is not a (snippet) CopyView
 
     # Copied from UserFeedbackViewSet
@@ -667,6 +807,35 @@ class PlanViewSet(SnippetViewSet[Plan]):
             return Plan.objects.qs.none()
         assert isinstance(request.user, User)
         return request.user.get_adminable_plans()
+
+    @property
+    def publish_view(self):
+        return self.construct_view(PlanPublishView, publish=True)
+
+    @property
+    def unpublish_view(self):
+        return self.construct_view(PlanPublishView, publish=False)
+
+    def get_common_view_kwargs(self, **kwargs):
+        return super().get_common_view_kwargs(
+            publish_url_name=self.get_url_name(self.publish_url_name),
+            unpublish_url_name=self.get_url_name(self.unpublish_url_name),
+            **kwargs,
+        )
+
+    def get_urlpatterns(self):
+        urls = super().get_urlpatterns()
+        publish_url = path(
+            f'{self.publish_url_name}/<str:pk>/',
+            view=self.publish_view,
+            name=self.publish_url_name,
+        )
+        unpublish_url = path(
+            f'{self.unpublish_url_name}/<str:pk>/',
+            view=self.unpublish_view,
+            name=self.unpublish_url_name,
+        )
+        return [*urls, publish_url, unpublish_url]
 
 
 register_snippet(PlanViewSet)

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -576,6 +576,29 @@ class ActivePlanNotificationSettingsViewSet(NotificationSettingsViewSet):
 register_snippet(ActivePlanNotificationSettingsViewSet)
 
 
+class PublicationStatusColumn(Column):
+    cell_template_name = "aplans/plan_publication_status_cell.html"
+
+    def __init__(self, name: str = 'publication_status', **kwargs):
+        super().__init__(name, label=_('Publication status'), **kwargs)
+
+    def get_cell_context_data(self, instance: Plan, parent_context):
+        context = super().get_cell_context_data(instance, parent_context)
+        state = instance.publication_state
+        tooltip = instance.publication_status_tooltip
+
+        status_class_map = {
+            Plan.PublicationState.INTERNAL: 'w-status--internal',
+            Plan.PublicationState.PUBLIC: 'w-status--public',
+            Plan.PublicationState.SCHEDULED: 'w-status--scheduled',
+        }
+        context['status_class'] = status_class_map[state]
+        context['status_label'] = state.label
+
+        context['tooltip'] = tooltip
+        return context
+
+
 class PlanIndexView(IndexView[Plan]):
     # FIXME: in yet unreleased Wagtail 6.2.X this is the default, so this line can be deleted
     any_permission_required = ['add', 'change', 'delete', 'view']
@@ -741,6 +764,25 @@ class PlanPublishView(
             user=self.request.user,
         )
 
+    def get_production_urls(self):
+        from actions.models.plan import PlanDomain
+        domains = self.object.domains.filter(
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION
+        )
+        return [f"https://{domain.hostname}" for domain in domains]
+
+    def get_preview_url(self):
+        try:
+            return f"https://{self.object.default_hostname()}"
+        except Exception:
+            return None
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['production_urls'] = self.get_production_urls()
+        context['preview_url'] = self.get_preview_url()
+        return context
+
     def post(self, request, *args, **kwargs):
         try:
             if self.publish:
@@ -770,7 +812,7 @@ class PlanViewSet(SnippetViewSet[Plan]):
     menu_order = 9000
     list_display = [
         'name', 'version_name', 'parent', 'organization', 'clients_as_string',
-        Column('publication_status', label=_('Published at')),
+        PublicationStatusColumn(),
     ]
     filterset_class = PlanFilter
     list_per_page = None  # disable pagination

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -585,7 +585,7 @@ class PublicationStatusColumn(Column):
     def get_cell_context_data(self, instance: Plan, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
         state = instance.publication_state
-        tooltip = instance.publication_status_tooltip
+        tooltip = instance.publication_status_description
 
         status_class_map = {
             Plan.PublicationState.INTERNAL: 'w-status--internal',
@@ -777,10 +777,15 @@ class PlanPublishView(
         except Exception:
             return None
 
+    def is_scheduled(self):
+        return self.object.publication_state == Plan.PublicationState.SCHEDULED
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['production_urls'] = self.get_production_urls()
         context['preview_url'] = self.get_preview_url()
+        context['is_scheduled'] = self.is_scheduled()
+        context['scheduled_info'] = self.object.publication_status_description if self.is_scheduled() else None
         return context
 
     def post(self, request, *args, **kwargs):

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -747,6 +747,7 @@ class PlanPublishView(
             raise ValueError(_("The plan is already published."))
         self.object.published_at = timezone.now()
         self.object.save(update_fields=['published_at'])
+        self.object.invalidate_cache()
         log(
             instance=self.object,
             action='plan.publish',
@@ -758,6 +759,7 @@ class PlanPublishView(
             raise ValueError(_("The plan is already unpublished."))
         self.object.published_at = None
         self.object.save(update_fields=['published_at'])
+        self.object.invalidate_cache()
         log(
             instance=self.object,
             action='plan.unpublish',

--- a/actions/wagtail_hooks.py
+++ b/actions/wagtail_hooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.templatetags.static import static
+from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.site_summary import SummaryItem
 
@@ -11,6 +12,8 @@ from admin_site.wagtail import execute_admin_post_save_tasks
 from . import wagtail_admin  # noqa: F401
 
 if TYPE_CHECKING:
+    from wagtail.log_actions import LogActionRegistry
+
     from laces.typing import RenderContext
 
     from aplans.types import WatchAdminRequest
@@ -45,3 +48,9 @@ def editor_js():
 @hooks.register('after_edit_snippet')
 def after_edit_snippet(request, snippet):
     execute_admin_post_save_tasks(snippet, request.user)
+
+
+@hooks.register('register_log_actions')
+def register_plan_log_actions(actions: LogActionRegistry):
+    actions.register_action('plan.publish', _("Publish plan"), _("Plan published"))
+    actions.register_action('plan.unpublish', _("Unpublish plan"), _("Plan unpublished"))

--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -91,6 +91,10 @@
   color: var(--w-color-warning-100);
 }
 
+.active-plan-live.scheduled {
+  color: #d8b4fe;
+}
+
 .sidebar--slim .active-plan-info {
   display: none;
 }
@@ -207,6 +211,21 @@ section[role='tabpanel'] .help-block:has(> .field-visibility-label) {
   clip: rect(0, 0, 0, 0) !important;
   white-space: nowrap !important;
   border: 0 !important;
+}
+
+.w-status--internal {
+  background-color: var(--w-color-grey-400);
+  color: var(--w-color-white);
+}
+
+.w-status--public {
+  background-color: #fef08a;
+  color: #854d0e;
+}
+
+.w-status--scheduled {
+  background-color: #d8b4fe;
+  color: #6b21a8;
 }
 
 /* Accessibility: Ensure form fields wrap on narrow or zoomed in screens */

--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -32,12 +32,11 @@
             {% endif %}
 
             <div>
-                <span class="active-plan-live {% if active_plan.is_live %}public{% else %}internal{% endif %}">
-                    {% if active_plan.is_live %}
-                        {% trans "Public" %}
-                    {% else %}
-                        {% trans "Internal" %}
-                    {% endif %}
+                <span class="active-plan-live {{ active_plan.publication_state }}"
+                    {% if active_plan.publication_state.value == 'scheduled' %}
+                        style="cursor: pointer;" data-controller="w-tooltip" data-w-tooltip-content-value="{{ active_plan.publication_status_tooltip }}" data-w-tooltip-placement-value="top"
+                    {% endif %}>
+                    {{ active_plan.publication_state.label }}
                 </span>
             </div>
         </div>

--- a/admin_site/templates/wagtailadmin/base.html
+++ b/admin_site/templates/wagtailadmin/base.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load static wagtailimages_tags wagtailadmin_tags sentry %}
+{% load static wagtailimages_tags wagtailadmin_tags sentry plan_tags %}
 {% load i18n %}
 
 
@@ -33,8 +33,8 @@
 
             <div>
                 <span class="active-plan-live {{ active_plan.publication_state }}"
-                    {% if active_plan.publication_state.value == 'scheduled' %}
-                        style="cursor: pointer;" data-controller="w-tooltip" data-w-tooltip-content-value="{{ active_plan.publication_status_tooltip }}" data-w-tooltip-placement-value="top"
+                    {% if active_plan|is_scheduled %}
+                        style="cursor: pointer;" data-controller="w-tooltip" data-w-tooltip-content-value="{{ active_plan.publication_status_description }}" data-w-tooltip-placement-value="top"
                     {% endif %}>
                     {{ active_plan.publication_state.label }}
                 </span>

--- a/admin_site/templatetags/plan_tags.py
+++ b/admin_site/templatetags/plan_tags.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from django import template
+
+from actions.models.plan import Plan
+
+register = template.Library()
+
+
+@register.filter
+def is_scheduled(plan: Plan) -> bool:
+    return plan.publication_state == Plan.PublicationState.SCHEDULED

--- a/templates/aplans/plan_publication_status_cell.html
+++ b/templates/aplans/plan_publication_status_cell.html
@@ -1,0 +1,7 @@
+{% load wagtailadmin_tags %}
+<td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
+    <span class="w-status {{ status_class }}" style="cursor: pointer;" data-controller="w-tooltip" data-w-tooltip-content-value="{{ tooltip }}">
+        {{ status_label }}
+    </span>
+</td>
+

--- a/templates/aplans/plan_publish_confirmation.html
+++ b/templates/aplans/plan_publish_confirmation.html
@@ -14,6 +14,12 @@
             {% block confirmation_message %}
                 <p>{{ view.confirmation_message }}</p>
                 {% if view.publish %}
+                    {% if is_scheduled %}
+                        <div class="help-block help-warning">
+                            <svg class="icon icon-warning icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
+                            {% blocktrans with info=scheduled_info %}This plan is already scheduled for publication: <strong>{{ info }}</strong>. Publishing now will override the scheduled date and make the plan public immediately.{% endblocktrans %}
+                        </div>
+                    {% endif %}
                     {% if production_urls %}
                         <div class="help-block help-info">
                             <svg class="icon icon-info-circle icon" aria-hidden="true"><use href="#icon-info-circle"></use></svg>

--- a/templates/aplans/plan_publish_confirmation.html
+++ b/templates/aplans/plan_publish_confirmation.html
@@ -1,0 +1,36 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{{ view.get_meta_title }}{% endblock %}
+
+{% block content %}
+
+    {% block header %}
+        {% include "wagtailadmin/shared/header.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon="kausal-plan" %}
+    {% endblock %}
+
+    {% block content_main %}
+        <div class="nice-padding">
+            {% block confirmation_message %}
+                <p>{{ view.confirmation_message }}</p>
+                {% if not view.publish %}
+                    <div class="help-block help-critical">
+                        <svg class="icon icon-warning icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
+                        {% trans "Unpublishing this plan will make it inaccessible to the public immediately." %}
+                    </div>
+
+                {% endif %}
+            {% endblock %}
+            <form action="" method="POST">
+                {% csrf_token %}
+                {% if view.publish %}
+                    <input type="submit" value="{% trans 'Yes, publish' %}" class="button button-primary" />
+                {% else %}
+                    <input type="submit" value="{% trans 'Yes, unpublish' %}" class="button button--warning" />
+                {% endif %}
+                <a href="{{ view.index_url }}" class="button button-secondary">{% trans "Cancel" %}</a>
+            </form>
+        </div>
+    {% endblock %}
+{% endblock %}
+

--- a/templates/aplans/plan_publish_confirmation.html
+++ b/templates/aplans/plan_publish_confirmation.html
@@ -13,12 +13,32 @@
         <div class="nice-padding">
             {% block confirmation_message %}
                 <p>{{ view.confirmation_message }}</p>
-                {% if not view.publish %}
+                {% if view.publish %}
+                    {% if production_urls %}
+                        <div class="help-block help-info">
+                            <svg class="icon icon-info-circle icon" aria-hidden="true"><use href="#icon-info-circle"></use></svg>
+                            {% trans "The plan will be published to:" %}
+                            <ul style="margin: 0.5em 0 0 1.5em;">
+                                {% for url in production_urls %}
+                                    <li><strong>{{ url }}</strong></li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% else %}
+                        <div class="help-block help-warning">
+                            <svg class="icon icon-warning icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
+                            {% if preview_url %}
+                                {% blocktrans %}This plan will only be published at <strong>{{ preview_url }}</strong> because no production domains have been configured.{% endblocktrans %}
+                            {% else %}
+                                {% trans "No production domains have been configured for this plan." %}
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                {% else %}
                     <div class="help-block help-critical">
                         <svg class="icon icon-warning icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
                         {% trans "Unpublishing this plan will make it inaccessible to the public immediately." %}
                     </div>
-
                 {% endif %}
             {% endblock %}
             <form action="" method="POST">

--- a/templates/aplans/plan_publish_confirmation.html
+++ b/templates/aplans/plan_publish_confirmation.html
@@ -26,7 +26,7 @@
                             {% trans "The plan will be published to:" %}
                             <ul style="margin: 0.5em 0 0 1.5em;">
                                 {% for url in production_urls %}
-                                    <li><strong>{{ url }}</strong></li>
+                                    <li><strong><a href="{{ url }}" target="_blank">{{ url }}</a></strong></li>
                                 {% endfor %}
                             </ul>
                         </div>
@@ -34,7 +34,7 @@
                         <div class="help-block help-warning">
                             <svg class="icon icon-warning icon" aria-hidden="true"><use href="#icon-warning"></use></svg>
                             {% if preview_url %}
-                                {% blocktrans %}This plan will only be published at <strong>{{ preview_url }}</strong> because no production domains have been configured.{% endblocktrans %}
+                                {% blocktrans %}This plan will only be published at <strong><a href="{{preview_url}}" target="_blank">{{ preview_url }}</a></strong> because no production domains have been configured.{% endblocktrans %}
                             {% else %}
                                 {% trans "No production domains have been configured for this plan." %}
                             {% endif %}


### PR DESCRIPTION
## Description
Ability for superusers to publish and unpublish plans

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1209642985605051

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
The function is available in planindexview in the dropdown behind the 3 dots

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    The function is available in planindexview in the dropdown behind the 3 dots

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces end-to-end plan publishing controls and visibility in Wagtail.
> 
> - Adds `Plan.PublicationState` and `publication_status_description` to `actions/models/plan.py` to compute Internal/Public/Scheduled states with UTC-formatted tooltips; updates tests
> - Wagtail admin: new `PublicationStatusColumn` in `PlanViewSet` list with tooltip badges; superuser-only `publish`/`unpublish` buttons and routes via `PlanPublishView` with confirmation screen and cache invalidation
> - Registers log actions `plan.publish` and `plan.unpublish` in `actions/wagtail_hooks.py`
> - UI: status badge styles in `admin_site/static/css/admin-styles.css`, base template shows current plan publication state with optional tooltip; adds `plan_tags.is_scheduled` filter
> - New templates: `templates/aplans/plan_publication_status_cell.html`, `templates/aplans/plan_publish_confirmation.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8717e975a943f6ab6d37a33ec31f2486d20c561f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->