### PR TITLE
Also show superusers in Change history "changed by" filter

### DIFF
--- a/audit_logging/views.py
+++ b/audit_logging/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.db.models import Q
 from django.forms import CheckboxSelectMultiple
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from wagtail.admin.filters import ContentTypeFilter, MultipleUserFilter
@@ -40,7 +41,7 @@ class CustomSiteHistoryReportFilterSet(SiteHistoryReportFilterSet):
         if not plan:
             return qs.none()
         persons_available_for_plan = Person.objects.available_for_plan(plan, include_contact_persons=True)
-        return qs.filter(person__in=persons_available_for_plan)
+        return qs.filter(Q(person__in=persons_available_for_plan) | Q(is_superuser=True))
 
 
 class PlanScopedLogEntriesView(LogEntriesView):


### PR DESCRIPTION


## Description
Previously we only displayed users whose persons were available for the plan, which excluded superusers.

## Screenshots/Videos (if applicable)
N/A

## Related issue
N/A

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A
------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Go to Change history from main admin menu. Click on filters -> Changed by. Verify that the user list contains only people available for the plan + superusers
    
### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
