### PR TITLE
Small change history language and UI fixes

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1182,7 +1182,7 @@ class Action(
             cp.person = cp.person.get_redacted_copy(plan)
         return visible_contact_persons
 
-    def get_public_change_log_message(self) -> ActionChangeLogMessage | None:
+    def get_public_change_log_message(self) -> BaseChangeLogMessage | None:
         if not self.live_revision:
             return None
         # When publishing, Wagtail creates a new revision, but the previous revision's id

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1931,7 +1931,7 @@ class ActionLink(ActionRelatedModelTransModelMixin, OrderedModel):
 class BaseChangeLogMessage(models.Model):
     content = models.TextField(
         verbose_name=_('content'),
-        help_text=_('Summarize what was changed. This message will be displayed publicly.'),
+        help_text=_('Please summarize the change you made. This message will be displayed publicly.'),
     )
 
     created_at = models.DateTimeField(

--- a/actions/models/category.py
+++ b/actions/models/category.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from kausal_common.models.types import MLMM, RevMany
     from kausal_common.users import UserOrAnon
 
+    from actions.models.action import BaseChangeLogMessage
     from actions.models.plan import Plan
     from indicators.models import Indicator
     from pages.models import CategoryPage, CategoryTypePage, CategoryTypePageLevelLayout
@@ -529,7 +530,7 @@ class Category(ModelWithAttributes, CategoryBase, ClusterableModel, PlanRelatedM
         # we do nothing here.
         pass
 
-    def get_public_change_log_message(self):
+    def get_public_change_log_message(self) -> BaseChangeLogMessage | None:
         from actions.models import CategoryChangeLogMessage
         return CategoryChangeLogMessage.objects.filter(category=self).order_by('-created_at').first()
 

--- a/actions/models/features.py
+++ b/actions/models/features.py
@@ -141,7 +141,7 @@ class PlanFeatures(PlanRelatedModelWithRevision):
         help_text=_("Should indicators open only in a modal dialog in the public UI?"),
     )
     enable_change_log = models.BooleanField(
-        default=False, verbose_name=_("Enable change log"),
+        default=False, verbose_name=_("Enable change history messages"),
         help_text=_("Prompt users to add a public change log message after editing actions, indicators, or categories."),
     )
 

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1204,7 +1204,9 @@ class ChangeLogMessageInterface(graphene.Interface[T], Generic[T]):
         return None
 
     @staticmethod
-    def resolve_created_by(root: BaseChangeLogMessage, _info: GQLInfo) -> Person:
+    def resolve_created_by(root: BaseChangeLogMessage, _info: GQLInfo) -> Person | None:
+        if root.created_by is None:
+            return None
         return root.created_by.person
 
 

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -693,8 +693,8 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
     def get_page_subtitle(self):
         related_obj = self.get_related_object()
         if related_obj is not None:
-            return pgettext_lazy('page subtitle', 'Change log message: %(obj)s') % {'obj': related_obj}
-        return pgettext_lazy('page subtitle', 'Change log message')
+            return pgettext_lazy('page subtitle', 'Change history message: %(obj)s') % {'obj': related_obj}
+        return pgettext_lazy('page subtitle', 'Change history message')
 
     def get_form(self, *args, **kwargs):
         form = super().get_form(*args, **kwargs)
@@ -762,7 +762,7 @@ class BaseChangeLogMessageDeleteView[M: models.Model](SnippetDeleteView):
 class BaseChangeLogMessageViewSet[M: models.Model](WatchViewSet[M]):
     add_to_admin_menu = False
     icon = 'doc-full'
-    page_title = pgettext_lazy('page title', 'Add change log message')
+    page_title = pgettext_lazy('page title', 'Add change history message')
     plan_filter_path: str
     create_template_name = 'aplans/change_log_message_create.html'
 
@@ -831,7 +831,7 @@ class ActionChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[ActionChan
 
 class ActionChangeLogMessageViewSet(BaseChangeLogMessageViewSet[ActionChangeLogMessage]):
     model = ActionChangeLogMessage
-    menu_label = pgettext_lazy('menu label', 'Action change log messages')
+    menu_label = pgettext_lazy('menu label', 'Action change history messages')
     plan_filter_path = 'action__plan'
     add_view_class = ActionChangeLogMessageCreateView
     edit_view_class = ActionChangeLogMessageEditView
@@ -872,7 +872,7 @@ class IndicatorChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[Indicat
 
 class IndicatorChangeLogMessageViewSet(BaseChangeLogMessageViewSet[IndicatorChangeLogMessage]):
     model = IndicatorChangeLogMessage
-    menu_label = pgettext_lazy('menu label', 'Indicator change log messages')
+    menu_label = pgettext_lazy('menu label', 'Indicator change history messages')
     plan_filter_path = 'indicator__plans'
     add_view_class = IndicatorChangeLogMessageCreateView
     edit_view_class = IndicatorChangeLogMessageEditView
@@ -913,7 +913,7 @@ class CategoryChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[Category
 
 class CategoryChangeLogMessageViewSet(BaseChangeLogMessageViewSet[CategoryChangeLogMessage]):
     model = CategoryChangeLogMessage
-    menu_label = pgettext_lazy('menu label', 'Category change log messages')
+    menu_label = pgettext_lazy('menu label', 'Category change history messages')
     plan_filter_path = 'category__type__plan'
     add_view_class = CategoryChangeLogMessageCreateView
     edit_view_class = CategoryChangeLogMessageEditView

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from functools import cached_property
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol, override
 
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import models, transaction
@@ -35,7 +35,7 @@ from kausal_common.users import user_or_bust
 from aplans.context_vars import ctx_instance, ctx_request
 
 from actions.chooser import CategoryTypeChooser, PlanChooser
-from actions.models.action import ActionSchedule
+from actions.models.action import ActionSchedule, BaseChangeLogMessage
 from admin_site.chooser import ClientChooser
 from admin_site.menu import PlanSpecificSingletonModelMenuItem
 from admin_site.mixins import SuccessUrlEditPageMixin
@@ -53,6 +53,7 @@ from admin_site.wagtail import (
     insert_model_translation_panels,
 )
 from copying.views import PlanCopyView
+from indicators.models import Indicator
 from notifications.models import NotificationSettings
 from orgs.chooser import OrganizationChooser
 from orgs.models import Organization
@@ -65,9 +66,11 @@ from . import (
     category_admin,  # noqa: F401
 )
 from .models import (
+    Action,
     ActionChangeLogMessage,
     ActionImpact,
     ActionStatus,
+    Category,
     CategoryChangeLogMessage,
     IndicatorChangeLogMessage,
     Plan,
@@ -662,12 +665,13 @@ class PlanViewSet(SnippetViewSet[Plan]):
 register_snippet(PlanViewSet)
 
 
-class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
+class ObjectWithPublicChangeLogMessage(Protocol):
+    def get_public_change_log_message(self) -> BaseChangeLogMessage | None: ...
+
+
+class BaseChangeLogMessageCreateView[M: models.Model, RelatedModel: ObjectWithPublicChangeLogMessage](WatchCreateView[M]):
     related_field_name: str
     success_url_name: str
-
-    def get_related_model(self) -> type[models.Model]:
-        return self.model._meta.get_field(self.related_field_name).related_model  # type: ignore[return-value]
 
     def get_related_id(self) -> str | None:
         """Get related object ID from GET params or POST data (hidden field)."""
@@ -675,13 +679,23 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
             return self.request.POST.get(self.related_field_name)
         return self.request.GET.get(self.related_field_name)
 
-    def get_related_object(self) -> models.Model | None:
+    def get_related_object(self) -> RelatedModel | None:
         related_id = self.get_related_id()
-        if related_id:
-            return self.get_related_model().objects.filter(pk=related_id).first()  # type: ignore[attr-defined]
-        return None
+        if not related_id:
+            return None
+        related_object = self.get_related_object_by_pk(related_id)
+        return related_object
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def get_latest_change_log_message(self) -> BaseChangeLogMessage | None:
+        related_object = self.get_related_object()
+        if related_object is None:
+            return None
+        return related_object.get_public_change_log_message()
+
+    def get_related_object_by_pk(self, _pk: str) -> RelatedModel | None:
+        raise NotImplementedError
+
+    def check_related_object_permission(self, _related_obj: RelatedModel | None) -> bool:
         raise NotImplementedError
 
     def dispatch(self, request, *args, **kwargs):
@@ -707,12 +721,6 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
     def get_skip_url(self) -> str:
         return reverse(self.success_url_name)
 
-    def get_latest_change_log_message(self):
-        related_obj = self.get_related_object()
-        if related_obj is None:
-            return None
-        return related_obj.get_public_change_log_message()
-
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['skip_url'] = self.get_skip_url()
@@ -725,11 +733,11 @@ class BaseChangeLogMessageCreateView[M: models.Model](WatchCreateView[M]):
         return reverse(self.success_url_name)
 
 
-class BaseChangeLogMessageEditView[M: models.Model](WatchEditView[M]):
+class BaseChangeLogMessageEditView[M: models.Model, RelatedModel: ObjectWithPublicChangeLogMessage](WatchEditView[M]):
     related_field_name: str
     success_url_name: str
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, _related_obj: RelatedModel | None) -> bool:
         raise NotImplementedError
 
     def dispatch(self, request, *args, **kwargs):
@@ -745,10 +753,10 @@ class BaseChangeLogMessageEditView[M: models.Model](WatchEditView[M]):
         return reverse(self.success_url_name, args=[related_obj.pk])
 
 
-class BaseChangeLogMessageDeleteView[M: models.Model](SnippetDeleteView):
+class BaseChangeLogMessageDeleteView[M: models.Model, RelatedModel: ObjectWithPublicChangeLogMessage](SnippetDeleteView):
     related_field_name: str
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, _related_obj: RelatedModel | None) -> bool:
         raise NotImplementedError
 
     def dispatch(self, request, *args, **kwargs):
@@ -779,9 +787,16 @@ class BaseChangeLogMessageViewSet[M: models.Model](WatchViewSet[M]):
         return qs.filter(**{self.plan_filter_path: plan})
 
 
-class ActionChangeLogMessageCreateView(BaseChangeLogMessageCreateView[ActionChangeLogMessage]):
+class ActionChangeLogMessageCreateView(BaseChangeLogMessageCreateView[ActionChangeLogMessage, Action]):
     related_field_name = 'action'
     success_url_name = 'actions_action_modeladmin_index'
+
+    @override
+    def get_related_object_by_pk(self, pk: str) -> Action | None:
+        try:
+            return Action.objects.get(pk=pk)
+        except Action.DoesNotExist:
+            return None
 
     def get_revision_id(self) -> str | None:
         """Get revision ID from GET params or POST data (hidden field)."""
@@ -804,29 +819,29 @@ class ActionChangeLogMessageCreateView(BaseChangeLogMessageCreateView[ActionChan
         context['revision_id'] = self.get_revision_id()
         return context
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Action | None) -> bool:
         if related_obj is None:
             return False
-        return user_or_bust(self.request.user).can_modify_action(action=related_obj)  # type: ignore[arg-type]
+        return user_or_bust(self.request.user).can_modify_action(action=related_obj)
 
 
-class ActionChangeLogMessageEditView(BaseChangeLogMessageEditView[ActionChangeLogMessage]):
+class ActionChangeLogMessageEditView(BaseChangeLogMessageEditView[ActionChangeLogMessage, Action]):
     related_field_name = 'action'
     success_url_name = 'actions_action_modeladmin_edit'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Action | None) -> bool:
         if related_obj is None:
             return False
-        return user_or_bust(self.request.user).can_modify_action(action=related_obj)  # type: ignore[arg-type]
+        return user_or_bust(self.request.user).can_modify_action(action=related_obj)
 
 
-class ActionChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[ActionChangeLogMessage]):
+class ActionChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[ActionChangeLogMessage, Action]):
     related_field_name = 'action'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Action | None) -> bool:
         if related_obj is None:
             return False
-        return user_or_bust(self.request.user).can_modify_action(action=related_obj)  # type: ignore[arg-type]
+        return user_or_bust(self.request.user).can_modify_action(action=related_obj)
 
 
 class ActionChangeLogMessageViewSet(BaseChangeLogMessageViewSet[ActionChangeLogMessage]):
@@ -841,30 +856,36 @@ class ActionChangeLogMessageViewSet(BaseChangeLogMessageViewSet[ActionChangeLogM
 register_snippet(ActionChangeLogMessageViewSet)
 
 
-class IndicatorChangeLogMessageCreateView(BaseChangeLogMessageCreateView[IndicatorChangeLogMessage]):
+class IndicatorChangeLogMessageCreateView(BaseChangeLogMessageCreateView[IndicatorChangeLogMessage, Indicator]):
     related_field_name = 'indicator'
     success_url_name = 'indicators_indicator_modeladmin_index'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def get_related_object_by_pk(self, pk: str) -> Indicator | None:
+        try:
+            return Indicator.objects.get(pk=pk)
+        except Indicator.DoesNotExist:
+            return None
+
+    def check_related_object_permission(self, related_obj: Indicator | None) -> bool:
         if related_obj is None:
             return False
         return user_or_bust(self.request.user).can_modify_indicator(indicator=related_obj)
 
 
-class IndicatorChangeLogMessageEditView(BaseChangeLogMessageEditView[IndicatorChangeLogMessage]):
+class IndicatorChangeLogMessageEditView(BaseChangeLogMessageEditView[IndicatorChangeLogMessage, Indicator]):
     related_field_name = 'indicator'
     success_url_name = 'indicators_indicator_modeladmin_edit'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Indicator | None) -> bool:
         if related_obj is None:
             return False
         return user_or_bust(self.request.user).can_modify_indicator(indicator=related_obj)
 
 
-class IndicatorChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[IndicatorChangeLogMessage]):
+class IndicatorChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[IndicatorChangeLogMessage, Indicator]):
     related_field_name = 'indicator'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Indicator | None) -> bool:
         if related_obj is None:
             return False
         return user_or_bust(self.request.user).can_modify_indicator(indicator=related_obj)
