### PR TITLE
Request change history message if enabled for actions without moderation

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -10,7 +10,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.utils import quote
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.urls import URLPattern, path, re_path
+from django.urls import URLPattern, path, re_path, reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from django.views.generic.detail import SingleObjectMixin
@@ -619,6 +619,14 @@ class ActionEditHandler(BuiltInFieldCustomizationAwareEditHandlerMixin, AplansTa
         return form_class
 
 
+def change_log_message_url_or_none(action: Action) -> str | None:
+    plan = action.plan
+    if plan.features.enable_change_log and not plan.features.moderation_workflow:
+        change_log_create_url = reverse('wagtailsnippets_actions_actionchangelogmessage:add')
+        return f'{change_log_create_url}?action={action.pk}'
+    return None
+
+
 class ActionCreateView(InitializeFormWithInitialPlanMixin, AplansCreateView):
     instance: Action
 
@@ -637,6 +645,10 @@ class ActionCreateView(InitializeFormWithInitialPlanMixin, AplansCreateView):
                 available_orgs = Organization.objects.get_queryset().available_for_plan(plan)
                 default_org = available_orgs.filter(id=person.organization_id).first()
                 self.instance.primary_org = default_org
+
+    def get_success_url(self):
+        url = change_log_message_url_or_none(self.instance)
+        return url if url else super().get_success_url()
 
 
 class ActionButtonHelper(AplansButtonHelper):
@@ -690,6 +702,11 @@ class ActionButtonHelper(AplansButtonHelper):
 class ActionEditView(
     InitializeFormWithInitialPlanMixin, SnippetsEditViewCompatibilityMixin, SingleObjectMixin[Action], AplansEditView[Action]
 ):
+
+    def get_success_url(self):
+        url = change_log_message_url_or_none(self.instance)
+        return url if url else super().get_success_url()
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.instance.plan.features.enable_moderation_workflow:


### PR DESCRIPTION
## Description
Request change history message if enabled for actions without moderation.
Previously the user was redirected to the add change history message view only on
submit, which only happens when moderation is enabled.

## Screenshots/Videos (if applicable)
N/A

## Related issue
Request change history message if enabled for actions without moderation

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
