### PR TITLE
More e2e organization tests

### DIFF
--- a/e2e-tests/tests/actions.spec.ts
+++ b/e2e-tests/tests/actions.spec.ts
@@ -3,11 +3,24 @@ import {
   test,
 } from '@playwright/test';
 
+const listActionsPath = '/admin/actions/action/';
+
 test.describe('Test admin', () => {
   test('List actions', async ({ page }) => {
     await page.goto('/admin/');
     await page.getByRole('link', { name: 'Actions', exact: true }).click();
     await expect(page.getByLabel('Filter actions')).toBeVisible();
+  });
+
+  test('Filter actions by name', async ({ page }) => {
+    await page.goto(listActionsPath);
+    await expect(page.getByText('Test action 1')).toBeVisible();
+    await expect(page.getByText('Test action 2')).toBeVisible();
+
+    await expect(page.getByRole('textbox', { name: 'Filter actions' })).toBeVisible();
+    await page.getByRole('textbox', { name: 'Filter actions' }).fill('Test action 1');
+    await expect(page.getByText('Test action 1')).toBeVisible();
+    await expect(page.getByText('Test action 2')).toBeHidden();
   });
 })
 

--- a/e2e-tests/tests/orgs.spec.ts
+++ b/e2e-tests/tests/orgs.spec.ts
@@ -4,7 +4,15 @@ import {
 } from '@playwright/test';
 
 const listOrganizationsPath = '/admin/snippets/orgs/organization/';