@@ -882,30 +903,36 @@ class IndicatorChangeLogMessageViewSet(BaseChangeLogMessageViewSet[IndicatorChan
 register_snippet(IndicatorChangeLogMessageViewSet)
 
 
-class CategoryChangeLogMessageCreateView(BaseChangeLogMessageCreateView[CategoryChangeLogMessage]):
+class CategoryChangeLogMessageCreateView(BaseChangeLogMessageCreateView[CategoryChangeLogMessage, Category]):
     related_field_name = 'category'
     success_url_name = 'actions_category_modeladmin_index'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def get_related_object_by_pk(self, pk: str) -> Category | None:
+        try:
+            return Category.objects.get(pk=pk)
+        except Category.DoesNotExist:
+            return None
+
+    def check_related_object_permission(self, related_obj: Category | None) -> bool:
         if related_obj is None:
             return False
         return user_or_bust(self.request.user).can_modify_category(category=related_obj)
 
 
-class CategoryChangeLogMessageEditView(BaseChangeLogMessageEditView[CategoryChangeLogMessage]):
+class CategoryChangeLogMessageEditView(BaseChangeLogMessageEditView[CategoryChangeLogMessage, Category]):
     related_field_name = 'category'
     success_url_name = 'actions_category_modeladmin_edit'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Category | None) -> bool:
         if related_obj is None:
             return False
         return user_or_bust(self.request.user).can_modify_category(category=related_obj)
 
 
-class CategoryChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[CategoryChangeLogMessage]):
+class CategoryChangeLogMessageDeleteView(BaseChangeLogMessageDeleteView[CategoryChangeLogMessage, Category]):
     related_field_name = 'category'
 