-const editOrganizationPath = RegExp(`${listOrganizationsPath}edit/[0-9]+/`);
+
+const testData = {
+  organization1: 'E2E test data: Test organization 1',
+  organization2: 'E2E test data: Test organization 2',
+  suborganization1: 'E2E test data: Suborganization 1',
+  deleteOrganization: 'E2E test data: Delete this organization',
+  organization1Person: 'E2E test data: Organization 1 person',
+  editOrganization: 'E2E test data: Edit this organization'
+}
 
 test.describe('Test organization admin', () => {
   test('Organizations appear in menu', async ({ page }) => {
@@ -18,10 +26,145 @@ test.describe('Test organization admin', () => {
     await expect(page.getByRole('table')).toContainText('Kausal Oy');
   });
 
-  test('Organization edit page has title', async ({ page }) => {
+  test('Filter organizations by name', async ({ page }) => {
     await page.goto(listOrganizationsPath);
-    await page.getByRole('link', { name: 'Kausal Oy' }).click();
-    await page.waitForURL(editOrganizationPath);
-    await expect(page.locator('#header-title')).toContainText('Kausal Oy');
+    await expect(page.getByText(testData.organization1)).toBeVisible();
+    await expect(page.getByText(testData.organization2)).toBeVisible();
+
+    await page.getByRole('textbox', { name: 'Filter organizations' }).fill(testData.organization1);
+    await expect(page.getByText(testData.organization1)).toBeVisible();
+    await expect(page.getByText(testData.organization2)).toBeHidden();
+  });
+
+  test('Toggling suborganization visibility', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await expect(page.getByText(testData.organization1)).toBeVisible();
+    await expect(page.getByText(testData.suborganization1)).toBeVisible();
+
+    await page.getByRole('cell', { name: testData.organization1 }).getByText('▼').click();
+    await expect(page.getByText(testData.organization1)).toBeVisible();
+    await expect(page.getByText(testData.suborganization1)).toBeHidden();
+  });
+
+  test('Adding an organization', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await expect(page.getByRole('table')).toBeVisible();
+    await expect(page.getByRole('table').getByText('Added organization')).toBeHidden();
+
+    await page.getByRole('link', { name: 'Add organization' }).click();
+    await page.getByRole('textbox', { name: 'Name (EN)*' }).fill('Added organization');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByRole('table').getByText('Added organization')).toBeVisible();
+  });
+
+  test('Adding a suborganization', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await expect(page.getByRole('table')).toBeVisible();
+    await expect(page.getByRole('table').getByText('Added suborganization')).toBeHidden();
+
+    await page.getByRole('button', { name: `More options for '${testData.organization1}'` }).click();
+    await page.getByRole('link', { name: 'Add suborganization' }).click();
+    await page.getByRole('textbox', { name: 'Name (EN)*' }).fill('Added suborganization');
+    await page.getByRole('button', { name: 'Save' }).click();
+    await expect(page.getByRole('table').getByText('Added suborganization')).toBeVisible();
+
+    // Test that the suborganization was added to the correct parent
+    // organization by toggling the parent organization's suborganization
+    // visibility
+    await page.getByRole('cell', { name: testData.organization1 }).getByText('▼').click();
+    await expect(page.getByRole('table').getByText('Added suborganization')).toBeHidden();
+  });
+
+  test('Deleting an organization', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await expect(page.getByRole('table').getByText(testData.deleteOrganization)).toBeVisible();
+
+    await page.getByRole('button', { name: `More options for '${testData.deleteOrganization}'` }).click();
+    await page.getByRole('link', { name: 'Delete', exact: true }).click();
+    await page.getByRole('button', { name: 'Yes, delete' }).click();
+    await page.waitForURL(listOrganizationsPath);
+    await expect(page.getByRole('table')).toBeVisible();
+    await expect(page.getByRole('table').getByText(testData.deleteOrganization)).toBeHidden();
+  });
+
+  test('Including/excluding an organization from active plan', async ({ page }) => {
+    // Wether an organization is included in the active plan or not can be
+    // checked by checking if the person is visible in the people list
+
+    const personPath = '/admin/people/person/';
+
+    await page.goto(personPath);
+    await expect(page.getByText(testData.organization1Person)).toBeVisible();
+
+    await page.goto(listOrganizationsPath);
+    await page.getByRole('button', { name: `More options for '${testData.organization1}'` }).click();
+    await page.getByRole('link', { name: 'Exclude from active plan' }).click();
+    await page.getByRole('button', { name: 'Yes' }).click();
+    await page.goto(personPath);
+    await expect(page.getByRole('table')).toBeVisible();
+    await expect(page.getByText(testData.organization1Person)).toBeHidden();
+
+    await page.goto(listOrganizationsPath);
+    await page.getByRole('button', { name: `More options for '${testData.organization1}'` }).click();
+    await page.getByRole('link', { name: 'Include in active plan' }).click();
+    await page.getByRole('button', { name: 'Yes' }).click();
+    await page.goto(personPath);
+    await expect(page.getByText(testData.organization1Person)).toBeVisible();
+  });
+
+  test('Including/excluding from active plan is not available for suborganizations', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await page.getByRole('button', { name: `More options for '${testData.suborganization1}'` }).click();
+    await expect(page.getByRole('link', { name: 'Include in active plan' })).toBeHidden();
+    await expect(page.getByRole('link', { name: 'Exclude from active plan' })).toBeHidden();
+  });
+
+  test('Editing an organization', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await page.getByRole('link', { name: testData.editOrganization }).click();
+    await expect(page.getByRole('heading', { name: testData.editOrganization })).toBeVisible();
+
+    await page.getByRole('textbox', { name: 'Name (EN)*' }).fill('Name (EN) edited');
+    await page.getByRole('textbox', { name: 'Name (FI)', exact: true }).fill('Name (FI) edited');
+    await page.locator('#id_parent').selectOption(testData.organization1);
+    // TODO: Edit logo
+    await page.getByRole('textbox', { name: 'Short name (EN)'}).fill('Short name (EN) edited');
+    await page.getByRole('textbox', { name: 'Short name (FI)' }).fill('Short name (FI) edited');
+    await page.getByRole('textbox', { name: 'Internal abbreviation' }).fill('Internal abbreviation edited');
+    await page.locator('.notranslate').describe('Description input').fill('Description edited');
+    await page.getByRole('textbox', { name: 'URL' }).fill('https://edited.com');
+    await page.getByRole('textbox', { name: 'Email address' }).fill('edited@example.com');
+    await expect(page.getByRole('textbox', { name: 'Primary language' })).not.toBeEditable();
+    // Skip editing location, it behaves strangely in Playwright
+
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.waitForURL(listOrganizationsPath);
+    await expect(page.getByRole('link', { name: 'Name (EN) edited' })).toBeVisible();
+  });
+
+  test('Adding a plan admin to an organization', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await page.getByRole('link', { name: testData.organization1 }).click();
+    await page.getByRole('tab', { name: 'Permissions' }).click();
+    await page.getByRole('button', { name: 'Add plan admin' }).click();
+    await page.getByRole('button', { name: 'Choose a person' }).click();
+    await page.getByRole('textbox', { name: 'Search term' }).fill(testData.organization1Person);
+    await page.getByRole('link', { name: testData.organization1Person }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.waitForURL(listOrganizationsPath);
+    // TODO: A proper check that the plan admin is taken into account
+  });
+
+  test('Adding a metadata admin to an organization', async ({ page }) => {
+    await page.goto(listOrganizationsPath);
+    await page.getByRole('link', { name: testData.organization1 }).click();
+    await page.getByRole('tab', { name: 'Permissions' }).click();
+    await page.getByRole('button', { name: 'Add metadata admin' }).click();
+    await page.getByRole('button', { name: 'Choose a person' }).click();
+    await page.getByRole('textbox', { name: 'Search term' }).fill(testData.organization1Person);
+    await page.getByRole('link', { name: testData.organization1Person }).click();
+    await page.getByRole('button', { name: 'Save' }).click();
+    await page.waitForURL(listOrganizationsPath);
+    // TODO: A proper check that the metadata admin is taken into account
   });
 })

--- a/e2e-tests/tests/orgs.spec.ts
+++ b/e2e-tests/tests/orgs.spec.ts
@@ -3,24 +3,25 @@ import {
   test,
 } from '@playwright/test';
 
-test.describe('Test organization admin', () => {
-  const organizationsPath = '/admin/snippets/orgs/organization/';
+const listOrganizationsPath = '/admin/snippets/orgs/organization/';
+const editOrganizationPath = RegExp(`${listOrganizationsPath}edit/[0-9]+/`);
 
+test.describe('Test organization admin', () => {
   test('Organizations appear in menu', async ({ page }) => {
     await page.goto('/admin/');
     const link = await page.getByRole('link', { name: 'Organizations' }).getAttribute('href');
-    expect(link).toBe(organizationsPath);
+    expect(link).toBe(listOrganizationsPath);
   });
 
   test('List organizations', async ({ page }) => {
-    await page.goto(organizationsPath);
+    await page.goto(listOrganizationsPath);
     await expect(page.getByRole('table')).toContainText('Kausal Oy');
   });
 
   test('Organization edit page has title', async ({ page }) => {
-    await page.goto(organizationsPath);
+    await page.goto(listOrganizationsPath);
     await page.getByRole('link', { name: 'Kausal Oy' }).click();
-    await page.waitForURL(RegExp(`${organizationsPath}edit/[0-9]+/`));
+    await page.waitForURL(editOrganizationPath);
     await expect(page.locator('#header-title')).toContainText('Kausal Oy');
   });
 })


### PR DESCRIPTION
## Description
Adds more E2E tests for organizations.

The tests are using data that has been added to `E2E test plan` in Watch. The tests also leave the test data in such a shape that the test data has to be returned back to its original state after each run of the tests – we need some automation for this to make running the tests manageable. It is pretty annoying, but I cannot think of any other way that keeps the tests independent from each other. (If we e.g. for testing deleting organizations first create the organization in one test, then delete it in another test, if the creation test fails also the delete test fails. By having a separate organization only meant for deletion in the prepared test data, we keep the deletion test isolated from other tests, but this means we need to bring that organization back before running the tests again.)

The PR also adds one new test for actions. After writing that I realised it might make sense to postpone new action tests until we have migrated actions to snippets, since the migration might change the way to locate different input fields etc., so I didn't go further with action tests yet.

------
#### Manual testing instructions
- Fetch prod database with data from 7th Jan or later to get the latest changes in `E2E test plan`
- Run the tests e.g. with `cd e2e-tests/; npx playwright test --max-failures 1 -j 1 --project chromium --ui`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds broad Playwright coverage for organization administration and basic action filtering.
> 
> - In `e2e-tests/tests/orgs.spec.ts`: new tests for filtering organizations, toggling suborganization visibility, adding organizations and suborganizations, deleting organizations, including/excluding an organization from the active plan (validated via people visibility), editing organization fields, and assigning plan/metadata admins.
> - In `e2e-tests/tests/actions.spec.ts`: adds `listActionsPath` and a test for filtering actions by name; retains validation after customizing the Action term in site settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4ccd66f24b7b702a57bace273ea9ab1a8e0072e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->