-    def check_related_object_permission(self, related_obj: models.Model | None) -> bool:
+    def check_related_object_permission(self, related_obj: Category | None) -> bool:
         if related_obj is None:
             return False
         return user_or_bust(self.request.user).can_modify_category(category=related_obj)
@@ -954,7 +981,7 @@ class ActivePlanModelAdminPermissionHelper(PermissionHelper):
 # ModelAdmin. Use that when implementing new classes or migrating away from
 # ModelAdmin. Remove this class when ModelAdmin migration is finished.
 class PlanSpecificSingletonModelAdminMenuItem(ModelAdminMenuItem):
-    def get_one_to_one_field(self, plan):
+    def get_one_to_one_field(self, _plan):
         # Implement in subclass
         raise NotImplementedError()
 

--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -53,6 +53,7 @@ if typing.TYPE_CHECKING:
     from aplans.types import WatchRequest
 
     from actions.models import Action
+    from actions.models.action import BaseChangeLogMessage
     from actions.models.category import Category, CategoryType
     from actions.models.plan import Plan, PlanQuerySet
     from indicators.models.action_links import ActionIndicator
@@ -417,7 +418,7 @@ class Indicator(
         level = self.levels.filter(plan=plan).first()
         return level.level if level is not None else None
 
-    def get_public_change_log_message(self):
+    def get_public_change_log_message(self) -> BaseChangeLogMessage | None:
         from actions.models import IndicatorChangeLogMessage
         return IndicatorChangeLogMessage.objects.filter(indicator=self).order_by('-created_at').first()
 

--- a/indicators/schema.py
+++ b/indicators/schema.py
@@ -14,7 +14,7 @@ from kausal_common.graphene.graphql_helpers import UpdateModelInstanceMutation
 from aplans.graphql_types import DjangoNode, get_plan_from_context, order_queryset, register_django_node
 from aplans.utils import RestrictedVisibilityModel, public_fields
 
-from actions.models import Action, IndicatorChangeLogMessage
+from actions.models import Action
 from actions.schema import ScenarioNode
 from indicators.models import (
     ActionIndicator,
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
     from aplans.graphql_types import GQLInfo
 
-    from actions.models.action import ActionQuerySet
+    from actions.models.action import ActionQuerySet, BaseChangeLogMessage
     from actions.models.plan import Plan, PlanQuerySet
 
 
@@ -363,7 +363,7 @@ class IndicatorNode(DjangoNode[Indicator]):
         return plans.visible_for_user(info.context.user)
 
     @staticmethod
-    def resolve_change_log_message(root: Indicator, _info: GQLInfo) -> IndicatorChangeLogMessage | None:
+    def resolve_change_log_message(root: Indicator, _info: GQLInfo) -> BaseChangeLogMessage | None:
         return root.get_public_change_log_message()
 
 

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Danish <https://weblate.kausal.tech/projects/watch/django/da/>\n"
@@ -1352,7 +1352,7 @@ msgstr "stat"
 msgid "comment"
 msgstr "kommentar"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "Afleveringsdato"
 
@@ -1441,7 +1441,7 @@ msgid "content"
 msgstr "indhold"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -2077,9 +2077,9 @@ msgstr "Indstil om kontaktpersonerne skal være synlige i den offentlige brugerg
 
 #: actions/models/features.py
 #, fuzzy
-#| msgid "Save changes"
-msgid "Enable change log"
-msgstr "Gem ændringer"
+#| msgid "category levels"
+msgid "Enable change history messages"
+msgstr "kategoriniveauer"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2694,42 +2694,42 @@ msgstr "Planer"
 #, fuzzy, python-format
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Ændringer blev gemt"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "Ændringer blev gemt"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Ændringer blev gemt"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Handlingsplaner"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicator list page"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Indikatorer tildelt mig"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Category type pages"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Kategoritype sider"
 
 #: admin_site/api.py
@@ -6043,12 +6043,6 @@ msgstr "Andre ansvarlige"
 
 #: reports/spreadsheets/action_print_layout.py
 #, fuzzy
-#| msgid "action link"
-msgid "Page"
-msgstr "handlingslink"
-
-#: reports/spreadsheets/action_print_layout.py
-#, fuzzy
 msgid "Profiles"
 msgstr "Profiler"
 
@@ -6202,8 +6196,10 @@ msgid "Report types"
 msgstr "Rapporttyper"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "Changes were saved"
+msgid "Current change history message"
+msgstr "Ændringer blev gemt"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -6253,6 +6249,16 @@ msgstr "Brugere"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Ingen tilladelse til at fjerne den bruger, der tilhører planer, du ikke administrerer."
+
+#, fuzzy
+#~| msgid "Save changes"
+#~ msgid "Enable change log"
+#~ msgstr "Gem ændringer"
+
+#, fuzzy
+#~| msgid "action link"
+#~ msgid "Page"
+#~ msgstr "handlingslink"
 
 #, fuzzy
 #~| msgid "Last modified"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -10,11 +10,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
-"PO-Revision-Date: 2026-01-02 15:15+0000\n"
+"POT-Creation-Date: 2026-01-07 09:29+0200\n"
+"PO-Revision-Date: 2026-01-07 09:29+0200\n"
 "Last-Translator: Bernhard Bliem <bernhard.bliem@kausal.tech>\n"
-"Language-Team: German <https://weblate.kausal.tech/projects/watch/django/de/>"
-"\n"
+"Language-Team: German <https://weblate.kausal.tech/projects/watch/django/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1218,7 +1217,7 @@ msgstr "Status"
 msgid "comment"
 msgstr "Kommentar"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "Frist"
 
@@ -1305,7 +1304,7 @@ msgid "content"
 msgstr "Inhalt"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr "Fassen Sie die vorgenommene Änderung zusammen. Diese Nachricht wird öffentlich angezeigt."
 
 #: actions/models/action.py aplans/utils.py
@@ -1850,14 +1849,15 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr "Sollen Indikatoren in der öffentlichen Benutzeroberfläche nur in einem modalen Dialogfeld geöffnet werden?"
 
 #: actions/models/features.py
-msgid "Enable change log"
-msgstr "Änderungsprotokoll aktivieren"
+#, fuzzy
+#| msgctxt "menu label"
+#| msgid "Category change history messages"
+msgid "Enable change history messages"
+msgstr "Einträge im Kategorieänderungsprotokoll"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
-msgstr ""
-"Fordere Benutzer auf, nach der Bearbeitung von Maßnahmen, Indikatoren oder "
-"Kategorien einen öffentlichen Eintrag im Änderungsprotokoll hinzuzufügen."
+msgstr "Fordere Benutzer auf, nach der Bearbeitung von Maßnahmen, Indikatoren oder Kategorien einen öffentlichen Eintrag im Änderungsprotokoll hinzuzufügen."
 
 #: actions/models/features.py
 msgid "plan feature"
@@ -2408,32 +2408,32 @@ msgstr "Pläne"
 #: actions/wagtail_admin.py
 #, python-format
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Eintrag im Änderungsprotokoll: %(obj)s"
 
 #: actions/wagtail_admin.py
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "Eintrag im Änderungsprotokoll"
 
 #: actions/wagtail_admin.py
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Eintrag im Änderungsprotokoll hinzufügen"
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Einträge im Maßnahmenänderungsprotokoll"
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Einträge im Indikatoränderungsprotokoll"
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Einträge im Kategorieänderungsprotokoll"
 
 #: admin_site/api.py
@@ -5343,10 +5343,6 @@ msgid "Other responsible parties"
 msgstr "Andere Verantwortliche"
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr "Seite"
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr "Steckbriefe"
 
@@ -5483,7 +5479,7 @@ msgid "Report types"
 msgstr "Berichtstypen"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
+msgid "Current change history message"
 msgstr "Aktuelle Änderungsnotiz"
 
 #: templates/aplans/change_log_message_create.html
@@ -5529,6 +5525,12 @@ msgstr "Benutzer"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Keine Berechtigung zum Entfernen von Benutzern, die zu Plänen gehören, die Sie nicht verwalten."
+
+#~ msgid "Enable change log"
+#~ msgstr "Änderungsprotokoll aktivieren"
+
+#~ msgid "Page"
+#~ msgstr "Seite"
 
 #~ msgid "Last modified at"
 #~ msgstr "Zuletzt geändert am"

--- a/locale/de_CH/LC_MESSAGES/django.po
+++ b/locale/de_CH/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: German (Switzerland) <https://weblate.kausal.tech/projects/watch/django/de_CH/>\n"
@@ -1247,7 +1247,7 @@ msgstr ""
 msgid "comment"
 msgstr ""
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgid "content"
 msgstr ""
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1905,8 +1905,10 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr ""
 
 #: actions/models/features.py
-msgid "Enable change log"
-msgstr ""
+#, fuzzy
+#| msgid "action schedules"
+msgid "Enable change history messages"
+msgstr "Massnahmenzeitpläne"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2488,42 +2490,42 @@ msgstr ""
 #, fuzzy, python-format
 #| msgid "action schedules"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Massnahmenzeitpläne"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "action schedules"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "Massnahmenzeitpläne"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Massnahmenzeitpläne"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Massnahmenzeitpläne"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicator for actions"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Indikator für Massnahmen"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "action schedules"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Massnahmenzeitpläne"
 
 #: admin_site/api.py
@@ -5549,10 +5551,6 @@ msgid "Other responsible parties"
 msgstr ""
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr ""
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5689,8 +5687,10 @@ msgid "Report types"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "action schedules"
+msgid "Current change history message"
+msgstr "Massnahmenzeitpläne"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"

--- a/locale/django.pot
+++ b/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:29+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "comment"
 msgstr ""
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgid "content"
 msgstr ""
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1846,7 +1846,7 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr ""
 
 #: actions/models/features.py
-msgid "Enable change log"
+msgid "Enable change history messages"
 msgstr ""
 
 #: actions/models/features.py
@@ -2396,32 +2396,32 @@ msgstr ""
 #: actions/wagtail_admin.py
 #, python-format
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr ""
 
 #: admin_site/api.py
@@ -5319,10 +5319,6 @@ msgid "Other responsible parties"
 msgstr ""
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr ""
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5459,7 +5455,7 @@ msgid "Report types"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
+msgid "Current change history message"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Greek <https://weblate.kausal.tech/projects/watch/django/el/>\n"
@@ -1267,7 +1267,7 @@ msgstr "κράτος"
 msgid "comment"
 msgstr "σχόλιο"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "ημερομηνία λήξης"
 
@@ -1354,7 +1354,7 @@ msgid "content"
 msgstr "περιεχόμενο"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1927,8 +1927,10 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr "Θα πρέπει να εμφανίζονται φωτογραφίες προφίλ για τα πρόσωπα επαφής στο δημόσιο περιβάλλον εργασίας;"
 
 #: actions/models/features.py
-msgid "Enable change log"
-msgstr ""
+#, fuzzy
+#| msgid "category levels"
+msgid "Enable change history messages"
+msgstr "επίπεδα κατηγορίας"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2510,42 +2512,42 @@ msgstr "Σχέδια"
 #, fuzzy, python-format
 #| msgid "Category type pages"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Σελίδες τύπου κατηγορίας"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "action schedules"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "χρονοδιαγράμματα δράσης"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Χρονοδιαγράμματα δράσης"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Χρονοδιαγράμματα δράσης"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicators assigned to me"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Δείκτες που μου έχουν ανατεθεί"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Category type pages"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Σελίδες τύπου κατηγορίας"
 
 #: admin_site/api.py
@@ -5627,12 +5629,6 @@ msgid "Other responsible parties"
 msgstr "Άλλοι υπεύθυνοι"
 
 #: reports/spreadsheets/action_print_layout.py
-#, fuzzy
-#| msgid "Page link"
-msgid "Page"
-msgstr "Σύνδεσμος σελίδας"
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr "Προφίλ"
 
@@ -5769,8 +5765,10 @@ msgid "Report types"
 msgstr "Τύποι αναφορών"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "action schedules"
+msgid "Current change history message"
+msgstr "χρονοδιαγράμματα δράσης"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -5823,6 +5821,11 @@ msgstr "Χρήστες"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Δεν έχετε δικαίωμα να καταργήσετε τον χρήστη που ανήκει σε σχέδια που δεν διαχειρίζεστε."
+
+#, fuzzy
+#~| msgid "Page link"
+#~ msgid "Page"
+#~ msgstr "Σύνδεσμος σελίδας"
 
 #, fuzzy
 #~| msgid "Last modified"

--- a/locale/en_AU/LC_MESSAGES/django.po
+++ b/locale/en_AU/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: English (Australia) <https://weblate.kausal.tech/projects/watch/django/en_AU/>\n"
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "comment"
 msgstr ""
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr ""
 
@@ -1309,7 +1309,7 @@ msgid "content"
 msgstr ""
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1880,8 +1880,10 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr ""
 
 #: actions/models/features.py
-msgid "Enable change log"
-msgstr ""
+#, fuzzy
+#| msgid "Action and indicator categorization"
+msgid "Enable change history messages"
+msgstr "Action and indicator categorisation"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2441,42 +2443,42 @@ msgstr ""
 #, fuzzy, python-format
 #| msgid "synchronize with pages"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "synchronize with pages"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "synchronize with pages"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "synchronize with pages"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action and indicator categorization"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Action and indicator categorisation"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action and indicator categorization"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Action and indicator categorisation"
 
 #: admin_site/api.py
@@ -5442,10 +5444,6 @@ msgid "Other responsible parties"
 msgstr "responsible organisations"
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr ""
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5582,8 +5580,10 @@ msgid "Report types"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "synchronize with pages"
+msgid "Current change history message"
+msgstr "synchronise with pages"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"

--- a/locale/en_GB/LC_MESSAGES/django.po
+++ b/locale/en_GB/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: English (United Kingdom) <https://weblate.kausal.tech/projects/watch/django/en_GB/>\n"
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "comment"
 msgstr ""
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgid "content"
 msgstr ""
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1887,8 +1887,10 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr ""
 
 #: actions/models/features.py
-msgid "Enable change log"
-msgstr ""
+#, fuzzy
+#| msgid "Action and indicator categorization"
+msgid "Enable change history messages"
+msgstr "Action and indicator categorisation"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2448,42 +2450,42 @@ msgstr ""
 #, fuzzy, python-format
 #| msgid "synchronize with pages"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "synchronize with pages"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "synchronize with pages"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "synchronize with pages"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "synchronise with pages"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action and indicator categorization"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Action and indicator categorisation"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action and indicator categorization"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Action and indicator categorisation"
 
 #: admin_site/api.py
@@ -5453,10 +5455,6 @@ msgid "Other responsible parties"
 msgstr "responsible organisations"
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr ""
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5593,8 +5591,10 @@ msgid "Report types"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "synchronize with pages"
+msgid "Current change history message"
+msgstr "synchronise with pages"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Spanish <https://weblate.kausal.tech/projects/watch/django/es/>\n"
@@ -1247,7 +1247,7 @@ msgstr "estado"
 msgid "comment"
 msgstr "comentario"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "fecha de vencimiento"
 
@@ -1334,7 +1334,7 @@ msgid "content"
 msgstr "contenido"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1907,8 +1907,10 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr "¿Deben mostrarse las fotos de perfil de las personas de contacto en la interfaz de usuario pública?"
 
 #: actions/models/features.py
-msgid "Enable change log"
-msgstr ""
+#, fuzzy
+#| msgid "category levels"
+msgid "Enable change history messages"
+msgstr "niveles de categoría"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2484,42 +2486,42 @@ msgstr "Planes"
 #, fuzzy, python-format
 #| msgid "Category type pages"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Páginas de tipo categoría"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "action schedules"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "calendarios de actuación"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Planes de acción"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Planes de acción"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicators assigned to me"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Indicadores que me han sido asignados"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Category type pages"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Páginas de tipo categoría"
 
 #: admin_site/api.py
@@ -5584,12 +5586,6 @@ msgid "Other responsible parties"
 msgstr "Otros responsables"
 
 #: reports/spreadsheets/action_print_layout.py
-#, fuzzy
-#| msgid "Page link"
-msgid "Page"
-msgstr "Enlace de página"
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr "Perfiles"
 
@@ -5726,8 +5722,10 @@ msgid "Report types"
 msgstr "Tipos de informes"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "action schedules"
+msgid "Current change history message"
+msgstr "calendarios de actuación"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -5780,6 +5778,11 @@ msgstr "Usuarios"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Sin permiso para eliminar el usuario perteneciente a planes que no gestiona."
+
+#, fuzzy
+#~| msgid "Page link"
+#~ msgid "Page"
+#~ msgstr "Enlace de página"
 
 #~ msgid "Last modified at"
 #~ msgstr "Última modificación en"

--- a/locale/es_US/LC_MESSAGES/django.po
+++ b/locale/es_US/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2024-12-11 10:52+0000\n"
 "Last-Translator: Timo Tuominen <timo.tuominen@kausal.tech>\n"
 "Language-Team: Spanish (American) <https://weblate.kausal.tech/projects/watch/django/es_US/>\n"
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "comment"
 msgstr ""
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgid "content"
 msgstr ""
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1848,7 +1848,7 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr ""
 
 #: actions/models/features.py
-msgid "Enable change log"
+msgid "Enable change history messages"
 msgstr ""
 
 #: actions/models/features.py
@@ -2398,32 +2398,32 @@ msgstr ""
 #: actions/wagtail_admin.py
 #, python-format
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr ""
 
 #: admin_site/api.py
@@ -5323,10 +5323,6 @@ msgid "Other responsible parties"
 msgstr "Otros responsables"
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr ""
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5463,7 +5459,7 @@ msgid "Report types"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
+msgid "Current change history message"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Finnish <https://weblate.kausal.tech/projects/watch/django/fi/>\n"
@@ -1257,7 +1257,7 @@ msgstr "tila"
 msgid "comment"
 msgstr "kommentti"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "tavoitepäivämäärä"
 
@@ -1345,7 +1345,7 @@ msgid "content"
 msgstr "sisältö"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1928,9 +1928,9 @@ msgstr "Aseta jos yhteyshenkilöt näkyvät julkisessa käyttöliittymässä"
 
 #: actions/models/features.py
 #, fuzzy
-#| msgid "Save changes"
-msgid "Enable change log"
-msgstr "Tallenna muutokset"
+#| msgid "category levels"
+msgid "Enable change history messages"
+msgstr "luokan tasot"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2505,42 +2505,42 @@ msgstr "Toimenpideohjelmat"
 #, fuzzy, python-format
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Muutokset tallennettu"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "Muutokset tallennettu"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Muutokset tallennettu"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Toimenpiteen aikataulu"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicators assigned to me"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Minulle osoitetut mittarit"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Category type pages"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Luokkatyyppisivut"
 
 #: admin_site/api.py
@@ -5681,11 +5681,6 @@ msgid "Other responsible parties"
 msgstr "Muut vastuutahot"
 
 #: reports/spreadsheets/action_print_layout.py
-#, fuzzy
-msgid "Page"
-msgstr "ulkopuolinen linkki"
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5822,8 +5817,10 @@ msgid "Report types"
 msgstr "Raporttityypit"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "Changes were saved"
+msgid "Current change history message"
+msgstr "Muutokset tallennettu"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -5872,6 +5869,15 @@ msgstr "Käyttäjät"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Ei oikeuksia poistaa käyttäjä joka kuuluu toimenpideohjelmiin, joita et hallinnoi."
+
+#, fuzzy
+#~| msgid "Save changes"
+#~ msgid "Enable change log"
+#~ msgstr "Tallenna muutokset"
+
+#, fuzzy
+#~ msgid "Page"
+#~ msgstr "ulkopuolinen linkki"
 
 #, fuzzy
 #~ msgid "Last modified at"

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Latvian <https://weblate.kausal.tech/projects/watch/django/lv/>\n"
@@ -1284,7 +1284,7 @@ msgstr "statuss"
 msgid "comment"
 msgstr "komentārs"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "termiņš"
 
@@ -1373,7 +1373,7 @@ msgid "content"
 msgstr "saturs"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1965,9 +1965,9 @@ msgstr "Izvēlieties, kura informācija par kontaktpersonām ir redzama publiska
 
 #: actions/models/features.py
 #, fuzzy
-#| msgid "Save changes"
-msgid "Enable change log"
-msgstr "Izmaiņu saglabāšana"
+#| msgid "category levels"
+msgid "Enable change history messages"
+msgstr "kategoriju līmeņi"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2553,42 +2553,42 @@ msgstr "Plāni"
 #, fuzzy, python-format
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Izmaiņas tika saglabātas"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "Izmaiņas tika saglabātas"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Izmaiņas tika saglabātas"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Rīcības grafiki"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicators assigned to me"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Man piešķirtie rādītāji"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Category type pages"
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Kategorijas tipa lapas"
 
 #: admin_site/api.py
@@ -5702,12 +5702,6 @@ msgid "Other responsible parties"
 msgstr "Citi atbildīgie"
 
 #: reports/spreadsheets/action_print_layout.py
-#, fuzzy
-#| msgid "Page link"
-msgid "Page"
-msgstr "Lapas saite"
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5844,8 +5838,10 @@ msgid "Report types"
 msgstr "Pārskatu veidi"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "Changes were saved"
+msgid "Current change history message"
+msgstr "Izmaiņas tika saglabātas"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -5894,6 +5890,16 @@ msgstr "Lietotāji"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Nav atļauts noņemt lietotājus, kas pieder pie plāniem, kurus jūs neapsaimniekojat."
+
+#, fuzzy
+#~| msgid "Save changes"
+#~ msgid "Enable change log"
+#~ msgstr "Izmaiņu saglabāšana"
+
+#, fuzzy
+#~| msgid "Page link"
+#~ msgid "Page"
+#~ msgstr "Lapas saite"
 
 #, fuzzy
 #~| msgid "Last modified"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 07:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Portuguese (Brazil) <https://weblate.kausal.tech/projects/watch/django/pt_BR/>\n"
@@ -1430,7 +1430,7 @@ msgstr "estado"
 msgid "comment"
 msgstr "comentário"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 #, fuzzy
 msgid "due date"
 msgstr "data de vencimento"
@@ -1538,7 +1538,7 @@ msgid "content"
 msgstr "conteúdo"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -2205,8 +2205,8 @@ msgstr "Os moderadores devem ser ocultados das pessoas de contato visíveis na i
 
 #: actions/models/features.py
 #, fuzzy
-msgid "Enable change log"
-msgstr "Salvar alterações"
+msgid "Enable change history messages"
+msgstr "níveis de categoria"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2854,37 +2854,37 @@ msgstr "Planos"
 #: actions/wagtail_admin.py
 #, fuzzy, python-format
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "As alterações foram salvas"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "As alterações foram salvas"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "As alterações foram salvas"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Cronogramas de ação"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Página da lista de indicadores"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Páginas de tipo de categoria"
 
 #: admin_site/api.py
@@ -6361,11 +6361,6 @@ msgid "Other responsible parties"
 msgstr "Outros responsáveis"
 
 #: reports/spreadsheets/action_print_layout.py
-#, fuzzy
-msgid "Page"
-msgstr "Link da página"
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -6518,8 +6513,9 @@ msgid "Report types"
 msgstr "Tipos de relatório"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+msgid "Current change history message"
+msgstr "As alterações foram salvas"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -6572,6 +6568,14 @@ msgstr "Usuários"
 #, fuzzy
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Nenhuma permissão para remover o usuário pertencente a planos que você não está gerenciando."
+
+#, fuzzy
+#~ msgid "Enable change log"
+#~ msgstr "Salvar alterações"
+
+#, fuzzy
+#~ msgid "Page"
+#~ msgstr "Link da página"
 
 #, fuzzy
 #~ msgid "Last modified at"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2025-04-02 12:20+0000\n"
 "Last-Translator: Matias Wargelin <matias.wargelin@kausal.tech>\n"
 "Language-Team: Swedish <https://weblate.kausal.tech/projects/watch/django/sv/>\n"
@@ -1282,7 +1282,7 @@ msgstr "stat"
 msgid "comment"
 msgstr "kommentar"
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr "förfallodatum"
 
@@ -1370,7 +1370,7 @@ msgid "content"
 msgstr "innehåll"
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1985,9 +1985,9 @@ msgstr "Ange om kontaktpersonerna inte ska vara synliga i det offentliga använd
 
 #: actions/models/features.py
 #, fuzzy
-#| msgid "Save changes"
-msgid "Enable change log"
-msgstr "Spara ändringar"
+#| msgid "category levels"
+msgid "Enable change history messages"
+msgstr "kategorinivåer"
 
 #: actions/models/features.py
 msgid "Prompt users to add a public change log message after editing actions, indicators, or categories."
@@ -2595,41 +2595,41 @@ msgstr "Planer"
 #, fuzzy, python-format
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr "Ändringar sparades"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr "Ändringar sparades"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Changes were saved"
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr "Ändringar sparades"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Action schedules"
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr "Tidsram för åtgärd"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 #| msgid "Indicators assigned to me"
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr "Indikatorer tilldelade mig"
 
 #: actions/wagtail_admin.py
 #, fuzzy
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr "Kategorityper"
 
 #: admin_site/api.py
@@ -5835,12 +5835,6 @@ msgstr "Andra ansvariga"
 
 #: reports/spreadsheets/action_print_layout.py
 #, fuzzy
-#| msgid "Page link"
-msgid "Page"
-msgstr "Sidolänk"
-
-#: reports/spreadsheets/action_print_layout.py
-#, fuzzy
 msgid "Profiles"
 msgstr "Profiler"
 
@@ -5985,8 +5979,10 @@ msgid "Report types"
 msgstr "Kategorityper"
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
-msgstr ""
+#, fuzzy
+#| msgid "Changes were saved"
+msgid "Current change history message"
+msgstr "Ändringar sparades"
 
 #: templates/aplans/change_log_message_create.html
 msgid "Skip"
@@ -6036,6 +6032,16 @@ msgstr "Användare"
 #: users/models.py
 msgid "No permission to remove the user belonging to plans you are not managing."
 msgstr "Inget tillstånd att ta bort användaren som tillhör planer som du inte hanterar."
+
+#, fuzzy
+#~| msgid "Save changes"
+#~ msgid "Enable change log"
+#~ msgstr "Spara ändringar"
+
+#, fuzzy
+#~| msgid "Page link"
+#~ msgid "Page"
+#~ msgstr "Sidolänk"
 
 #, fuzzy
 #~| msgid "Last modified"

--- a/locale/sv_FI/LC_MESSAGES/django.po
+++ b/locale/sv_FI/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-01-02 16:02+0100\n"
+"POT-Creation-Date: 2026-01-07 09:10+0200\n"
 "PO-Revision-Date: 2024-12-11 10:47+0000\n"
 "Last-Translator: Timo Tuominen <timo.tuominen@kausal.tech>\n"
 "Language-Team: Swedish <https://weblate.kausal.tech/projects/watch/django/sv_FI/>\n"
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "comment"
 msgstr ""
 
-#: actions/models/action.py reports/report_formatters.py
+#: actions/models/action.py
 msgid "due date"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgid "content"
 msgstr ""
 
 #: actions/models/action.py
-msgid "Summarize what was changed. This message will be displayed publicly."
+msgid "Please summarize the change you made. This message will be displayed publicly."
 msgstr ""
 
 #: actions/models/action.py aplans/utils.py
@@ -1846,7 +1846,7 @@ msgid "Should indicators open only in a modal dialog in the public UI?"
 msgstr ""
 
 #: actions/models/features.py
-msgid "Enable change log"
+msgid "Enable change history messages"
 msgstr ""
 
 #: actions/models/features.py
@@ -2396,32 +2396,32 @@ msgstr ""
 #: actions/wagtail_admin.py
 #, python-format
 msgctxt "page subtitle"
-msgid "Change log message: %(obj)s"
+msgid "Change history message: %(obj)s"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "page subtitle"
-msgid "Change log message"
+msgid "Change history message"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "page title"
-msgid "Add change log message"
+msgid "Add change history message"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Action change log messages"
+msgid "Action change history messages"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Indicator change log messages"
+msgid "Indicator change history messages"
 msgstr ""
 
 #: actions/wagtail_admin.py
 msgctxt "menu label"
-msgid "Category change log messages"
+msgid "Category change history messages"
 msgstr ""
 
 #: admin_site/api.py
@@ -5319,10 +5319,6 @@ msgid "Other responsible parties"
 msgstr "Andra ansvariga"
 
 #: reports/spreadsheets/action_print_layout.py
-msgid "Page"
-msgstr ""
-
-#: reports/spreadsheets/action_print_layout.py
 msgid "Profiles"
 msgstr ""
 
@@ -5459,7 +5455,7 @@ msgid "Report types"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html
-msgid "Current change log message"
+msgid "Current change history message"
 msgstr ""
 
 #: templates/aplans/change_log_message_create.html

--- a/templates/aplans/change_log_message_create.html
+++ b/templates/aplans/change_log_message_create.html
@@ -14,7 +14,7 @@
 {% block before_form %}
     {% if latest_change_log_message %}
         <div style="margin-bottom: 1.5rem; padding: 0.75rem; background-color: var(--w-color-surface-page); border: 2px solid var(--w-color-secondary); border-radius: 0.375rem; max-width: 600px;">
-            <h3 style="font-weight: 600; margin-bottom: 0.5rem; color: var(--w-color-text-label);">{% trans "Current change log message" %}</h3>
+            <h3 style="font-weight: 600; margin-bottom: 0.5rem; color: var(--w-color-text-label);">{% trans "Current change history message" %}</h3>
             <p style="color: var(--w-color-text-meta); font-size: 0.875rem; margin-bottom: 0.25rem;">{{ latest_change_log_message.created_at|date:"SHORT_DATETIME_FORMAT" }}</p>
             <p style="white-space: pre-wrap; color: var(--w-color-text-label);">{{ latest_change_log_message.content }}</p>
         </div>

--- a/templates/aplans/change_log_message_create.html
+++ b/templates/aplans/change_log_message_create.html
@@ -24,7 +24,7 @@
 {% block actions %}
     {{ action_menu.render_html }}
     {% if skip_url %}
-        <a href="{{ skip_url }}" class="button button-secondary">
+        <a href="{{ skip_url }}" class="button no">
             {% trans "Skip" %}
         </a>
     {% endif %}


### PR DESCRIPTION
## Description
Miscellaneous, mostly language changes to the change history messages feature.

## Screenshots/Videos (if applicable)
N/A

## Related issue
P-2697 P-2696 P-2695 

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
N/A

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
N/A

If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes terminology and tightens types around change history messages.
> 
> - Replace `"change log"` with `"change history"` in model help texts, `PlanFeatures`, admin menu/page labels, and `templates/aplans/change_log_message_create.html`
> - Unify return types to `BaseChangeLogMessage` for `get_public_change_log_message` and GraphQL resolvers; make `created_by` resolver nullable
> - Refactor Wagtail admin change message views to generic, typed versions using a `Protocol` and `get_related_object_by_pk` for `Action`, `Indicator`, and `Category`; update permission checks accordingly
> - Update i18n strings and POT/PO files across locales; minor UI tweak to template button class
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f1b5eb5ca68384ca187cf046bedefb124083f48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->