### PR TITLE
Add MCP server for LLM integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ requirements-local.txt
 .secrets/**
 *.egg-info/
 /schema.graphql
+/.mcp.json
+/.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ requirements-local.txt
 /.dmypy.json
 .secrets/**
 *.egg-info/
+/schema.graphql

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,200 @@
+# CLAUDE.md
+
+## Product Overview
+
+Kausal Watch is an open-source platform (AGPLv3) for managing and communicating climate action plan implementation in cities and regional authorities. It replaces traditional spreadsheet-based action plan management with a structured data platform.
+
+**Key capabilities:**
+- **Action plan management** - Hierarchical organization of climate actions (themes → strategies → actions) with flexible metadata, progress tracking, and task/milestone management
+- **Multi-tenancy** - Support for multiple action plans per organization, or shared regional platforms across multiple municipalities
+- **Indicator tracking** - Measurable indicators linked to actions, with causal relationship visualization
+- **Organization integration** - SSO via Azure AD, mirrored org structure, automatic update reminders to action owners
+- **Public UI** - Customizable citizen-facing website with dashboards, filtering by department/theme, and real-time progress visualization
+- **Content management** - Wagtail CMS for publishing supplementary information about action plans
+
+**Users:**
+- Climate coordinators (plan administrators)
+- Department employees (action contact persons who update progress)
+- Politicians and decision-makers (dashboard consumers)
+- Citizens (public UI readers)
+
+Can integrate with Kausal Paths (scenario modeling product) for emissions impact assessment.
+
+## Development Commands
+
+### Core Django Commands
+- `python manage.py runserver` - Start development server
+- `python manage.py migrate` - Run database migrations
+- `python manage.py shell_plus` - Enhanced Django shell (from django-extensions)
+
+### Testing
+- `python run_tests.py` - Run all tests (includes kausal_watch_extensions if available)
+- `pytest` - Alternative test runner with configuration in pyproject.toml
+
+### Linting and Type Checking
+- `ruff check` - Run code linting (configuration extends kausal_common/configs/ruff.toml)
+- `mypy . | mypy-baseline filter` - Run type checking with Django plugin and baseline support
+
+## Architecture Overview
+
+### Core Technologies
+- **Django 6.0** with Wagtail CMS for content management
+- **GraphQL** APIs using both Graphene and Strawberry GraphQL
+- **PostgreSQL** with PostGIS for geographic data
+- **Redis** for caching and Celery task queue
+- **Elasticsearch** for search functionality
+
+### Key Django Apps Structure
+- `actions/` - Core action plan management (actions, categories, plans)
+- `aplans/` - Main Django project settings and shared utilities
+- `indicators/` - Performance indicators and metrics
+- `orgs/` - Organization management
+- `people/` - Person and user management
+- `pages/` - Wagtail CMS pages and content blocks
+- `reports/` - Report generation and export functionality
+- `notifications/` - Email notification system using MJML templates
+- `admin_site/` - Custom admin interface extensions
+- `kausal_common/` - git submodule for code that is shared between Kausal Paths and Kausal Watch
+
+### GraphQL Schema Architecture
+The application provides dual GraphQL implementations:
+- **Graphene Django** (legacy) - Located in various `schema.py` files
+- **Strawberry GraphQL** (modern) - Gradually replacing Graphene
+- Main schema entry: `aplans/schema.py`
+- Execution context: `aplans/schema_context.py` with `WatchGraphQLContext`
+
+### Django App File Conventions
+Each Django app follows consistent naming conventions for different functionality:
+
+- `schema.py` - GraphQL schema definitions (Graphene/Strawberry)
+- `api.py` - Django REST Framework components (serializers, viewsets, permissions)
+- `wagtail_admin.py` - Wagtail admin interface customizations (ModelViewSet, SnippetViewSet)
+  - For large admin modules, split into `*_admin.py` files (e.g., `action_admin.py`, `category_admin.py`)
+- `tasks.py` - Celery task definitions for background processing
+- `models.py` - Django model definitions (may be split into subdirectory for large apps)
+- `apps.py` - Django app configuration
+- `signals.py` - Django signal handlers
+- `permissions.py` - Custom permission classes
+- `utils.py` - Utility functions specific to the app
+
+### Model Conventions
+- All Django models should include a type annotation for the default manager: `objects: ClassVar[models.Manager[Self]]`.
+- For ForeignKeys that point to strings, you need to add a `FK[TargetModel]` (or `FK[TargetModel | None])` type annotation to the field. Import it in a `TYPE_CHECKING` block: `from kausal_common.models.types import FK`.
+- Models inheriting from `UserModifiableModel` get automatic creation/modification timestamps and user tracking
+
+### Logging Conventions
+- Use loguru for logging instead of Python's built-in logging module
+- Initialize module-level logger with:
+  ```python
+  from loguru import logger
+  logger = logger.bind(name='app.module')
+  ```
+- Use descriptive logger names following the pattern `app.module` (e.g., `webhooks.tasks`, `actions.models`)
+
+### Error Handling Conventions
+- Use Sentry for error reporting and monitoring
+- Report exceptions to Sentry with context:
+  ```python
+  import sentry_sdk
+
+  try:
+      # risky operation
+      pass
+  except Exception as e:
+      sentry_sdk.capture_exception(e)
+      raise  # or handle appropriately
+  ```
+- Report unexpected events or conditions:
+  ```python
+  sentry_sdk.capture_message("Unexpected condition: webhook config not found", level="warning")
+  ```
+- Use appropriate Sentry levels: `"debug"`, `"info"`, `"warning"`, `"error"`, `"fatal"`
+
+### Type Annotation Conventions
+- Use modern Python 3.13+ type annotation syntax:
+  - `dict` instead of `Dict`, `list` instead of `List`
+  - `A | None` instead of `Optional[A]`
+  - `A | B` instead of `Union[A, B]`
+- Import collection types from `collections.abc`:
+  ```python
+  from collections.abc import Callable, Sequence, Iterable, Generator
+  ```
+- For type-only imports, use `TYPE_CHECKING` block:
+  ```python
+  from __future__ import annotations
+  from typing import TYPE_CHECKING
+
+  if TYPE_CHECKING:
+      from django.db.models import QuerySet
+      from some.module import ComplexType
+  ```
+- Always include `from __future__ import annotations` at the top of files.
+
+### Key Models Hierarchy
+- `actions/models/plan.py` - Plan, PlanDomain, PlanFeatures
+- `actions/models/action.py` - Action (main entity)
+- `actions/models/category.py` - CategoryType, Category for action organization
+- `actions/models/attributes.py` - Dynamic attributes system
+- `orgs/models.py` - Organization hierarchy
+- `people/models.py` - Person, User extensions
+
+### Multi-tenancy via Plan Domains
+- Plans are isolated by domain via `PlanDomain` model
+- Context filtering throughout the application based on current plan
+- Admin interface restricts data access by plan context
+
+### Internationalization (i18n)
+- Uses `django-modeltrans` for model field translations
+- MJML email templates use Jinja2 (not Django templates)
+- Supports multiple locales with separate translation workflows
+
+### Extensions System
+- Optional, closed-source `kausal_watch_extensions` package for SaaS-enabling features
+- Automatically included in tests and URL routing when available
+- Symlinked from separate kausal-extensions repository
+
+### Background Tasks
+- Celery for asynchronous task processing
+- Redis as message broker
+- Task definitions in various `tasks.py` files
+
+## Testing Strategy
+
+### Test Configuration
+- Uses pytest with Django integration
+- Configuration in `pyproject.toml` under `[tool.pytest.ini_options]`
+- Factory Boy for test data generation
+- Coverage reporting available
+
+### Type Checking
+- MyPy configuration with Django plugin
+- Baseline file `.mypy-baseline.txt` for gradual typing adoption
+- Type stubs for some 3rd party packages in `kausal_common/typings/`
+
+## API Architecture
+
+### REST API
+- Django REST Framework at `/v1/` prefix
+- Nested routers for hierarchical resources
+- OpenAPI schema available at `/v1/schema/`
+- Swagger UI at `/v1/docs/`
+
+### GraphQL API
+- Endpoint at `/v1/graphql/`
+- GraphQL Voyager documentation at `/v1/graphql/docs/`
+- Supports both query and mutation operations
+- Plan-based data filtering built into resolvers
+
+## Content Management
+
+### Wagtail CMS Integration
+- Page models in `pages/models.py`
+- Custom Wagtail blocks in various `blocks/` directories
+- Admin interface customizations in `*_wagtail.py` files
+- Custom choosers for plan-specific content
+
+### Rich Content Blocks
+- Modular content blocks system
+- Action content blocks for displaying plan data
+- Category listing and filtering blocks
+- Custom stream fields for flexible page layouts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Can integrate with Kausal Paths (scenario modeling product) for emissions impact
 - `notifications/` - Email notification system using MJML templates
 - `admin_site/` - Custom admin interface extensions
 - `kausal_common/` - git submodule for code that is shared between Kausal Paths and Kausal Watch
+- `mcp_server/` - MCP server for AI assistant integration (see [architecture docs](docs/architecture/mcp-server.md))
 
 ### GraphQL Schema Architecture
 The application provides dual GraphQL implementations:
@@ -198,3 +199,9 @@ Each Django app follows consistent naming conventions for different functionalit
 - Action content blocks for displaying plan data
 - Category listing and filtering blocks
 - Custom stream fields for flexible page layouts
+
+## Detailed Architecture Documentation
+
+For in-depth implementation details on specific subsystems, see:
+
+- [MCP Server](docs/architecture/mcp-server.md) - Adding tools, GraphQL integration, authentication flow

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.core.management import CommandError
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from django.db.models.signals import post_delete
 from reversion.models import Revision as ReversionRevision
 from wagtail.models import ModelLogEntry, PageLogEntry, Revision as WagtailRevision
 
-from easy_thumbnails.models import Thumbnail
+import factory
+from easy_thumbnails.models import Source, Thumbnail
 
 from actions.models.plan import Plan
 from admin_site.models import Client
@@ -16,50 +20,48 @@ from orgs.models import Organization
 from request_log.models import LoggedRequest
 from users.models import User
 
+if TYPE_CHECKING:
+    from django.db.models import Model
+
 
 class Command(BaseCommand):
-    help = "Delete plans and related data"
+    help = 'Delete plans and related data'
 
     def add_arguments(self, parser):
         parser.add_argument(
             '--exclude-plan',
             metavar='IDENTIFIER',
             action='append',
-            help="Exclude the plan with the specified identifier from deletion",
+            help='Exclude the plan with the specified identifier from deletion',
         )
         parser.add_argument(
             '--exclude-organization',
             metavar='UUID',
             action='append',
-            help="Exclude the organization with the specified UUID from deletion",
+            help='Exclude the organization with the specified UUID from deletion',
         )
         parser.add_argument(
             '--exclude-client',
             metavar='ID',
             action='append',
-            help="Exclude the client with the specified ID (primary key) from deletion",
+            help='Exclude the client with the specified ID (primary key) from deletion',
         )
         parser.add_argument(
             '--no-confirm',
             action='store_true',
-            help="Do not ask for confirmation but delete right away",
+            help='Do not ask for confirmation but delete right away',
         )
         parser.add_argument(
-            '--keep-page-log',
+            '--thorough',
             action='store_true',
-            help="Do not clear Wagtail's page log",
-        )
-        parser.add_argument(
-            '--keep-model-log',
-            action='store_true',
-            help="Do not clear Wagtail's model log",
+            help='Delete more data, including revision history and audit logs'
         )
 
     def handle(self, *args, **options):
-        if not settings.DEBUG or settings.DEPLOYMENT_TYPE != 'production':
+        if not settings.DEBUG or settings.DEPLOYMENT_TYPE == 'production':
             raise CommandError(
-                "Sorry, for preventing accidents, this management command only works if DEBUG is true and "
-                "DEPLOYMENT_TYPE is 'production'.",
+                'Sorry, for preventing accidents, this management command only works if DEBUG is true and '
+                "DEPLOYMENT_TYPE is not 'production'.",
             )
 
         # Determine plans to delete
@@ -73,9 +75,9 @@ class Command(BaseCommand):
         plans_to_keep = Plan.objects.qs.exclude(id__in=plans_to_delete)
         delete_identifiers = plans_to_delete.values_list('identifier', flat=True)
         if options['exclude_plan']:
-            self.stdout.write(f"The following plans will not be deleted: {', '.join(options['exclude_plan'])}")
+            self.stdout.write(f'The following plans will not be deleted: {", ".join(options["exclude_plan"])}')
         if delete_identifiers:
-            self.stdout.write(f"The following plans will be deleted with all related data: {', '.join(delete_identifiers)}")
+            self.stdout.write(f'The following plans will be deleted with all related data: {", ".join(delete_identifiers)}')
 
         # Determine organizations to delete
         orgs_to_keep = Organization.objects.qs.available_for_plans(plans_to_keep)
@@ -95,42 +97,80 @@ class Command(BaseCommand):
                 elif n > 1:
                     string += f' (and {n} suborganizations)'
                 strings.append(string)
-            self.stdout.write(f"The following organizations will be deleted: {', '.join(strings)}")
+            self.stdout.write(f'The following organizations will be deleted: {", ".join(strings)}')
 
-        self.stdout.write("Moreover, the following data will be deleted:")
+        self.stdout.write('Moreover, the following data will be deleted:')
         self.stdout.write("- all User instances that don't have a corresponding Person anymore")
         client_message = "- all Client instances that don't have a corresponding Plan anymore"
         if options['exclude_client']:
             client_names = Client.objects.filter(id__in=options['exclude_client']).values_list('name', flat=True)
-            client_message += f" and are not among the following: {', '.join(client_names)}"
+            client_message += f' and are not among the following: {", ".join(client_names)}'
         self.stdout.write(client_message)
         self.stdout.write("- all Reversion Revision instances that don't have a corresponding User anymore")
         self.stdout.write("- all Wagtail Revision instances that don't have a corresponding User anymore")
         self.stdout.write("- all Wagtail ModelLogEntry instances that don't have a corresponding User anymore")
-        self.stdout.write("- all logged requests")
-        if not options['keep_page_log']:
-            self.stdout.write("- all entries of Wagtail's page log")
-        if not options['keep_model_log']:
-            self.stdout.write("- all entries of Wagtail's model log")
-        self.stdout.write("- all thumbnails")
-        self.stdout.write("- all sessions")
+        self.stdout.write('- all logged requests')
+        # if not options['keep_page_log']:
+        #     self.stdout.write("- all entries of Wagtail's page log")
+        # if not options['keep_model_log']:
+        #     self.stdout.write("- all entries of Wagtail's model log")
+        self.stdout.write('- all thumbnails')
+        self.stdout.write('- all sessions')
         if not options['no_confirm']:
-            confirmation = input("Do you want to proceed? [y/N] ").lower()
+            confirmation = input('Do you want to proceed? [y/N] ').lower()
             if confirmation != 'y':
-                self.stdout.write(self.style.WARNING("Aborted by user."))
+                self.stdout.write(self.style.WARNING('Aborted by user.'))
                 return
-        self.delete_data(
-            plans_to_delete, orgs_to_delete, options['exclude_client'], options['keep_page_log'],
-            options['keep_model_log'],
-        )
-        self.stdout.write("You may also want to run the following management commands now:")
-        self.stdout.write("- `wagtail_update_image_renditions --purge-only` to remove all renditions")
-        self.stdout.write("- `rebuild_references_index` to get rid of broken references")
+        with factory.django.mute_signals(post_delete):
+            self.delete_data(
+                plans_to_delete,
+                orgs_to_delete,
+                clients_to_keep=options['exclude_client'],
+                thorough=options['thorough'],
+            )
+        self.stdout.write('You may also want to run the following management commands now:')
+        self.stdout.write('- `wagtail_update_image_renditions --purge-only` to remove all renditions')
+        self.stdout.write('- `rebuild_references_index` to get rid of broken references')
+
+    def delete_all(self, model: type[Model]) -> None:
+        self.stdout.write(f'Deleting {model.__name__} instances...')
+        _, by_type = model._default_manager.all().delete()
+        self.print_deleted_instances_by_model(by_type)
+
+    def delete_thoroughly(self):
+        from django.contrib.admin.models import LogEntry
+
+        from oauth2_provider.models import RefreshToken
+        from social_django.models import Association, Code, Nonce, Partial
+
+        from kausal_watch_extensions.models import AuthIDToken
+        from notifications.models import SentNotification
+
+        # Delete Reversion revisions without users
+        self.delete_all(ReversionRevision)
+        # Delete Wagtail revisions without users
+        self.delete_all(WagtailRevision)
+        # Delete Wagtail model log entries without users
+        self.delete_all(ModelLogEntry)
+        # Delete Wagtail page log entries
+        self.delete_all(PageLogEntry)
+        self.delete_all(LogEntry)
+
+        self.delete_all(Association)
+        self.delete_all(Nonce)
+        self.delete_all(Code)
+        self.delete_all(Partial)
+        self.delete_all(SentNotification)
+        self.delete_all(AuthIDToken)
+        self.delete_all(RefreshToken)
 
     @transaction.atomic
     def delete_data(
-        self, plans_to_delete, orgs_to_delete, clients_to_keep: list[int] | None = None, keep_page_log: bool = False,
-        keep_model_log: bool = False,
+        self,
+        plans_to_delete,
+        orgs_to_delete,
+        clients_to_keep: list[int] | None = None,
+        thorough: bool = False,
     ):
         if clients_to_keep is None:
             clients_to_keep = []
@@ -140,12 +180,12 @@ class Command(BaseCommand):
         # related objects in place.
         for plan in plans_to_delete:
             plan.delete()
-            self.stdout.write(f"Deleted plan {plan.identifier}; information on deleted related rows not available.")
+            self.stdout.write(f'Deleted plan {plan.identifier}; information on deleted related rows not available.')
         # Delete organizations
         num_orgs = orgs_to_delete.count()
         orgs_to_delete.delete()
         # Treebeard won't tell us the deleted numbers -_-
-        self.stdout.write(f"Deleted {num_orgs} organizations; information on deleted related rows not available.")
+        self.stdout.write(f'Deleted {num_orgs} organizations; information on deleted related rows not available.')
         # Delete users without persons
         _, by_type = User.objects.filter(person__isnull=True).delete()
         self.print_deleted_instances_by_model(by_type)
@@ -165,21 +205,18 @@ class Command(BaseCommand):
         _, by_type = PageLogEntry.objects.filter(user__isnull=True).delete()
         self.print_deleted_instances_by_model(by_type)
         # Delete all logged requests
-        _, by_type = LoggedRequest.objects.all().delete()
-        if not keep_model_log:
-            # Delete all Wagtail page log entries
-            _, by_type = PageLogEntry.objects.all().delete()
-            self.print_deleted_instances_by_model(by_type)
-        if not keep_page_log:
-            # Delete all Wagtail model log entries
-            _, by_type = ModelLogEntry.objects.all().delete()
-            self.print_deleted_instances_by_model(by_type)
-        self.print_deleted_instances_by_model(by_type)
+        self.delete_all(LoggedRequest)
         # Delete thumbnails
-        Thumbnail.objects.all().delete()
+        self.delete_all(Thumbnail)
+        self.delete_all(Source)
+
         # Delete sessions
-        Session.objects.all().delete()
+        self.delete_all(Session)
+
+        if thorough:
+            self.delete_thoroughly()
+
 
     def print_deleted_instances_by_model(self, by_type):
         for model_name, n in by_type.items():
-            self.stdout.write(f"Deleted {n} instances of {model_name}.")
+            self.stdout.write(f'Deleted {n} instances of {model_name}.')

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -55,8 +55,6 @@ from orgs.models import Organization
 from people.models import Person
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from django.http.request import HttpRequest
     from django_stubs_ext import StrOrPromise
 
@@ -294,7 +292,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         Group, null=True, on_delete=models.PROTECT, editable=False, related_name='contact_person_for_plan',
     )
 
-    other_languages: ChoiceArrayField[list[str]] = ChoiceArrayField(  # pyright: ignore
+    other_languages: ChoiceArrayField[list[str]] = ChoiceArrayField(
         models.CharField(max_length=8, choices=get_supported_languages(), default=get_default_language),
         default=list, blank=True,
     )
@@ -394,7 +392,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
     cache_invalidated_at = models.DateTimeField(auto_now=True)
     i18n = TranslationField(fields=['name', 'short_name'], default_language_field='primary_language_lowercase')
 
-    action_attribute_types: RevMany[AttributeType] = GenericRelation(  # type: ignore
+    action_attribute_types: RevMany[AttributeType] = GenericRelation(  # type: ignore  # pyright: ignore[reportAssignmentType]
         to='actions.AttributeType',
         related_query_name='plan',
         content_type_field='scope_content_type',
@@ -539,7 +537,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         return page
 
     @classmethod
-    def permission_policy(cls) -> PlanPermissionPolicy:  # pyright: ignore[reportIncompatibleMethodOverride]
+    def permission_policy(cls) -> PlanPermissionPolicy:
         return PlanPermissionPolicy(cls)
 
     def get_translated_root_page(self, fallback=True) -> Page | None:
@@ -655,9 +653,23 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         )
 
     def invalidate_cache(self):
+        from asgiref.sync import async_to_sync
+        from channels.layers import get_channel_layer
+
         logger.info('Invalidate cache for %s' % self)
         self.cache_invalidated_at = timezone.now()
         super().save(update_fields=['cache_invalidated_at'])
+        channel_layer = get_channel_layer()
+        if channel_layer is None:
+            return
+        async_to_sync(channel_layer.group_send)(
+            'plan_cache_invalidations',
+            {
+                'type': 'plan.cache_invalidated',
+                'plan_identifier': self.identifier,
+                'invalidated_at': self.cache_invalidated_at.isoformat(),
+            },
+        )
 
     def create_default_pages(self):
         """
@@ -1143,7 +1155,7 @@ class GeneralPlanAdmin(OrderedModel):
     person = models.ForeignKey(Person, on_delete=models.CASCADE, verbose_name=_('person'),
                                related_name='general_admin_plans_ordered')
 
-    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+    class Meta:
         ordering = ['plan', 'order']
         indexes = [
             models.Index(fields=['plan', 'order']),
@@ -1318,7 +1330,7 @@ class Scenario(PlanRelatedModelWithRevision):
         'id', 'plan', 'name', 'identifier', 'description',
     ]
 
-    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+    class Meta:
         unique_together = (('plan', 'identifier'),)
         verbose_name = _('scenario')
         verbose_name_plural = _('scenarios')
@@ -1347,7 +1359,7 @@ class ImpactGroup(PlanRelatedModelWithRevision):
         'id', 'plan', 'identifier', 'parent', 'weight', 'name', 'color', 'actions',
     ]
 
-    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+    class Meta:
         unique_together = (('plan', 'identifier'),)
         verbose_name = _('impact group')
         verbose_name_plural = _('impact groups')
@@ -1383,7 +1395,7 @@ class MonitoringQualityPoint(PlanRelatedModelWithRevision, OrderedModel):
         'id', 'name', 'description_yes', 'description_no', 'plan', 'identifier',
     ]
 
-    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+    class Meta:
         verbose_name = _('monitoring quality point')
         verbose_name_plural = _('monitoring quality points')
         unique_together = (('plan', 'order'),)

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import AsyncGenerator
+from datetime import datetime
 from itertools import chain
 from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Generic, Protocol, TypeVar
 from urllib.parse import urlparse
 
 import graphene
 import strawberry
+import strawberry as sb
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Prefetch, Q, QuerySet, prefetch_related_objects
 from django.forms import ModelForm
@@ -36,6 +39,7 @@ from aplans.cache import SerializedDictWithRelatedObjectCache
 from aplans.graphql_helpers import ModelAdminAdminButtonsMixin
 from aplans.graphql_types import (
     DjangoNode,
+    SBInfo,
     WorkflowStateDescription,
     WorkflowStateEnum,
     get_plan_from_context,
@@ -103,7 +107,7 @@ from .models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import AsyncGenerator, Iterable, Mapping, Sequence
 
     from django_stubs_ext import StrOrPromise
 
@@ -331,6 +335,7 @@ class PlanNode(DjangoNode[Plan]):
     )
 
     has_indicator_relationships = graphene.Boolean()
+
     @staticmethod
     @gql_optimizer.resolver_hints(
         model_field='indicator_levels',
@@ -1774,7 +1779,6 @@ class Query:
             'description': WorkflowStateEnum(e).description,
         } for e in result]
 
-
     @staticmethod
     def resolve_plan(_root: Query, info: GQLInfo, id: str | None = None, domain: str | None = None, **_kwargs) -> Plan | None:
         if not id and not domain:
@@ -2026,3 +2030,29 @@ class UpdatePlanMutation(UpdateModelInstanceMutation):
 class Mutation(graphene.ObjectType[Any]):
     update_plan = UpdatePlanMutation.Field()
     update_action_responsible_party = UpdateActionResponsiblePartyMutation.Field()
+
+
+@sb.type
+class PlanUpdate:
+    identifier: sb.ID
+    cache_invalidated_at: datetime
+
+
+@sb.type
+class Subscription:
+    @sb.subscription
+    async def plan_cache_invalidations(self, info: SBInfo) -> AsyncGenerator[list[PlanUpdate]]:
+        ws = info.context.get_ws_consumer()
+        channel_layer = ws.channel_layer
+        if channel_layer is None:
+            raise ValueError('Channel layer is not available')
+        await channel_layer.group_add('plan_cache_invalidations', ws.channel_name)
+        async with ws.listen_to_channel('plan.cache_invalidated') as listener:
+            async for message in listener:
+                plan_identifier = message.get('plan_identifier')
+                if plan_identifier is None:
+                    continue
+                invalidated_at = message.get('invalidated_at')
+                if invalidated_at is None:
+                    continue
+                yield [PlanUpdate(identifier=plan_identifier, cache_invalidated_at=datetime.fromisoformat(invalidated_at))]

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1721,6 +1721,7 @@ def _resolve_action_revision(action: Action, desired_workflow_state: WorkflowSta
 class Query:
     plan = gql_optimizer.field(graphene.Field(PlanNode, id=graphene.ID(), domain=graphene.String()))
     plans_for_hostname = graphene.List(graphene.NonNull(PlanInterface), hostname=graphene.String())
+    plans = graphene.List(graphene.NonNull(PlanNode))
     my_plans = graphene.List(PlanNode)
 
     action = graphene.Field(ActionNode, id=graphene.ID(), identifier=graphene.ID(), plan=graphene.ID())
@@ -1804,6 +1805,15 @@ class Query:
         if not ret:
             logger.info("No plans found for hostname %s (wildcard domains: %s)" % (hostname, req.wildcard_domains))
         return ret
+
+    @staticmethod
+    def resolve_plans(_root: Query, info: GQLInfo) -> list[Plan]:
+        user = user_or_none(info.context.user)
+        if user is None or not user.is_superuser:
+            return []
+
+        qs = Plan.objects.get_queryset().visible_for_user(info.context.user)
+        return list(qs)
 
     @staticmethod
     def resolve_my_plans(_root, info: GQLInfo):

--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -254,3 +254,220 @@ with Wagtail's styles but so far these are required.
     text-decoration: underline;
   }
 }
+
+/*
+ * Select2 / Autocomplete widget styling
+ * Harmonize Select2 widgets with Wagtail's native text input styling
+ */
+
+/* Base styling for Select2 selection containers (single and multiple) */
+.select2-container--default .select2-selection--single,
+.select2-container--default .select2-selection--multiple {
+  min-height: 2.625rem; /* Match Wagtail's $text-input-height: 42px */
+  border-radius: 0.3125rem; /* Match Wagtail's default border-radius: 5px */
+  border: 1px solid var(--w-color-border-field-default);
+  background-color: var(--w-color-surface-field);
+  font-size: 1.1875rem; /* Match Wagtail's body-text-large: 19px */
+  line-height: 1.5;
+}
+
+/* Hover state */
+.select2-container--default .select2-selection--single:hover,
+.select2-container--default .select2-selection--multiple:hover {
+  border-color: var(--w-color-border-field-hover);
+}
+
+/* Focus state */
+.select2-container--default.select2-container--focus .select2-selection--single,
+.select2-container--default.select2-container--focus .select2-selection--multiple,
+.select2-container--default.select2-container--open .select2-selection--single,
+.select2-container--default.select2-container--open .select2-selection--multiple {
+  border-color: var(--w-color-border-field-hover);
+  outline: none;
+}
+
+/* Single select: rendered text wrapper - handles the text and clear button */
+/* Using !important to override default Select2 styles */
+.select2-container--default .select2-selection--single .select2-selection__rendered {
+  color: var(--w-color-text-context);
+  padding-top: 0.375rem !important;
+  padding-bottom: 0.375rem !important;
+  padding-left: 1.25rem !important;
+  padding-right: 2.5rem !important; /* Leave room for arrow */
+  line-height: calc(2.625rem - 0.75rem - 2px); /* height - vertical padding - border */
+  display: block;
+}
+
+/* Single select: placeholder */
+.select2-container--default .select2-selection--single .select2-selection__placeholder {
+  color: var(--w-color-text-placeholder);
+}
+
+/* Single select: arrow positioning */
+/* Using !important to override default Select2 styles */
+.select2-container--default .select2-selection--single .select2-selection__arrow {
+  position: absolute;
+  top: 0 !important;
+  right: 0 !important;
+  height: 100% !important;
+  width: 2rem !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Fix arrow icon */
+.select2-container--default .select2-selection--single .select2-selection__arrow b {
+  border-width: 5px 4px 0 4px;
+  margin-left: 0;
+  margin-top: 0;
+  position: static;
+  top: auto;
+  left: auto;
+}
+
+/* Multiple select: rendered container */
+.select2-container--default .select2-selection--multiple .select2-selection__rendered {
+  padding: 0.375rem 1.25rem !important; /* Match Wagtail's input padding */
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center;
+  gap: 0.375rem; /* Vertical and horizontal spacing between pills */
+  white-space: normal !important; /* Allow wrapping */
+}
+
+/* Multiple select: choice pills */
+.select2-container--default .select2-selection--multiple .select2-selection__choice {
+  background-color: var(--w-color-surface-header);
+  border: 1px solid var(--w-color-border-field-default);
+  border-radius: 0.3125rem; /* Match main border-radius */
+  color: var(--w-color-text-context);
+  margin: 0 !important;
+  padding: 0.25rem 0.625rem !important;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.1875rem; /* Match main input font size */
+  line-height: 1.3;
+  float: none !important; /* Override default float */
+  max-width: calc(100% - 1rem); /* Prevent overflow, leave some margin */
+  /* Text overflow handling - only for content inside pill */
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Multiple select: choice remove button */
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove {
+  color: var(--w-color-icon-secondary);
+  margin-right: 0.5rem !important; /* More space between x and text */
+  order: -1; /* Move remove button to the left */
+  font-size: 1.1875rem;
+  line-height: 1;
+  flex-shrink: 0; /* Don't shrink the x button */
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__choice__remove:hover {
+  color: var(--w-color-text-context);
+}
+
+/* Multiple select: search input inside */
+.select2-container--default .select2-selection--multiple .select2-search--inline .select2-search__field {
+  margin: 0;
+  padding: 0.25rem 0;
+  font-size: 1.1875rem;
+}
+
+/* Dropdown styling */
+.select2-container--default .select2-dropdown {
+  border: 1px solid var(--w-color-border-field-default);
+  border-radius: 0.3125rem;
+  background-color: var(--w-color-surface-field);
+  box-shadow: 5px 5px 20px rgba(0, 0, 0, 0.05);
+}
+
+/* Dropdown: search field */
+.select2-container--default .select2-search--dropdown .select2-search__field {
+  border: 1px solid var(--w-color-border-field-default);
+  border-radius: 0.3125rem;
+  background-color: var(--w-color-surface-field);
+  color: var(--w-color-text-context);
+  padding: 0.375rem 1.25rem;
+  min-height: 2.625rem;
+  font-size: 1.1875rem;
+  line-height: 1.5;
+}
+
+.select2-container--default .select2-search--dropdown .select2-search__field:focus {
+  border-color: var(--w-color-border-field-hover);
+  outline: none;
+}
+
+/* Dropdown: results */
+.select2-container--default .select2-results__option {
+  color: var(--w-color-text-context);
+  padding: 0.5rem 1.25rem;
+  font-size: 1.1875rem;
+}
+
+/* Dropdown: highlighted option */
+.select2-container--default .select2-results__option--highlighted[aria-selected] {
+  background-color: var(--w-color-surface-button-default);
+  color: var(--w-color-text-button);
+}
+
+/* Dropdown: selected option */
+.select2-container--default .select2-results__option[aria-selected="true"] {
+  background-color: var(--w-color-surface-header);
+}
+
+/* Disabled state */
+.select2-container--default.select2-container--disabled .select2-selection--single,
+.select2-container--default.select2-container--disabled .select2-selection--multiple {
+  background-color: var(--w-color-surface-field-inactive);
+  border-color: var(--w-color-border-field-inactive);
+  cursor: not-allowed;
+}
+
+.select2-container--default.select2-container--disabled .select2-selection--single .select2-selection__rendered {
+  color: var(--w-color-text-placeholder);
+}
+
+/* Error state */
+.w-field--error .select2-container--default .select2-selection--single,
+.w-field--error .select2-container--default .select2-selection--multiple {
+  border-color: var(--w-color-critical-200);
+}
+
+/* Clear button styling for single select - position absolutely within the selection */
+.select2-container--default .select2-selection--single .select2-selection__clear {
+  color: var(--w-color-icon-secondary);
+  font-size: 1.1875rem;
+  font-weight: 400;
+  position: absolute !important;
+  right: 2.5rem !important; /* Position before the arrow */
+  top: 50% !important;
+  transform: translateY(-50%);
+  float: none !important;
+  margin: 0 !important;
+}
+
+.select2-container--default .select2-selection--single .select2-selection__clear:hover {
+  color: var(--w-color-text-context);
+}
+
+/* Clear button styling for multiple select - position absolutely */
+.select2-container--default .select2-selection--multiple .select2-selection__clear {
+  color: var(--w-color-icon-secondary);
+  font-size: 1.1875rem;
+  font-weight: 400;
+  position: absolute !important;
+  right: 0.75rem !important;
+  top: 50% !important;
+  transform: translateY(-50%);
+  float: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__clear:hover {
+  color: var(--w-color-text-context);
+}

--- a/aplans/asgi.py
+++ b/aplans/asgi.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.1/howto/deployment/asgi/
 from __future__ import annotations
 
 import os
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, cast
 
 from django.core.asgi import get_asgi_application
@@ -22,11 +23,23 @@ from kausal_common.asgi.middleware import HTTPMiddleware, WebSocketMiddleware
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from fastmcp.server.http import StarletteWithLifespan
+
+    from mcp_server.auth import MCPAuthMiddleware
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'aplans.settings')
 
 django_asgi_app = get_asgi_application()
 
 class AuthGraphQLProtocolTypeRouter(ProtocolTypeRouter):
+    def _get_mcp_server_app(self) -> tuple[StarletteWithLifespan, MCPAuthMiddleware]:
+        from mcp_server.auth import MCPAuthMiddleware
+        from mcp_server.server import mcp as mcp_server
+
+        mcp_asgi_app = mcp_server.http_app(path='/mcp', stateless_http=True)
+        mcp_with_auth = MCPAuthMiddleware(mcp_asgi_app, resource_path='mcp')
+        return mcp_asgi_app, mcp_with_auth
+
     def __init__(self):
         from django.conf import settings
         from django.urls import URLPattern, URLResolver, re_path
@@ -34,7 +47,7 @@ class AuthGraphQLProtocolTypeRouter(ProtocolTypeRouter):
         from channels.routing import URLRouter
 
         from .graphql_views import WatchGraphQLHTTPConsumer, WatchGraphQLWSConsumer
-        from .schema import schema
+        from .schema import async_schema, schema
 
         re_path_any = cast('Callable[[str, Any], URLPattern | URLResolver]', re_path)
 
@@ -45,26 +58,39 @@ class AuthGraphQLProtocolTypeRouter(ProtocolTypeRouter):
         if not settings.ENABLE_DEBUG_TOOLBAR:
             graphql_asgi_app = HTTPMiddleware(WatchGraphQLHTTPConsumer.as_asgi(schema=schema))
             http_urls.append(re_path_any(gql_url_pattern, graphql_asgi_app))
-        http_urls.append(re_path_any(r"^static/", Mount(path='/static', app=StaticFiles(directory=settings.STATIC_ROOT))))
+        if not settings.DEBUG:
+            http_urls.append(re_path_any(r"^static/", Mount(path='/static', app=StaticFiles(directory=settings.STATIC_ROOT))))
+
+        # MCP server with our own auth middleware (wraps the FastMCP app)
+        # Use stateless_http=True to avoid session tracking issues on server restart
+        if settings.ENABLE_MCP_SERVER:
+            if find_spec('fastmcp') is None:
+                raise RuntimeError("MCP server is enabled, but fastmcp is not installed.")
+            mcp_asgi_app, mcp_with_auth = self._get_mcp_server_app()
+            http_urls.append(re_path_any(r"^mcp[/]?$", HTTPMiddleware(mcp_with_auth)))
+        else:
+            mcp_asgi_app = None
         http_urls.append(re_path_any(r"^", django_asgi_app))
 
-        super().__init__(
-            {
+        type_routing = {
                 "http": URLRouter(
-                    http_urls,
+                    http_urls,  # pyright: ignore[reportArgumentType]
                 ),
                 "websocket": WebSocketMiddleware(
                     URLRouter(
                         [
-                            re_path_any(
+                            re_path_any(  # pyright: ignore[reportArgumentType]
                                 gql_url_pattern,
-                                WatchGraphQLWSConsumer.as_asgi(schema=schema),
+                                WatchGraphQLWSConsumer.as_asgi(schema=async_schema),
                             ),
                         ],
                     ),
                 ),
-            },
-        )
+        }
+        if mcp_asgi_app:
+            type_routing['lifespan'] = mcp_asgi_app.router.lifespan
+
+        super().__init__(type_routing)
 
 
 application = AuthGraphQLProtocolTypeRouter()

--- a/aplans/graphql_views.py
+++ b/aplans/graphql_views.py
@@ -58,7 +58,7 @@ class WatchExecutionContext(ExecutionContext):
 
 class WatchGraphQLWSConsumer(GraphQLWSConsumer[WatchGraphQLContext]):
     @override
-    async def get_context(self, request: GraphQLWSConsumer, response: GraphQLWSConsumer) -> WatchGraphQLContext:  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def get_context(self, request: GraphQLWSConsumer, response: GraphQLWSConsumer) -> WatchGraphQLContext:
         base_ctx = await self.get_base_context(request, response)
         return WatchGraphQLContext(
             **base_ctx,

--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -12,6 +12,7 @@ from graphql.type import (
     GraphQLDirective,
 )
 from strawberry.schema import Schema as StrawberrySchema
+from strawberry.tools import merge_types
 from strawberry.types import has_object_definition
 
 import graphene_django_optimizer as gql_optimizer
@@ -322,6 +323,9 @@ def _validate_type_registry(types: set[type]) -> None:
         registered_names.add(name)
 
 
+Subscription = merge_types('Subscription', (actions_schema.Subscription,))
+
+
 def generate_strawberry_schema() -> sb.Schema:
     from kausal_common.graphene.registry import registry as graphene_registry
     from kausal_common.strawberry.registry import strawberry_types
@@ -335,6 +339,7 @@ def generate_strawberry_schema() -> sb.Schema:
     schema = WatchSchema(
         query=Query,
         mutation=Mutation,
+        subscription=Subscription,
         types=all_types,
         directives=[context_directive, workflow_directive, auth_directive],
     )

--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -23,6 +23,7 @@ from kausal_common.models.types import copy_signature
 from kausal_common.strawberry.extensions import LoggingTracingExtension
 from kausal_common.strawberry.schema import Schema as UnifiedSchema
 from kausal_common.users import user_or_none
+from kausal_common.users.schema import UserNode
 
 from aplans.cache import OrganizationActionCountCache
 from aplans.graphql_types import WorkflowStateGrapheneEnum
@@ -61,6 +62,7 @@ if TYPE_CHECKING:
     from aplans.graphql_types import GQLInfo
 
     from actions.models import Plan
+    from users.models import User
 
 
 def mp_node_get_ancestors[QS: MP_NodeQuerySet[Any]](qs: QS, include_self: bool = False) -> QS:
@@ -102,6 +104,7 @@ class Query(
         required=False,
     )
     person = graphene.Field(people_schema.PersonNode, id=graphene.ID(required=True), plan=graphene.ID(required=True))
+    me = graphene.Field(UserNode, required=False, description='The current user')
 
     def resolve_plan_organizations(
         self, info: GQLInfo, plan: str | None, with_ancestors: bool, for_responsible_parties: bool, for_contact_persons: bool,
@@ -193,6 +196,9 @@ class Query(
             return None
         qs = Person.objects.get_queryset().available_for_plan(plan_obj).visible_for_user(user, plan=plan_obj)
         return qs.filter(id=id).first()
+
+    def resolve_me(self, info: GQLInfo) -> User | None:
+        return user_or_none(info.context.user)
 
 
 @sb.type
@@ -336,3 +342,6 @@ def generate_strawberry_schema() -> sb.Schema:
 
 
 schema = generate_strawberry_schema()
+# We need a separate schema instance for async operations due to
+# some weird behavior in the GraphQL MiddlewareManager.
+async_schema = generate_strawberry_schema()

--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -101,6 +102,7 @@ env = environ.FileAwareEnv(
     ENABLE_DEBUG_TOOLBAR=(bool, False),
     KAUSAL_PATHS_URL=(str, ''),
     DISABLE_WAGTAIL_EDITING_SESSION_PING=(bool, False),
+    ENABLE_MCP_SERVER=(bool, False),
     **COMMON_ENV_SCHEMA,
 )
 
@@ -118,12 +120,12 @@ else:
 
 # Read all files in the directories given in MOUNTED_SECRET_PATHS whose names look like environment variables and use
 # the contents of the files for the corresponding variables
-for directory in env('MOUNTED_SECRET_PATHS'):
+for directory in cast('list[str]', env('MOUNTED_SECRET_PATHS')):
     set_secret_file_vars(env, directory)
 
-DEBUG = env('DEBUG')
-DEPLOYMENT_TYPE = env('DEPLOYMENT_TYPE')
-ALLOWED_HOSTS = env('ALLOWED_HOSTS')
+DEBUG = cast('bool', env('DEBUG'))
+DEPLOYMENT_TYPE = cast('str', env('DEPLOYMENT_TYPE'))
+ALLOWED_HOSTS = cast('list[str]', env('ALLOWED_HOSTS'))
 INTERNAL_IPS = env.list('INTERNAL_IPS',
                         default=(['127.0.0.1'] if DEBUG else []))  # pyright: ignore
 DATABASES = {
@@ -137,7 +139,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # If Redis is configured, but no CACHE_URL is set in the environment,
 # default to using Redis as the cache.
-REDIS_URL = env('REDIS_URL')
+REDIS_URL = cast('str', env('REDIS_URL'))
 
 cache_var = 'CACHE_URL'
 if env.get_value('CACHE_URL', default=None) is None and REDIS_URL:  # pyright: ignore
@@ -200,6 +202,8 @@ INSTALLED_APPS = [
     'django_extensions',
     'modeltrans',
     'corsheaders',
+    'channels',
+    'strawberry_django',
 
     'wagtail.contrib.forms',
     'wagtail.contrib.redirects',
@@ -319,7 +323,7 @@ STORAGES: dict[str, dict[str, Any]] = {
 if 'pytest' in sys.modules:
     STORAGES['default']['BACKEND'] = 'django.core.files.storage.InMemoryStorage'
 else:
-    media_storage_url: ParseResult = env.url('S3_MEDIA_STORAGE_URL')
+    media_storage_url: ParseResult = cast('ParseResult', env.url('S3_MEDIA_STORAGE_URL'))
     if media_storage_url.scheme:
         if media_storage_url.scheme != 's3':
             raise ImproperlyConfigured('S3_MEDIA_STORAGE_URL only supports s3 scheme')
@@ -448,6 +452,27 @@ REST_FRAMEWORK = {
     'DEFAULT_SCHEMA_CLASS': f'{PROJECT_NAME}.openapi.AutoSchema',
 }
 
+
+if REDIS_URL:
+    CHANNEL_LAYERS = {
+        'default': {
+            'BACKEND': 'channels_redis.core.RedisChannelLayer',
+            'CONFIG': {
+                'hosts': [REDIS_URL],
+                'prefix': f'{PROJECT_NAME}-asgi',
+            },
+        },
+    }
+else:
+    CHANNEL_LAYERS = {
+        'default': {
+            'BACKEND': 'channels.layers.InMemoryChannelLayer',
+        },
+    }
+ENABLE_MCP_SERVER = cast('bool', env('ENABLE_MCP_SERVER'))
+
+if REDIS_URL and not os.getenv('FASTMCP_DOCKET_URL'):
+    os.environ['FASTMCP_DOCKET_URL'] = REDIS_URL
 
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_HEADERS = list(default_cors_headers) + get_allowed_cors_headers() + [
@@ -799,7 +824,7 @@ MEDIA_ROOT = env('MEDIA_ROOT')
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-SENTRY_DSN = env('SENTRY_DSN')
+SENTRY_DSN = cast('str', env('SENTRY_DSN'))
 
 SILENCED_SYSTEM_CHECKS = [
     'fields.W904',  # postgres JSONField -> django JSONField
@@ -840,7 +865,7 @@ if not locals().get('SECRET_KEY', ''):
 
         system_random = random.SystemRandom()
         try:
-            SECRET_KEY = ''.join([system_random.choice('abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)') for i in range(64)])
+            SECRET_KEY = ''.join([system_random.choice('abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)') for _i in range(64)])
             with secret_file.open('w') as f:
                 secret_file.chmod(0o0600)
                 f.write(SECRET_KEY)
@@ -868,16 +893,18 @@ LOGGING = None
 if env('CONFIGURE_LOGGING'):
     from kausal_common.logging.init import LogFormat, UserLoggingOptions, init_logging_django
 
-    is_kube = env.bool('KUBERNETES_MODE') or env.bool('KUBERNETES_LOGGING', False) # type: ignore
+    kube_mode = cast('bool', env.bool('KUBERNETES_MODE'))
+    kube_logging = cast('bool', env.bool('KUBERNETES_LOGGING', default=False))  # pyright: ignore[reportArgumentType]
+    enable_kube_logging = kube_mode or kube_logging
     log_format: LogFormat | None
-    if not is_kube and DEBUG:
+    if not enable_kube_logging and DEBUG:
         # If logfmt hasn't been explicitly selected and DEBUG is on, fall back to autodetection.
         log_format = None
     else:
         log_format = 'logfmt'
 
     if DEBUG:
-        runserver_logging = dict(
+        runserver_logging = cast('dict[str, bool]', dict(
             django_runserver_minimize_noise=env('LOG_DJANGO_RUNSERVER_MINIMIZE_NOISE'),
             django_runserver_requests_media=env('LOG_DJANGO_RUNSERVER_REQUESTS_MEDIA'),
             django_runserver_requests_static=env('LOG_DJANGO_RUNSERVER_REQUESTS_STATIC'),
@@ -887,7 +914,7 @@ if env('CONFIGURE_LOGGING'):
             django_runserver_errors_favicon=env('LOG_DJANGO_RUNSERVER_ERRORS_FAVICON'),
             django_runserver_requests_broken_pipe=env('LOG_DJANGO_RUNSERVER_REQUESTS_BROKEN_PIPE'),
             people_verbose=env('LOG_PEOPLE_VERBOSE'),
-        )
+        ))
     else:
         runserver_logging = dict()
 

--- a/aplans/urls.py
+++ b/aplans/urls.py
@@ -175,6 +175,10 @@ urlpatterns = [
     path('', RootRedirectView.as_view(), name='root-redirect'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+if settings.DEBUG:
+    from django.contrib.staticfiles.views import serve as serve_static
+    urlpatterns.append(re_path(r"^static/(?P<path>.*)$", serve_static))
+
 
 if kwe_urls:
     urlpatterns.append(path('', include(kwe_urls)))

--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -1,0 +1,141 @@
+# MCP Server Architecture
+
+## Overview
+
+Kausal Watch exposes an MCP (Model Context Protocol) server at `/mcp` to enable AI assistants (LibreChat, Claude.ai, etc.) to query climate action plan data.
+
+## Architecture
+
+- **Framework**: FastMCP with Streamable HTTP transport
+- **Mounting**: Under `/mcp` in the Django ASGI app via `ProtocolTypeRouter`
+- **Authentication**: OAuth2 Bearer tokens via existing `HTTPMiddleware`
+- **Data Layer**: GraphQL queries executed programmatically, reusing all existing permission logic
+
+## File Structure
+
+```
+mcp_server/
+├── __init__.py              # Package init
+├── server.py                # FastMCP app, core utilities, and tool registration
+├── queries.graphql          # GraphQL queries for MCP tools
+├── mcp_client_tool.py       # CLI tool for testing
+├── tools/                   # Tool implementations by domain
+│   ├── __init__.py          # Exports register functions
+│   ├── helpers.py           # Shared utilities (execute_operation)
+│   ├── plan.py              # Plan-related tools (list_plans, get_plan)
+│   ├── action.py            # Action-related tools (list_actions, get_action)
+│   └── user.py              # User-related tools (user_details)
+└── __generated__/           # Auto-generated GraphQL client code (DO NOT EDIT)
+    └── schema.py            # Pydantic models for all operations
+```
+
+## Development Workflow
+
+### Adding a New Tool
+
+1. **Add the GraphQL query** to `mcp_server/queries.graphql`:
+
+   ```graphql
+   query MCPGetPlan($identifier: ID!) @context(input: {identifier: $identifier}) {
+       plan(id: $identifier) {
+           id
+           identifier
+           name
+           shortName
+           # ... other fields
+       }
+   }
+   ```
+
+   > **Note**: Use the `@context` directive on plan-specific queries to activate the
+   > correct language and plan context. Pass the plan identifier via
+   > `@context(input: {identifier: $planVariable})`.
+
+2. **Regenerate the client code**:
+
+   ```bash
+   python manage.py export_schema aplans.schema > schema.graphql
+   uvx turms gen
+   ```
+
+   This generates typed Pydantic models in `mcp_server/__generated__/schema.py`.
+
+3. **Add the tool** to the appropriate file in `mcp_server/tools/`:
+
+   ```python
+   # In mcp_server/tools/plan.py
+   from mcp_server.__generated__.schema import MCPGetPlan
+
+   from .helpers import execute_operation
+
+   async def get_plan(identifier: str) -> MCPGetPlan:
+       """Get plan details by identifier."""
+       result = await execute_operation(MCPGetPlan, MCPGetPlan.Arguments(identifier=identifier))
+       if result.plan is None:
+           raise ToolError(f"Plan '{identifier}' not found")
+       return result
+   ```
+
+   Tools are organized by domain (e.g., `plan.py`, `action.py`, `indicator.py`).
+   Each module exports a `register_*_tools(mcp)` function called from `server.py`.
+   The tool schema is introspected through the function type annotations,
+   so the types need to be available in runtime (not imported in a TYPE_CHECKING block).
+
+## Testing
+
+### Using the CLI Tool
+
+The `mcp_client_tool.py` script provides a simple way to test the MCP server:
+
+```bash
+# List available tools
+uv run mcp_server/mcp_client_tool.py --list-tools
+
+# Call a tool
+uv run mcp_server/mcp_client_tool.py --call list_plans
+
+# Call with arguments
+uv run mcp_server/mcp_client_tool.py --call hello_world --args '{"name": "World"}'
+
+# Get raw JSON output
+uv run mcp_server/mcp_client_tool.py --call list_plans --raw
+```
+
+**Prerequisites**: Set `MCP_CLIENT_TOKEN` in your `.env` file with a valid OAuth2 access token.
+
+### Using MCP Inspector
+
+1. Start the server: `uvicorn aplans.asgi:application --reload`
+2. Open MCP Inspector and connect to `http://localhost:8000/mcp`
+3. Add authorization header: `Authorization: Bearer <your-token>`
+
+## Authentication Flow
+
+1. Client sends `Authorization: Bearer <token>` header
+2. `HTTPMiddleware` validates the token and sets `scope['user']`
+3. `WatchGraphQLContext` reads the user from the ASGI scope
+4. GraphQL resolvers use `info.context.user` for permission checks
+
+## v0 Tools (Read-Only)
+
+| Tool | Description | Status |
+|------|-------------|--------|
+| `list_plans` | List accessible plans | Implemented |
+| `get_plan` | Get plan details | Implemented |
+| `list_actions` | List/filter actions | Implemented |
+| `get_action` | Get action details | Implemented |
+| `user_details` | Get current user info | Implemented |
+| `search` | Full-text search | Planned |
+| `list_indicators` | List indicators | Planned |
+| `get_indicator` | Get indicator with values | Planned |
+| `get_category_tree` | Hierarchical categories | Planned |
+| `list_organizations` | Organizations in plan | Planned |
+| `get_action_status_summary` | Dashboard stats | Planned |
+
+## Future Considerations
+
+- Write tools (update action status, add comments)
+- Customer-facing deployment with plan-scoped tokens
+- MCP Resources for plans/actions
+- MCP Prompts for common queries
+- Generalize to `kausal_common` for Kausal Paths reuse

--- a/graphql.config.yaml
+++ b/graphql.config.yaml
@@ -1,0 +1,21 @@
+projects:
+  mcp_server:
+    schema: schema.graphql
+    documents: mcp_server/queries.graphql
+    extensions:
+      turms: # path for configuration for turms
+        out_dir: mcp_server/__generated__
+        plugins: # path for plugin configuration
+          - type: turms.plugins.enums.EnumsPlugin
+          - type: turms.plugins.inputs.InputsPlugin
+          - type: turms.plugins.fragments.FragmentsPlugin
+          - type: turms.plugins.operations.OperationsPlugin
+          - type: turms.plugins.funcs.FuncsPlugin
+        stylers:
+          - type: turms.stylers.snake_case.SnakeCaseStyler
+        # processors:
+        #   - type: turms.processors.black.BlackProcessor
+        #   - type: turms.processors.isort.IsortProcessor
+        scalar_definitions:
+          UUID: str
+          Date: str

--- a/mcp_server/__generated__/schema.py
+++ b/mcp_server/__generated__/schema.py
@@ -1,0 +1,778 @@
+from typing import Optional, Annotated, Literal, Union, List
+from pydantic import BaseModel, Field, ConfigDict
+from datetime import datetime
+from enum import Enum
+
+class ActionContactPersonRole(str, Enum):
+    """An enumeration."""
+    EDITOR = 'EDITOR'
+    'Editor'
+    MODERATOR = 'MODERATOR'
+    'Moderator'
+
+class ActionDateFormat(str, Enum):
+    """An enumeration."""
+    FULL = 'FULL'
+    'Day, month and year (31.12.2020)'
+    MONTH_YEAR = 'MONTH_YEAR'
+    'Month and year (12.2020)'
+    YEAR = 'YEAR'
+    'Year (2020)'
+
+class ActionIndicatorEffectType(str, Enum):
+    """An enumeration."""
+    INCREASES = 'INCREASES'
+    'increases'
+    DECREASES = 'DECREASES'
+    'decreases'
+
+class ActionResponsiblePartyRole(str, Enum):
+    """An enumeration."""
+    NONE = 'NONE'
+    'Unspecified'
+    PRIMARY = 'PRIMARY'
+    'Primary responsible party'
+    COLLABORATOR = 'COLLABORATOR'
+    'Collaborator'
+
+class ActionStatusSummaryIdentifier(str, Enum):
+    """An enumeration."""
+    COMPLETED = 'COMPLETED'
+    ON_TIME = 'ON_TIME'
+    IN_PROGRESS = 'IN_PROGRESS'
+    NOT_STARTED = 'NOT_STARTED'
+    LATE = 'LATE'
+    CANCELLED = 'CANCELLED'
+    OUT_OF_SCOPE = 'OUT_OF_SCOPE'
+    MERGED = 'MERGED'
+    POSTPONED = 'POSTPONED'
+    UNDEFINED = 'UNDEFINED'
+
+class ActionTaskState(str, Enum):
+    """An enumeration."""
+    NOT_STARTED = 'NOT_STARTED'
+    'not started'
+    IN_PROGRESS = 'IN_PROGRESS'
+    'in progress'
+    COMPLETED = 'COMPLETED'
+    'completed'
+    CANCELLED = 'CANCELLED'
+    'cancelled'
+
+class ActionTimelinessIdentifier(str, Enum):
+    """An enumeration."""
+    OPTIMAL = 'OPTIMAL'
+    ACCEPTABLE = 'ACCEPTABLE'
+    LATE = 'LATE'
+    STALE = 'STALE'
+
+class ActionVisibility(str, Enum):
+    """An enumeration."""
+    INTERNAL = 'INTERNAL'
+    'Internal'
+    PUBLIC = 'PUBLIC'
+    'Public'
+
+class AttributeTypeFormat(str, Enum):
+    """An enumeration."""
+    ORDERED_CHOICE = 'ORDERED_CHOICE'
+    'Ordered choice'
+    OPTIONAL_CHOICE = 'OPTIONAL_CHOICE'
+    'Optional choice with optional text'
+    UNORDERED_CHOICE = 'UNORDERED_CHOICE'
+    'Choice'
+    TEXT = 'TEXT'
+    'Text'
+    RICH_TEXT = 'RICH_TEXT'
+    'Rich text'
+    NUMERIC = 'NUMERIC'
+    'Numeric'
+    CATEGORY_CHOICE = 'CATEGORY_CHOICE'
+    'Category'
+
+class Comparison(str, Enum):
+    """An enumeration."""
+    LTE = 'LTE'
+    GT = 'GT'
+
+class PlanFeaturesContactPersonsPublicData(str, Enum):
+    """An enumeration."""
+    NONE = 'NONE'
+    'Do not show contact persons publicly'
+    NAME = 'NAME'
+    'Show only name, role and affiliation'
+    ALL = 'ALL'
+    'Show all information'
+    ALL_FOR_AUTHENTICATED = 'ALL_FOR_AUTHENTICATED'
+    'Show all information but only for authenticated users'
+
+class Sentiment(str, Enum):
+    """An enumeration."""
+    POSITIVE = 'POSITIVE'
+    NEGATIVE = 'NEGATIVE'
+    NEUTRAL = 'NEUTRAL'
+
+class MCPUserDetailsMe(BaseModel):
+    """No documentation"""
+    typename: Literal['User'] = Field(alias='__typename', default='User')
+    id: str
+    uuid: str
+    email: str
+    first_name: str = Field(alias='firstName')
+    last_name: str = Field(alias='lastName')
+    is_superuser: bool = Field(alias='isSuperuser')
+
+class MCPUserDetails(BaseModel):
+    """No documentation found for this operation."""
+    me: Optional[MCPUserDetailsMe] = Field(default=None)
+    'The current user'
+
+    class Arguments(BaseModel):
+        """Arguments for MCPUserDetails """
+        model_config = ConfigDict(populate_by_name=None)
+
+    class Meta:
+        """Meta class for MCPUserDetails """
+        document = 'query MCPUserDetails {\n  me {\n    id\n    uuid\n    email\n    firstName\n    lastName\n    isSuperuser\n    __typename\n  }\n}'
+
+class MCPListPlansPlans(BaseModel):
+    """The Action Plan under monitoring.
+
+Most information in this service is linked to a Plan."""
+    typename: Literal['Plan'] = Field(alias='__typename', default='Plan')
+    id: str
+    identifier: str
+    'A unique identifier for the plan used internally to distinguish between plans. This becomes part of the test site URL: https://[identifier].watch-test.kausal.tech. Use lowercase letters and dashes.'
+    name: str
+    'The official plan name in full form'
+    short_name: Optional[str] = Field(default=None, alias='shortName')
+    'A shorter version of the plan name'
+    version_name: str = Field(alias='versionName')
+    'If this plan has multiple versions, name of this version'
+    primary_language: str = Field(alias='primaryLanguage')
+    other_languages: List[str] = Field(alias='otherLanguages')
+    published_at: Optional[datetime] = Field(default=None, alias='publishedAt')
+    view_url: Optional[str] = Field(default=None, alias='viewUrl')
+
+class MCPListPlans(BaseModel):
+    """No documentation found for this operation."""
+    plans: Optional[List[MCPListPlansPlans]] = Field(default=None)
+
+    class Arguments(BaseModel):
+        """Arguments for MCPListPlans """
+        model_config = ConfigDict(populate_by_name=None)
+
+    class Meta:
+        """Meta class for MCPListPlans """
+        document = 'query MCPListPlans {\n  plans {\n    id\n    identifier\n    name\n    shortName\n    versionName\n    primaryLanguage\n    otherLanguages\n    publishedAt\n    viewUrl\n    __typename\n  }\n}'
+
+class MCPListActionsPlanactionsStatus(BaseModel):
+    """The current status for the action ("on time", "late", "completed", etc.)."""
+    typename: Literal['ActionStatus'] = Field(alias='__typename', default='ActionStatus')
+    id: str
+    identifier: str
+    name: str
+    is_completed: bool = Field(alias='isCompleted')
+
+class MCPListActionsPlanactionsImplementationphase(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionImplementationPhase'] = Field(alias='__typename', default='ActionImplementationPhase')
+    id: str
+    identifier: str
+    name: str
+
+class MCPListActionsPlanactionsStatussummary(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionStatusSummary'] = Field(alias='__typename', default='ActionStatusSummary')
+    identifier: ActionStatusSummaryIdentifier
+    label: str
+    sentiment: Sentiment
+    is_active: bool = Field(alias='isActive')
+    is_completed: bool = Field(alias='isCompleted')
+
+class MCPListActionsPlanactionsResponsiblepartiesOrganization(BaseModel):
+    """No documentation"""
+    typename: Literal['Organization'] = Field(alias='__typename', default='Organization')
+    id: str
+    name: str
+    'Full name of the organization'
+    abbreviation: Optional[str] = Field(default=None)
+    'Short version or abbreviation of the organization name to be displayed when it is not necessary to show the full name'
+
+class MCPListActionsPlanactionsResponsibleparties(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionResponsibleParty'] = Field(alias='__typename', default='ActionResponsibleParty')
+    id: str
+    organization: MCPListActionsPlanactionsResponsiblepartiesOrganization
+
+class MCPListActionsPlanactionsPrimaryorg(BaseModel):
+    """No documentation"""
+    typename: Literal['Organization'] = Field(alias='__typename', default='Organization')
+    id: str
+    name: str
+    'Full name of the organization'
+    abbreviation: Optional[str] = Field(default=None)
+    'Short version or abbreviation of the organization name to be displayed when it is not necessary to show the full name'
+
+class MCPListActionsPlanactionsCategoriesType(BaseModel):
+    """Type of the categories.
+
+Is used to group categories together. One action plan can have several
+category types."""
+    typename: Literal['CategoryType'] = Field(alias='__typename', default='CategoryType')
+    id: str
+    identifier: str
+    name: str
+
+class MCPListActionsPlanactionsCategories(BaseModel):
+    """A category for actions and indicators."""
+    typename: Literal['Category'] = Field(alias='__typename', default='Category')
+    id: str
+    identifier: str
+    name: str
+    type: MCPListActionsPlanactionsCategoriesType
+
+class MCPListActionsPlanactions(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+    official_name: Optional[str] = Field(default=None, alias='officialName')
+    'The name as approved by an official party'
+    completion: Optional[int] = Field(default=None)
+    'The completion percentage for this action'
+    schedule_continuous: bool = Field(alias='scheduleContinuous')
+    'Set if the action does not have a start or an end date'
+    start_date: Optional[str] = Field(default=None, alias='startDate')
+    'The date when implementation of this action starts'
+    end_date: Optional[str] = Field(default=None, alias='endDate')
+    'The date when implementation of this action ends'
+    updated_at: datetime = Field(alias='updatedAt')
+    status: Optional[MCPListActionsPlanactionsStatus] = Field(default=None)
+    implementation_phase: Optional[MCPListActionsPlanactionsImplementationphase] = Field(default=None, alias='implementationPhase')
+    status_summary: MCPListActionsPlanactionsStatussummary = Field(alias='statusSummary')
+    responsible_parties: List[MCPListActionsPlanactionsResponsibleparties] = Field(alias='responsibleParties')
+    primary_org: Optional[MCPListActionsPlanactionsPrimaryorg] = Field(default=None, alias='primaryOrg')
+    categories: List[MCPListActionsPlanactionsCategories]
+
+class MCPListActions(BaseModel):
+    """No documentation found for this operation."""
+    plan_actions: Optional[List[MCPListActionsPlanactions]] = Field(default=None, alias='planActions')
+
+    class Arguments(BaseModel):
+        """Arguments for MCPListActions """
+        plan: str
+        category: Optional[str] = Field(default=None)
+        first: Optional[int] = Field(default=None)
+        order_by: Optional[str] = Field(alias='orderBy', default=None)
+        model_config = ConfigDict(populate_by_name=None)
+
+    class Meta:
+        """Meta class for MCPListActions """
+        document = 'query MCPListActions($plan: ID!, $category: ID, $first: Int, $orderBy: String) @context(input: {identifier: $plan}) {\n  planActions(plan: $plan, category: $category, first: $first, orderBy: $orderBy) {\n    id\n    identifier\n    name\n    officialName\n    completion\n    scheduleContinuous\n    startDate\n    endDate\n    updatedAt\n    status {\n      id\n      identifier\n      name\n      isCompleted\n      __typename\n    }\n    implementationPhase {\n      id\n      identifier\n      name\n      __typename\n    }\n    statusSummary {\n      identifier\n      label\n      sentiment\n      isActive\n      isCompleted\n      __typename\n    }\n    responsibleParties {\n      id\n      organization {\n        id\n        name\n        abbreviation\n        __typename\n      }\n      __typename\n    }\n    primaryOrg {\n      id\n      name\n      abbreviation\n      __typename\n    }\n    categories {\n      id\n      identifier\n      name\n      type {\n        id\n        identifier\n        name\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}'
+
+class MCPGetPlanPlanFeatures(BaseModel):
+    """No documentation"""
+    typename: Literal['PlanFeatures'] = Field(alias='__typename', default='PlanFeatures')
+    public_contact_persons: bool = Field(alias='publicContactPersons')
+    has_action_identifiers: bool = Field(alias='hasActionIdentifiers')
+    'Set if the plan uses meaningful action identifiers'
+    has_action_official_name: bool = Field(alias='hasActionOfficialName')
+    'Set if the plan uses the official name field'
+    has_action_lead_paragraph: bool = Field(alias='hasActionLeadParagraph')
+    'Set if the plan uses the lead paragraph field'
+    has_action_primary_orgs: bool = Field(alias='hasActionPrimaryOrgs')
+    'Set if actions have a clear primary organization (such as multi-city plans)'
+    enable_search: bool = Field(alias='enableSearch')
+    'Enable site-wide search functionality'
+    enable_indicator_comparison: bool = Field(alias='enableIndicatorComparison')
+    'Set to enable comparing indicators between organizations'
+    minimal_statuses: bool = Field(alias='minimalStatuses')
+    "Set to prevent showing status-specific graphs and other elements if statuses aren't systematically used in this action plan"
+    contact_persons_public_data: PlanFeaturesContactPersonsPublicData = Field(alias='contactPersonsPublicData')
+    'Choose which information about contact persons is visible in the public UI'
+
+class MCPGetPlanPlanCategorytypes(BaseModel):
+    """Type of the categories.
+
+Is used to group categories together. One action plan can have several
+category types."""
+    typename: Literal['CategoryType'] = Field(alias='__typename', default='CategoryType')
+    id: str
+    identifier: str
+    name: str
+    usable_for_actions: bool = Field(alias='usableForActions')
+    usable_for_indicators: bool = Field(alias='usableForIndicators')
+
+class MCPGetPlanPlanActionstatussummaries(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionStatusSummary'] = Field(alias='__typename', default='ActionStatusSummary')
+    identifier: ActionStatusSummaryIdentifier
+    label: str
+    is_active: bool = Field(alias='isActive')
+    is_completed: bool = Field(alias='isCompleted')
+    sentiment: Sentiment
+
+class MCPGetPlanPlanActionattributetypesUnit(BaseModel):
+    """No documentation"""
+    typename: Literal['Unit'] = Field(alias='__typename', default='Unit')
+    id: str
+    short_name: Optional[str] = Field(default=None, alias='shortName')
+
+class MCPGetPlanPlanActionattributetypesChoiceoptions(BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeTypeChoiceOption'] = Field(alias='__typename', default='AttributeTypeChoiceOption')
+    id: str
+    identifier: str
+    name: str
+
+class MCPGetPlanPlanActionattributetypes(BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeType'] = Field(alias='__typename', default='AttributeType')
+    id: str
+    identifier: str
+    name: str
+    format: AttributeTypeFormat
+    unit: Optional[MCPGetPlanPlanActionattributetypesUnit] = Field(default=None)
+    choice_options: List[MCPGetPlanPlanActionattributetypesChoiceoptions] = Field(alias='choiceOptions')
+
+class MCPGetPlanPlan(BaseModel):
+    """The Action Plan under monitoring.
+
+Most information in this service is linked to a Plan."""
+    typename: Literal['Plan'] = Field(alias='__typename', default='Plan')
+    id: str
+    identifier: str
+    'A unique identifier for the plan used internally to distinguish between plans. This becomes part of the test site URL: https://[identifier].watch-test.kausal.tech. Use lowercase letters and dashes.'
+    name: str
+    'The official plan name in full form'
+    short_name: Optional[str] = Field(default=None, alias='shortName')
+    'A shorter version of the plan name'
+    version_name: str = Field(alias='versionName')
+    'If this plan has multiple versions, name of this version'
+    primary_language: str = Field(alias='primaryLanguage')
+    other_languages: List[str] = Field(alias='otherLanguages')
+    published_at: Optional[datetime] = Field(default=None, alias='publishedAt')
+    view_url: Optional[str] = Field(default=None, alias='viewUrl')
+    accessibility_statement_url: Optional[str] = Field(default=None, alias='accessibilityStatementUrl')
+    external_feedback_url: Optional[str] = Field(default=None, alias='externalFeedbackUrl')
+    "If not empty, the system's built-in user feedback feature will be replaced by a link to an external feedback form available at this web address."
+    features: MCPGetPlanPlanFeatures
+    category_types: List[MCPGetPlanPlanCategorytypes] = Field(alias='categoryTypes')
+    action_status_summaries: List[MCPGetPlanPlanActionstatussummaries] = Field(alias='actionStatusSummaries')
+    action_attribute_types: List[MCPGetPlanPlanActionattributetypes] = Field(alias='actionAttributeTypes')
+
+class MCPGetPlan(BaseModel):
+    """No documentation found for this operation."""
+    plan: Optional[MCPGetPlanPlan] = Field(default=None)
+
+    class Arguments(BaseModel):
+        """Arguments for MCPGetPlan """
+        identifier: str
+        model_config = ConfigDict(populate_by_name=None)
+
+    class Meta:
+        """Meta class for MCPGetPlan """
+        document = 'query MCPGetPlan($identifier: ID!) @context(input: {identifier: $identifier}) {\n  plan(id: $identifier) {\n    id\n    identifier\n    name\n    shortName\n    versionName\n    primaryLanguage\n    otherLanguages\n    publishedAt\n    viewUrl\n    accessibilityStatementUrl\n    externalFeedbackUrl\n    features {\n      publicContactPersons\n      hasActionIdentifiers\n      hasActionOfficialName\n      hasActionLeadParagraph\n      hasActionPrimaryOrgs\n      enableSearch\n      enableIndicatorComparison\n      minimalStatuses\n      contactPersonsPublicData\n      __typename\n    }\n    categoryTypes {\n      id\n      identifier\n      name\n      usableForActions\n      usableForIndicators\n      __typename\n    }\n    actionStatusSummaries {\n      identifier\n      label\n      isActive\n      isCompleted\n      sentiment\n      __typename\n    }\n    actionAttributeTypes {\n      id\n      identifier\n      name\n      format\n      unit {\n        id\n        shortName\n        __typename\n      }\n      choiceOptions {\n        id\n        identifier\n        name\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}'
+
+class MCPGetActionActionStatus(BaseModel):
+    """The current status for the action ("on time", "late", "completed", etc.)."""
+    typename: Literal['ActionStatus'] = Field(alias='__typename', default='ActionStatus')
+    id: str
+    identifier: str
+    name: str
+    is_completed: bool = Field(alias='isCompleted')
+
+class MCPGetActionActionImplementationphase(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionImplementationPhase'] = Field(alias='__typename', default='ActionImplementationPhase')
+    id: str
+    identifier: str
+    name: str
+
+class MCPGetActionActionStatussummary(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionStatusSummary'] = Field(alias='__typename', default='ActionStatusSummary')
+    identifier: ActionStatusSummaryIdentifier
+    label: str
+    sentiment: Sentiment
+    is_active: bool = Field(alias='isActive')
+    is_completed: bool = Field(alias='isCompleted')
+
+class MCPGetActionActionTimeliness(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionTimeliness'] = Field(alias='__typename', default='ActionTimeliness')
+    identifier: ActionTimelinessIdentifier
+    comparison: Comparison
+    days: int
+
+class MCPGetActionActionImpact(BaseModel):
+    """An impact classification for an action in an action plan."""
+    typename: Literal['ActionImpact'] = Field(alias='__typename', default='ActionImpact')
+    id: str
+    identifier: str
+    name: str
+
+class MCPGetActionActionPrimaryorg(BaseModel):
+    """No documentation"""
+    typename: Literal['Organization'] = Field(alias='__typename', default='Organization')
+    id: str
+    name: str
+    'Full name of the organization'
+    abbreviation: Optional[str] = Field(default=None)
+    'Short version or abbreviation of the organization name to be displayed when it is not necessary to show the full name'
+
+class MCPGetActionActionResponsiblepartiesOrganization(BaseModel):
+    """No documentation"""
+    typename: Literal['Organization'] = Field(alias='__typename', default='Organization')
+    id: str
+    name: str
+    'Full name of the organization'
+    abbreviation: Optional[str] = Field(default=None)
+    'Short version or abbreviation of the organization name to be displayed when it is not necessary to show the full name'
+
+class MCPGetActionActionResponsibleparties(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionResponsibleParty'] = Field(alias='__typename', default='ActionResponsibleParty')
+    id: str
+    role: Optional[ActionResponsiblePartyRole] = Field(default=None)
+    specifier: str
+    'The responsibility domain for the organization'
+    organization: MCPGetActionActionResponsiblepartiesOrganization
+
+class MCPGetActionActionCategoriesType(BaseModel):
+    """Type of the categories.
+
+Is used to group categories together. One action plan can have several
+category types."""
+    typename: Literal['CategoryType'] = Field(alias='__typename', default='CategoryType')
+    id: str
+    identifier: str
+    name: str
+
+class MCPGetActionActionCategories(BaseModel):
+    """A category for actions and indicators."""
+    typename: Literal['Category'] = Field(alias='__typename', default='Category')
+    id: str
+    identifier: str
+    name: str
+    type: MCPGetActionActionCategoriesType
+
+class MCPGetActionActionContactpersonsPersonOrganization(BaseModel):
+    """No documentation"""
+    typename: Literal['Organization'] = Field(alias='__typename', default='Organization')
+    id: str
+    name: str
+    'Full name of the organization'
+    abbreviation: Optional[str] = Field(default=None)
+    'Short version or abbreviation of the organization name to be displayed when it is not necessary to show the full name'
+
+class MCPGetActionActionContactpersonsPerson(BaseModel):
+    """No documentation"""
+    typename: Literal['Person'] = Field(alias='__typename', default='Person')
+    id: str
+    first_name: str = Field(alias='firstName')
+    last_name: str = Field(alias='lastName')
+    title: Optional[str] = Field(default=None)
+    'Job title or role of this person'
+    email: str
+    organization: MCPGetActionActionContactpersonsPersonOrganization
+
+class MCPGetActionActionContactpersons(BaseModel):
+    """A Person acting as a contact for an action."""
+    typename: Literal['ActionContactPerson'] = Field(alias='__typename', default='ActionContactPerson')
+    id: str
+    role: ActionContactPersonRole
+    primary_contact: bool = Field(alias='primaryContact')
+    'Is this person the primary contact person for the action?'
+    person: MCPGetActionActionContactpersonsPerson
+
+class MCPGetActionActionTasks(BaseModel):
+    """A task that should be completed during the execution of an action.
+
+The task will have at least a name and an estimate of the due date."""
+    typename: Literal['ActionTask'] = Field(alias='__typename', default='ActionTask')
+    id: str
+    name: str
+    state: ActionTaskState
+    due_at: str = Field(alias='dueAt')
+    'The date by which the task should be completed (deadline)'
+    completed_at: Optional[str] = Field(default=None, alias='completedAt')
+    'The date when the task was completed'
+    comment: Optional[str] = Field(default=None)
+
+class MCPGetActionActionRelatedindicatorsIndicatorUnit(BaseModel):
+    """No documentation"""
+    typename: Literal['Unit'] = Field(alias='__typename', default='Unit')
+    id: str
+    name: str
+    short_name: Optional[str] = Field(default=None, alias='shortName')
+
+class MCPGetActionActionRelatedindicatorsIndicatorLatestvalue(BaseModel):
+    """One measurement of an indicator for a certain date/month/year."""
+    typename: Literal['IndicatorValue'] = Field(alias='__typename', default='IndicatorValue')
+    id: str
+    date: Optional[str] = Field(default=None)
+    value: float
+
+class MCPGetActionActionRelatedindicatorsIndicator(BaseModel):
+    """An indicator with which to measure actions and progress towards strategic goals."""
+    typename: Literal['Indicator'] = Field(alias='__typename', default='Indicator')
+    id: str
+    identifier: Optional[str] = Field(default=None)
+    name: str
+    unit: MCPGetActionActionRelatedindicatorsIndicatorUnit
+    latest_value: Optional[MCPGetActionActionRelatedindicatorsIndicatorLatestvalue] = Field(default=None, alias='latestValue')
+
+class MCPGetActionActionRelatedindicators(BaseModel):
+    """Link between an action and an indicator."""
+    typename: Literal['ActionIndicator'] = Field(alias='__typename', default='ActionIndicator')
+    id: str
+    effect_type: ActionIndicatorEffectType = Field(alias='effectType')
+    'What type of effect should the action cause?'
+    indicates_action_progress: bool = Field(alias='indicatesActionProgress')
+    'Set if the indicator should be used to determine action progress'
+    indicator: MCPGetActionActionRelatedindicatorsIndicator
+
+class MCPGetActionActionLinks(BaseModel):
+    """A link related to an action."""
+    typename: Literal['ActionLink'] = Field(alias='__typename', default='ActionLink')
+    id: str
+    url: str
+    title: str
+
+class MCPGetActionActionStatusupdatesAuthor(BaseModel):
+    """No documentation"""
+    typename: Literal['Person'] = Field(alias='__typename', default='Person')
+    id: str
+    first_name: str = Field(alias='firstName')
+    last_name: str = Field(alias='lastName')
+
+class MCPGetActionActionStatusupdates(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionStatusUpdate'] = Field(alias='__typename', default='ActionStatusUpdate')
+    id: str
+    title: str
+    date: str
+    content: str
+    author: Optional[MCPGetActionActionStatusupdatesAuthor] = Field(default=None)
+
+class MCPGetActionActionRelatedactions(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionMergedwith(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionMergedactions(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionSupersededby(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionSupersededactions(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionAlldependencyrelationshipsPreceding(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionAlldependencyrelationshipsDependent(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+
+class MCPGetActionActionAlldependencyrelationships(BaseModel):
+    """No documentation"""
+    typename: Literal['ActionDependencyRelationship'] = Field(alias='__typename', default='ActionDependencyRelationship')
+    preceding: MCPGetActionActionAlldependencyrelationshipsPreceding
+    dependent: MCPGetActionActionAlldependencyrelationshipsDependent
+
+class MCPGetActionActionImpactgroupsGroup(BaseModel):
+    """No documentation"""
+    typename: Literal['ImpactGroup'] = Field(alias='__typename', default='ImpactGroup')
+    id: str
+    identifier: str
+    name: str
+
+class MCPGetActionActionImpactgroupsImpact(BaseModel):
+    """An impact classification for an action in an action plan."""
+    typename: Literal['ActionImpact'] = Field(alias='__typename', default='ActionImpact')
+    id: str
+    identifier: str
+
+class MCPGetActionActionImpactgroups(BaseModel):
+    """No documentation"""
+    typename: Literal['ImpactGroupAction'] = Field(alias='__typename', default='ImpactGroupAction')
+    id: str
+    group: MCPGetActionActionImpactgroupsGroup
+    impact: MCPGetActionActionImpactgroupsImpact
+
+class MCPGetActionActionAttributesTypeUnit(BaseModel):
+    """No documentation"""
+    typename: Literal['Unit'] = Field(alias='__typename', default='Unit')
+    short_name: Optional[str] = Field(default=None, alias='shortName')
+
+class MCPGetActionActionAttributesType(BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeType'] = Field(alias='__typename', default='AttributeType')
+    identifier: str
+    name: str
+    unit: Optional[MCPGetActionActionAttributesTypeUnit] = Field(default=None)
+
+class MCPGetActionActionAttributesCategoriesType(BaseModel):
+    """Type of the categories.
+
+Is used to group categories together. One action plan can have several
+category types."""
+    typename: Literal['CategoryType'] = Field(alias='__typename', default='CategoryType')
+    identifier: str
+
+class MCPGetActionActionAttributesCategories(BaseModel):
+    """A category for actions and indicators."""
+    typename: Literal['Category'] = Field(alias='__typename', default='Category')
+    identifier: str
+    type: MCPGetActionActionAttributesCategoriesType
+
+class MCPGetActionActionAttributesChoice(BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeTypeChoiceOption'] = Field(alias='__typename', default='AttributeTypeChoiceOption')
+    identifier: str
+
+class MCPGetActionActionAttributesBase(BaseModel):
+    """No documentation"""
+    type: MCPGetActionActionAttributesType
+    key_identifier: str = Field(alias='keyIdentifier')
+
+class MCPGetActionActionAttributesBaseAttributeCategoryChoice(MCPGetActionActionAttributesBase, BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeCategoryChoice'] = Field(alias='__typename', default='AttributeCategoryChoice')
+    categories: List[MCPGetActionActionAttributesCategories]
+
+class MCPGetActionActionAttributesBaseAttributeChoice(MCPGetActionActionAttributesBase, BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeChoice'] = Field(alias='__typename', default='AttributeChoice')
+    choice: Optional[MCPGetActionActionAttributesChoice] = Field(default=None)
+
+class MCPGetActionActionAttributesBaseAttributeNumericValue(MCPGetActionActionAttributesBase, BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeNumericValue'] = Field(alias='__typename', default='AttributeNumericValue')
+    numeric_value: float = Field(alias='numericValue')
+
+class MCPGetActionActionAttributesBaseAttributeRichText(MCPGetActionActionAttributesBase, BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeRichText'] = Field(alias='__typename', default='AttributeRichText')
+    rich_text_value: str = Field(alias='richTextValue')
+
+class MCPGetActionActionAttributesBaseAttributeText(MCPGetActionActionAttributesBase, BaseModel):
+    """No documentation"""
+    typename: Literal['AttributeText'] = Field(alias='__typename', default='AttributeText')
+    text_value: str = Field(alias='textValue')
+
+class MCPGetActionActionAttributesBaseCatchAll(MCPGetActionActionAttributesBase, BaseModel):
+    """Catch all class for MCPGetActionActionAttributesBase"""
+    typename: str = Field(alias='__typename')
+
+class MCPGetActionAction(BaseModel):
+    """One action/measure tracked in an action plan."""
+    typename: Literal['Action'] = Field(alias='__typename', default='Action')
+    id: str
+    uuid: str
+    identifier: str
+    'The identifier for this action (e.g. number)'
+    name: str
+    official_name: Optional[str] = Field(default=None, alias='officialName')
+    'The name as approved by an official party'
+    lead_paragraph: str = Field(alias='leadParagraph')
+    description: Optional[str] = Field(default=None)
+    'What does this action involve in more detail?'
+    start_date: Optional[str] = Field(default=None, alias='startDate')
+    'The date when implementation of this action starts'
+    end_date: Optional[str] = Field(default=None, alias='endDate')
+    'The date when implementation of this action ends'
+    schedule_continuous: bool = Field(alias='scheduleContinuous')
+    'Set if the action does not have a start or an end date'
+    date_format: Optional[ActionDateFormat] = Field(default=None, alias='dateFormat')
+    'Format of action start and end dates shown in the public UI.             The default for all actions can be specified on the actions page.'
+    updated_at: datetime = Field(alias='updatedAt')
+    completion: Optional[int] = Field(default=None)
+    'The completion percentage for this action'
+    manual_status_reason: Optional[str] = Field(default=None, alias='manualStatusReason')
+    'Describe the reason why this action has this status'
+    status: Optional[MCPGetActionActionStatus] = Field(default=None)
+    implementation_phase: Optional[MCPGetActionActionImplementationphase] = Field(default=None, alias='implementationPhase')
+    status_summary: MCPGetActionActionStatussummary = Field(alias='statusSummary')
+    timeliness: MCPGetActionActionTimeliness
+    color: Optional[str] = Field(default=None)
+    impact: Optional[MCPGetActionActionImpact] = Field(default=None)
+    'The impact of this action'
+    primary_org: Optional[MCPGetActionActionPrimaryorg] = Field(default=None, alias='primaryOrg')
+    responsible_parties: List[MCPGetActionActionResponsibleparties] = Field(alias='responsibleParties')
+    categories: List[MCPGetActionActionCategories]
+    contact_persons: List[MCPGetActionActionContactpersons] = Field(alias='contactPersons')
+    tasks: List[MCPGetActionActionTasks]
+    related_indicators: List[MCPGetActionActionRelatedindicators] = Field(alias='relatedIndicators')
+    links: List[MCPGetActionActionLinks]
+    status_updates: List[MCPGetActionActionStatusupdates] = Field(alias='statusUpdates')
+    related_actions: List[MCPGetActionActionRelatedactions] = Field(alias='relatedActions')
+    merged_with: Optional[MCPGetActionActionMergedwith] = Field(default=None, alias='mergedWith')
+    'Set if this action is merged with another action'
+    merged_actions: List[MCPGetActionActionMergedactions] = Field(alias='mergedActions')
+    'Set if this action is merged with another action'
+    superseded_by: Optional[MCPGetActionActionSupersededby] = Field(default=None, alias='supersededBy')
+    'Set if this action is superseded by another action'
+    superseded_actions: List[MCPGetActionActionSupersededactions] = Field(alias='supersededActions')
+    'Set if this action is superseded by another action'
+    all_dependency_relationships: List[MCPGetActionActionAlldependencyrelationships] = Field(alias='allDependencyRelationships')
+    impact_groups: List[MCPGetActionActionImpactgroups] = Field(alias='impactGroups')
+    attributes: List[Union[Annotated[Union[MCPGetActionActionAttributesBaseAttributeCategoryChoice, MCPGetActionActionAttributesBaseAttributeChoice, MCPGetActionActionAttributesBaseAttributeNumericValue, MCPGetActionActionAttributesBaseAttributeRichText, MCPGetActionActionAttributesBaseAttributeText], Field(discriminator='typename')], MCPGetActionActionAttributesBaseCatchAll]]
+    visibility: ActionVisibility
+    order: int
+    view_url: str = Field(alias='viewUrl')
+
+class MCPGetAction(BaseModel):
+    """No documentation found for this operation."""
+    action: Optional[MCPGetActionAction] = Field(default=None)
+
+    class Arguments(BaseModel):
+        """Arguments for MCPGetAction """
+        plan: str
+        identifier: str
+        model_config = ConfigDict(populate_by_name=None)
+
+    class Meta:
+        """Meta class for MCPGetAction """
+        document = 'query MCPGetAction($plan: ID!, $identifier: ID!) @context(input: {identifier: $plan}) {\n  action(plan: $plan, identifier: $identifier) {\n    id\n    uuid\n    identifier\n    name\n    officialName\n    leadParagraph\n    description\n    startDate\n    endDate\n    scheduleContinuous\n    dateFormat\n    updatedAt\n    completion\n    manualStatusReason\n    status {\n      id\n      identifier\n      name\n      isCompleted\n      __typename\n    }\n    implementationPhase {\n      id\n      identifier\n      name\n      __typename\n    }\n    statusSummary {\n      identifier\n      label\n      sentiment\n      isActive\n      isCompleted\n      __typename\n    }\n    timeliness {\n      identifier\n      comparison\n      days\n      __typename\n    }\n    color\n    impact {\n      id\n      identifier\n      name\n      __typename\n    }\n    primaryOrg {\n      id\n      name\n      abbreviation\n      __typename\n    }\n    responsibleParties {\n      id\n      role\n      specifier\n      organization {\n        id\n        name\n        abbreviation\n        __typename\n      }\n      __typename\n    }\n    categories {\n      id\n      identifier\n      name\n      type {\n        id\n        identifier\n        name\n        __typename\n      }\n      __typename\n    }\n    contactPersons {\n      id\n      role\n      primaryContact\n      person {\n        id\n        firstName\n        lastName\n        title\n        email\n        organization {\n          id\n          name\n          abbreviation\n          __typename\n        }\n        __typename\n      }\n      __typename\n    }\n    tasks {\n      id\n      name\n      state\n      dueAt\n      completedAt\n      comment\n      __typename\n    }\n    relatedIndicators {\n      id\n      effectType\n      indicatesActionProgress\n      indicator {\n        id\n        identifier\n        name\n        unit {\n          id\n          name\n          shortName\n          __typename\n        }\n        latestValue {\n          id\n          date\n          value\n          __typename\n        }\n        __typename\n      }\n      __typename\n    }\n    links {\n      id\n      url\n      title\n      __typename\n    }\n    statusUpdates {\n      id\n      title\n      date\n      content\n      author {\n        id\n        firstName\n        lastName\n        __typename\n      }\n      __typename\n    }\n    relatedActions {\n      id\n      identifier\n      name\n      __typename\n    }\n    mergedWith {\n      id\n      identifier\n      name\n      __typename\n    }\n    mergedActions {\n      id\n      identifier\n      name\n      __typename\n    }\n    supersededBy {\n      id\n      identifier\n      name\n      __typename\n    }\n    supersededActions {\n      id\n      identifier\n      name\n      __typename\n    }\n    allDependencyRelationships {\n      preceding {\n        id\n        identifier\n        name\n        __typename\n      }\n      dependent {\n        id\n        identifier\n        name\n        __typename\n      }\n      __typename\n    }\n    impactGroups {\n      id\n      group {\n        id\n        identifier\n        name\n        __typename\n      }\n      impact {\n        id\n        identifier\n        __typename\n      }\n      __typename\n    }\n    attributes {\n      __typename\n      type {\n        identifier\n        name\n        unit {\n          shortName\n          __typename\n        }\n        __typename\n      }\n      keyIdentifier\n      ... on AttributeText {\n        textValue: value\n      }\n      ... on AttributeRichText {\n        richTextValue: value\n      }\n      ... on AttributeCategoryChoice {\n        categories {\n          identifier\n          type {\n            identifier\n          }\n        }\n      }\n      ... on AttributeNumericValue {\n        numericValue: value\n      }\n      ... on AttributeChoice {\n        choice {\n          identifier\n        }\n      }\n    }\n    visibility\n    order\n    viewUrl\n    __typename\n  }\n}'

--- a/mcp_server/ariadne-codegen.toml
+++ b/mcp_server/ariadne-codegen.toml
@@ -1,0 +1,9 @@
+[tool.ariadne-codegen]
+queries_path = "mcp_server/queries.graphql"
+# remote_schema_url = 'http://localhost:8000/v1/graphql/'
+schema_path = 'schema.graphql'
+client_name = 'MCPClient'
+target_package_path = 'mcp_server/_generated_'
+base_client_name = 'DirectSchemaClient'
+base_client_file_path = 'mcp_server/base_graphql_client.py'
+plugins = ['kausal_common.strawberry.ariadne_plugins.IncludeDescriptionsPlugin']

--- a/mcp_server/auth.py
+++ b/mcp_server/auth.py
@@ -1,0 +1,114 @@
+"""
+Django OAuth authentication middleware for MCP.
+
+This module provides ASGI middleware that enforces authentication for the MCP
+endpoint, returning proper OAuth 2.0 error responses when authentication fails.
+Token validation is handled by GeneralRequestMiddleware (kausal_common/asgi/middleware.py).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+
+from loguru import logger
+
+from kausal_common.users import user_or_none
+
+if TYPE_CHECKING:
+    from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logger.bind(name='mcp.auth')
+
+
+class MCPAuthMiddleware:
+    """
+    ASGI middleware that enforces authentication for MCP endpoints.
+
+    This middleware checks if the request has an authenticated Django user
+    (set by GeneralRequestMiddleware) and returns a 401 response with proper
+    OAuth 2.0 headers if not authenticated.
+
+    The WWW-Authenticate header includes the resource_metadata URL pointing
+    to our RFC 9728 Protected Resource Metadata endpoint, which allows
+    MCP clients to discover our OAuth server for authentication.
+    """
+
+    def __init__(self, app: ASGIApp, resource_path: str = 'mcp'):
+        self.app = app
+        self.resource_path = resource_path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope['type'] != 'http':
+            await self.app(scope, receive, send)
+            return
+
+        user = user_or_none(scope.get('user'))
+        if user is None:
+            await self._send_auth_error(send)
+            return
+
+        # Allow only for superusers for now
+        if not user.is_superuser:
+            await self._send_forbidden_error(send)
+            return
+
+        await self.app(scope, receive, send)
+
+    async def _send_forbidden_error(self, send: Send) -> None:
+        """Send a 403 Forbidden response."""
+        await send({
+            'type': 'http.response.start',
+            'status': 403,
+            'headers': [
+                (b'content-type', b'application/json'),
+            ],
+        })
+        await send({
+            'type': 'http.response.body',
+            'body': b'Forbidden',
+        })
+        logger.warning('MCP auth error: forbidden request')
+
+    async def _send_auth_error(self, send: Send) -> None:
+        """Send a 401 Unauthorized response with OAuth 2.0 headers."""
+        base_url = getattr(settings, 'ADMIN_BASE_URL', '').rstrip('/')
+        resource_metadata_url = f'{base_url}/.well-known/oauth-protected-resource/{self.resource_path}'
+
+        # Build WWW-Authenticate header per RFC 6750 and RFC 9728
+        www_auth_parts = [
+            'error="invalid_token"',
+            'error_description="Authentication required"',
+            f'resource_metadata="{resource_metadata_url}"',
+        ]
+        www_authenticate = f"Bearer {', '.join(www_auth_parts)}"
+
+        body = {
+            'error': 'invalid_token',
+            'error_description': 'Authentication required. Use the resource_metadata URL to discover the OAuth server.',
+        }
+        body_bytes = json.dumps(body).encode()
+
+        await send({
+            'type': 'http.response.start',
+            'status': 401,
+            'headers': [
+                (b'content-type', b'application/json'),
+                (b'content-length', str(len(body_bytes)).encode()),
+                (b'www-authenticate', www_authenticate.encode()),
+                (b'access-control-allow-origin', b'*'),
+            ],
+        })
+
+        await send({
+            'type': 'http.response.body',
+            'body': body_bytes,
+        })
+
+        logger.debug('MCP auth error: unauthenticated request')
+
+# summary metrics
+# plans that are inactive
+# start tracking analytics

--- a/mcp_server/base_graphql_client.py
+++ b/mcp_server/base_graphql_client.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Self
+
+from asgiref.sync import sync_to_async
+
+if TYPE_CHECKING:
+    from strawberry import Schema
+    from strawberry.types import ExecutionResult
+
+    from kausal_common.strawberry.context import GraphQLContext
+
+
+class DirectSchemaClient:
+    def __init__(self, context: GraphQLContext) -> None:
+        self.context = context
+
+    def __enter__(self: Self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        pass
+
+    @property
+    def schema(self) -> Schema:
+        from aplans.schema import schema
+        return schema
+
+    async def execute(
+        self,
+        query: str,
+        operation_name: str | None = None,
+        variables: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> ExecutionResult:
+        res = await sync_to_async(self.schema.execute_sync)(
+            query, operation_name=operation_name, context_value=self.context, variable_values=variables
+        )
+        return res
+
+    def get_data(self, result: ExecutionResult) -> dict[str, Any] | None:
+        # FIXME: Error handling
+        return result.data

--- a/mcp_server/mcp_client_tool.py
+++ b/mcp_server/mcp_client_tool.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+"""Simple MCP client tool for testing the Kausal Watch MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import httpx
+from dotenv import dotenv_values
+
+
+def get_token() -> str:
+    """Get the MCP client token from .env file."""
+    config = dotenv_values('.env')
+    token = config.get('MCP_CLIENT_TOKEN')
+    if not token:
+        print('Error: MCP_CLIENT_TOKEN not found in .env file', file=sys.stderr)
+        sys.exit(1)
+    return token
+
+
+def make_request(
+    client: httpx.Client,
+    method: str,
+    params: dict[str, Any] | None = None,
+    request_id: int = 1,
+    session_id: str | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    """Make a JSON-RPC request to the MCP server."""
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json, text/event-stream',
+        'Authorization': f'Bearer {get_token()}',
+    }
+    if session_id:
+        headers['Mcp-Session-Id'] = session_id
+
+    payload: dict[str, Any] = {
+        'jsonrpc': '2.0',
+        'method': method,
+        'id': request_id,
+    }
+    if params:
+        payload['params'] = params
+
+    response = client.post('/mcp', headers=headers, json=payload)
+    response.raise_for_status()
+
+    # Extract session ID from headers
+    new_session_id = response.headers.get('mcp-session-id')
+
+    # Parse SSE response
+    text = response.text
+    for line in text.split('\n'):
+        if line.startswith('data: '):
+            data = json.loads(line[6:])
+            return data, new_session_id or session_id
+
+    raise ValueError(f'No data found in response: {text}')
+
+
+def initialize(client: httpx.Client) -> str | None:
+    """Initialize MCP session and return session ID (if stateful mode is enabled)."""
+    result, session_id = make_request(
+        client,
+        'initialize',
+        params={
+            'protocolVersion': '2024-11-05',
+            'capabilities': {},
+            'clientInfo': {'name': 'mcp-client-tool', 'version': '1.0'},
+        },
+    )
+    if 'error' in result:
+        print(f'Error initializing: {result["error"]}', file=sys.stderr)
+        sys.exit(1)
+
+    print(f'Connected to: {result["result"]["serverInfo"]["name"]} v{result["result"]["serverInfo"]["version"]}')
+    # Session ID is optional in stateless mode
+    # TODO: Re-enable session ID requirement when stateful mode is restored
+    return session_id
+
+
+def list_tools(client: httpx.Client, session_id: str | None) -> list[dict[str, Any]]:
+    """List available tools."""
+    result, _ = make_request(client, 'tools/list', session_id=session_id, request_id=2)
+    if 'error' in result:
+        print(f'Error listing tools: {result["error"]}', file=sys.stderr)
+        sys.exit(1)
+    return result['result']['tools']
+
+
+def call_tool(
+    client: httpx.Client, session_id: str | None, tool_name: str, arguments: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Call a tool and return the result."""
+    params: dict[str, Any] = {'name': tool_name}
+    if arguments:
+        params['arguments'] = arguments
+
+    result, _ = make_request(client, 'tools/call', params=params, session_id=session_id, request_id=3)
+    if 'error' in result:
+        print(f'Error calling tool: {result["error"]}', file=sys.stderr)
+        sys.exit(1)
+    return result['result']
+
+
+def describe_tool(tools: list[dict[str, Any]], tool_name: str, raw: bool = False) -> None:
+    """Show full details of a specific tool."""
+    tool = next((t for t in tools if t['name'] == tool_name), None)
+    if not tool:
+        print(f"Error: Tool '{tool_name}' not found", file=sys.stderr)
+        print(f'Available tools: {", ".join(t["name"] for t in tools)}', file=sys.stderr)
+        sys.exit(1)
+
+    if raw:
+        print(json.dumps(tool, indent=2))
+        return
+
+    print(f'\nTool: {tool["name"]}')
+    print(f'Description: {tool.get("description", "No description")}')
+
+    input_schema = tool.get('inputSchema', {})
+    if input_schema:
+        print('\nInput Schema:')
+        properties = input_schema.get('properties', {})
+        required = set(input_schema.get('required', []))
+
+        if properties:
+            for prop_name, prop_info in properties.items():
+                req_marker = ' (required)' if prop_name in required else ''
+                prop_type = prop_info.get('type', 'any')
+                prop_desc = prop_info.get('description', '')
+                print(f'  - {prop_name}: {prop_type}{req_marker}')
+                if prop_desc:
+                    print(f'      {prop_desc}')
+        else:
+            print('  (no parameters)')
+
+    output_schema = tool.get('outputSchema')
+    if output_schema:
+        print('\nOutput Schema:')
+        print(json.dumps(output_schema, indent=2))
+
+
+def print_tools_list(tools: list[dict[str, Any]]) -> None:
+    """Print a formatted list of tools."""
+    print(f'\nAvailable tools ({len(tools)}):')
+    for tool in tools:
+        print(f'  - {tool["name"]}: {tool.get("description", "No description")}')
+
+
+def handle_call_result(result: dict[str, Any], raw: bool) -> None:
+    """Handle and print the result of a tool call."""
+    if raw:
+        print(json.dumps(result, indent=2))
+        return
+
+    # Show text content
+    for content in result.get('content', []):
+        if content.get('type') == 'text':
+            print(f'\n{content["text"]}')
+
+    # Show structured content if present
+    if 'structuredContent' in result:
+        print('\nStructured content:')
+        print(json.dumps(result['structuredContent'], indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Test the Kausal Watch MCP server')
+    parser.add_argument('--base-url', default='http://localhost:8000', help='Base URL of the server')
+    parser.add_argument('--list-tools', action='store_true', help='List available tools')
+    parser.add_argument('--describe', metavar='TOOL', help='Show full details of a tool (description, input/output schema)')
+    parser.add_argument('--call', metavar='TOOL', help='Call a tool by name')
+    parser.add_argument('--args', metavar='JSON', help='JSON arguments for the tool call')
+    parser.add_argument('--raw', action='store_true', help='Output raw JSON response')
+
+    args = parser.parse_args()
+
+    with httpx.Client(base_url=args.base_url, timeout=30.0) as client:
+        session_id = initialize(client)
+
+        if args.list_tools:
+            tools = list_tools(client, session_id)
+            if args.raw:
+                print(json.dumps(tools, indent=2))
+            else:
+                print_tools_list(tools)
+        elif args.describe:
+            tools = list_tools(client, session_id)
+            describe_tool(tools, args.describe, raw=args.raw)
+        elif args.call:
+            arguments = json.loads(args.args) if args.args else {}
+            result = call_tool(client, session_id, args.call, arguments)
+            handle_call_result(result, args.raw)
+        else:
+            # Default: list tools with usage hint
+            tools = list_tools(client, session_id)
+            print_tools_list(tools)
+            print('\nUse --call TOOL to call a tool, e.g.:')
+            print(f'  python {sys.argv[0]} --call list_plans')
+            print(f'  python {sys.argv[0]} --call hello_world --args \'{{"name": "World"}}\'')
+
+
+if __name__ == '__main__':
+    main()

--- a/mcp_server/queries.graphql
+++ b/mcp_server/queries.graphql
@@ -1,0 +1,411 @@
+query MCPUserDetails {
+  me {
+    id
+    uuid
+    email
+    firstName
+    lastName
+    isSuperuser
+  }
+}
+
+query MCPListPlans {
+  plans {
+    id
+    identifier
+    name
+    shortName
+    versionName
+    primaryLanguage
+    otherLanguages
+    publishedAt
+    viewUrl
+  }
+}
+
+query MCPListActions(
+  $plan: ID!
+  $category: ID
+  $first: Int
+  $orderBy: String
+) @context(input: {identifier: $plan}) {
+  planActions(
+    plan: $plan
+    category: $category
+    first: $first
+    orderBy: $orderBy
+  ) {
+    id
+    identifier
+    name
+    officialName
+    completion
+    scheduleContinuous
+    startDate
+    endDate
+    updatedAt
+
+    # Status information
+    status {
+      id
+      identifier
+      name
+      isCompleted
+    }
+    implementationPhase {
+      id
+      identifier
+      name
+    }
+    statusSummary {
+      identifier
+      label
+      sentiment
+      isActive
+      isCompleted
+    }
+
+    # Organization info
+    responsibleParties {
+      id
+      organization {
+        id
+        name
+        abbreviation
+      }
+    }
+    primaryOrg {
+      id
+      name
+      abbreviation
+    }
+
+    # Categories (for filtering/grouping)
+    categories {
+      id
+      identifier
+      name
+      type {
+        id
+        identifier
+        name
+      }
+    }
+  }
+}
+
+query MCPGetPlan($identifier: ID!) @context(input: {identifier: $identifier}) {
+  plan(id: $identifier) {
+    id
+    identifier
+    name
+    shortName
+    versionName
+    primaryLanguage
+    otherLanguages
+    publishedAt
+    viewUrl
+    accessibilityStatementUrl
+    externalFeedbackUrl
+
+    # Plan features configuration
+    features {
+      publicContactPersons
+      hasActionIdentifiers
+      hasActionOfficialName
+      hasActionLeadParagraph
+      hasActionPrimaryOrgs
+      enableSearch
+      enableIndicatorComparison
+      minimalStatuses
+      contactPersonsPublicData
+    }
+
+    # Category types (organizational structure)
+    categoryTypes {
+      id
+      identifier
+      name
+      usableForActions
+      usableForIndicators
+    }
+
+    # Action status summaries (dashboard statistics)
+    actionStatusSummaries {
+      identifier
+      label
+      isActive
+      isCompleted
+      sentiment
+    }
+
+    # Attribute types (dynamic attributes schema)
+    actionAttributeTypes {
+      id
+      identifier
+      name
+      format
+      unit {
+        id
+        shortName
+      }
+      choiceOptions {
+        id
+        identifier
+        name
+      }
+    }
+  }
+}
+
+query MCPGetAction($plan: ID!, $identifier: ID!) @context(input: {identifier: $plan}) {
+  action(plan: $plan, identifier: $identifier) {
+    # Core identifiers
+    id
+    uuid
+    identifier
+    name
+    officialName
+
+    # Content
+    leadParagraph
+    description
+
+    # Scheduling
+    startDate
+    endDate
+    scheduleContinuous
+    dateFormat
+    updatedAt
+
+    # Status & Progress
+    completion
+    manualStatusReason
+    status {
+      id
+      identifier
+      name
+      isCompleted
+    }
+    implementationPhase {
+      id
+      identifier
+      name
+    }
+    statusSummary {
+      identifier
+      label
+      sentiment
+      isActive
+      isCompleted
+    }
+    timeliness {
+      identifier
+      comparison
+      days
+    }
+    color
+
+    # Impact
+    impact {
+      id
+      identifier
+      name
+    }
+
+    # Organizations
+    primaryOrg {
+      id
+      name
+      abbreviation
+    }
+    responsibleParties {
+      id
+      role
+      specifier
+      organization {
+        id
+        name
+        abbreviation
+      }
+    }
+
+    # Categories
+    categories {
+      id
+      identifier
+      name
+      type {
+        id
+        identifier
+        name
+      }
+    }
+
+    # Contact Persons
+    contactPersons {
+      id
+      role
+      primaryContact
+      person {
+        id
+        firstName
+        lastName
+        title
+        email
+        organization {
+          id
+          name
+          abbreviation
+        }
+      }
+    }
+
+    # Tasks
+    tasks {
+      id
+      name
+      state
+      dueAt
+      completedAt
+      comment
+    }
+
+    # Indicators
+    relatedIndicators {
+      id
+      effectType
+      indicatesActionProgress
+      indicator {
+        id
+        identifier
+        name
+        unit {
+          id
+          name
+          shortName
+        }
+        latestValue {
+          id
+          date
+          value
+        }
+      }
+    }
+
+    # Links
+    links {
+      id
+      url
+      title
+    }
+
+    # Status Updates
+    statusUpdates {
+      id
+      title
+      date
+      content
+      author {
+        id
+        firstName
+        lastName
+      }
+    }
+
+    # Related Actions
+    relatedActions {
+      id
+      identifier
+      name
+    }
+    mergedWith {
+      id
+      identifier
+      name
+    }
+    mergedActions {
+      id
+      identifier
+      name
+    }
+    supersededBy {
+      id
+      identifier
+      name
+    }
+    supersededActions {
+      id
+      identifier
+      name
+    }
+
+    # Dependencies
+    allDependencyRelationships {
+      preceding {
+        id
+        identifier
+        name
+      }
+      dependent {
+        id
+        identifier
+        name
+      }
+    }
+
+    # Impact Groups
+    impactGroups {
+      id
+      group {
+        id
+        identifier
+        name
+      }
+      impact {
+        id
+        identifier
+      }
+    }
+
+    # Attributes (dynamic fields)
+    attributes {
+      __typename
+      type {
+        identifier
+        name
+        unit {
+          shortName
+        }
+      }
+      keyIdentifier
+      ... on AttributeText {
+        textValue: value
+      }
+      ... on AttributeRichText {
+        richTextValue: value
+      }
+      ... on AttributeCategoryChoice {
+        categories {
+          identifier
+          type {
+            identifier
+          }
+        }
+      }
+      ... on AttributeNumericValue {
+        numericValue: value
+      }
+      ... on AttributeChoice {
+        choice {
+          identifier
+        }
+      }
+    }
+
+    # Metadata
+    visibility
+    order
+    viewUrl
+  }
+}

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from kausal_common.deployment import get_deployment_build_id
+
+from .tools import register_action_tools, register_plan_tools, register_user_tools
+
+# Create FastMCP without built-in auth - we handle auth ourselves via MCPAuthMiddleware
+mcp = FastMCP(
+    name="KausalWatch",
+    instructions="""
+        Provides tools for accessing and modifying action plans, indicators, and other
+        related objects on the Kausal Watch platform.
+    """,
+    version=get_deployment_build_id() or "0.1.0-dev",
+)
+
+# Register tools from separate modules
+register_plan_tools(mcp)
+register_action_tools(mcp)
+register_user_tools(mcp)

--- a/mcp_server/tools/__init__.py
+++ b/mcp_server/tools/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from mcp_server.tools.action import register_action_tools
+from mcp_server.tools.plan import register_plan_tools
+from mcp_server.tools.user import register_user_tools
+
+__all__ = ['register_action_tools', 'register_plan_tools', 'register_user_tools']
+

--- a/mcp_server/tools/action.py
+++ b/mcp_server/tools/action.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from fastmcp.exceptions import ToolError
+
+from mcp_server.__generated__.schema import MCPGetAction, MCPGetActionAction, MCPListActions, MCPListActionsPlanactions
+
+from .helpers import execute_operation
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+async def list_actions(
+    plan: Annotated[str, "The plan identifier (e.g., 'sunnydale', 'tampere-ilmasto')"],
+    category: Annotated[str | None, 'Filter by category ID (includes descendants)'] = None,
+    first: Annotated[int | None, 'Limit number of results (default: all)'] = None,
+    order_by: Annotated[str | None, "Order by field: 'updated_at' or 'identifier'"] = None,
+) -> list[MCPListActionsPlanactions]:
+    """
+    List actions from a climate action plan with optional filtering.
+
+    Returns actions with their status, responsible organizations, and categories.
+    Use the category filter to narrow down to a specific theme or strategy.
+    """
+    result = await execute_operation(
+        MCPListActions, # type: ignore[type-var]
+        MCPListActions.Arguments(plan=plan, category=category, first=first, orderBy=order_by),
+    )
+
+    if result.plan_actions is None:
+        raise ToolError(f"Plan '{plan}' not found or not accessible")
+
+    return result.plan_actions
+
+
+async def get_action(
+    plan: Annotated[str, "The plan identifier (e.g., 'sunnydale', 'tampere-ilmasto')"],
+    identifier: Annotated[str, "The action identifier within the plan (e.g., '1.1.1', 'A.2')"],
+) -> MCPGetActionAction:
+    """
+    Get detailed information about a specific action in a climate action plan.
+
+    Returns comprehensive action details including:
+    - Status and completion information
+    - Responsible organizations and contact persons
+    - Tasks and their states
+    - Related indicators with latest values
+    - Links and status updates
+    - Related and dependent actions
+    """
+    result = await execute_operation(MCPGetAction, MCPGetAction.Arguments(plan=plan, identifier=identifier))  # type: ignore[type-var]
+
+    if result.action is None:
+        raise ToolError(f"Action '{identifier}' not found in plan '{plan}'")
+
+    return result.action
+
+
+def register_action_tools(mcp: FastMCP) -> None:
+    """Register all action-related MCP tools."""
+
+    mcp.tool(list_actions)
+    mcp.tool(get_action)

--- a/mcp_server/tools/helpers.py
+++ b/mcp_server/tools/helpers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast
+
+from pydantic import BaseModel
+
+from asgiref.sync import sync_to_async
+
+from kausal_common.strawberry.views import get_base_context
+
+from aplans.schema_context import WatchGraphQLContext
+
+if TYPE_CHECKING:
+    from strawberry.types import ExecutionResult
+
+    from starlette.requests import Request as StarletteRequest
+
+
+def get_schema_execution_context():
+    from mcp.server.lowlevel.server import request_ctx
+
+    context = request_ctx.get()
+    req = cast('StarletteRequest', context.request)
+    base_ctx = get_base_context(req, None)
+    schema_ctx = WatchGraphQLContext(**base_ctx)
+    return schema_ctx
+
+
+async def execute_schema_query(query: str, variables: dict[str, Any] | None = None) -> ExecutionResult:
+    from aplans.schema import schema
+    schema_ctx = get_schema_execution_context()
+    res = await sync_to_async(schema.execute_sync)(query, context_value=schema_ctx, variable_values=variables)
+    return res
+
+
+class OperationMeta(Protocol):
+    document: str
+
+
+class Operation[ArgT: BaseModel, MetaT: OperationMeta](Protocol):
+    Arguments: ArgT
+    Meta: type[MetaT]
+
+    @classmethod
+    def model_validate(
+        cls,
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        from_attributes: bool | None = None,
+        context: Any | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
+    ) -> Self: ...
+
+
+
+async def execute_operation[T: Operation[Any, Any]](operation_class: type[T], args: BaseModel | None = None) -> T:
+    """
+    Execute a turms-generated GraphQL operation and return the validated result.
+
+    Args:
+        operation_class: A turms-generated Pydantic model with Meta.document and Arguments inner classes.
+        args: The arguments to pass to the operation.
+
+    Returns:
+        The validated operation result as an instance of the operation class.
+
+    Raises:
+        RuntimeError: If the GraphQL execution returns errors.
+
+    """
+    # Build the arguments and serialize to dict
+    if args is None:
+        variables_dict = {}
+    else:
+        assert isinstance(args, operation_class.Arguments)
+        variables_dict = args.model_dump(by_alias=True, exclude_none=True)
+
+    # Execute the query
+    result = await execute_schema_query(
+        query=operation_class.Meta.document,
+        variables=variables_dict,
+    )
+
+    if result.errors:
+        error_msgs = '; '.join(str(e) for e in result.errors)
+        raise RuntimeError(f"GraphQL errors: {error_msgs}")
+
+    # Validate and return the result
+    return operation_class.model_validate(result.data)

--- a/mcp_server/tools/plan.py
+++ b/mcp_server/tools/plan.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+from fastmcp.exceptions import ToolError
+
+from mcp_server.__generated__.schema import MCPGetPlan, MCPListPlans
+
+from .helpers import execute_operation
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+async def list_plans() -> MCPListPlans:
+    """List accessible plans. Returns plans where the user has a staff role."""
+
+
+    result = await execute_operation(MCPListPlans, MCPListPlans.Arguments())  # type: ignore[type-var]
+    if result.plans is None:
+        raise ToolError("No plans found")
+    return result
+
+
+async def get_plan(
+    identifier: Annotated[str, "The unique identifier of the plan (e.g., 'sunnydale', 'tampere-ilmasto')"],
+) -> MCPGetPlan:
+    """Get detailed information about a specific action plan."""
+    result = await execute_operation(MCPGetPlan, MCPGetPlan.Arguments(identifier=identifier))  # type: ignore[type-var]
+
+    if result.plan is None:
+        raise ToolError(f"Plan '{identifier}' not found")
+
+    return result
+
+
+def register_plan_tools(mcp: FastMCP) -> None:
+    """Register all plan-related MCP tools."""
+
+    mcp.tool(list_plans)
+    mcp.tool(get_plan)

--- a/mcp_server/tools/user.py
+++ b/mcp_server/tools/user.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp.exceptions import ToolError
+
+from mcp_server.__generated__.schema import MCPUserDetails, MCPUserDetailsMe
+
+from .helpers import execute_operation
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+async def user_details() -> MCPUserDetailsMe:
+    """
+    Get details about the currently authenticated user.
+
+    Returns the user's ID, email, name, and superuser status.
+    """
+    result = await execute_operation(MCPUserDetails, MCPUserDetails.Arguments())  # type: ignore[type-var]
+
+    if result.me is None:
+        raise ToolError("Not authenticated or user not found")
+
+    return result.me
+
+
+def register_user_tools(mcp: FastMCP) -> None:
+    """Register all user-related MCP tools."""
+
+    mcp.tool(user_details)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,7 @@ kausal = [
 
 [tool.ruff]
 extend = "./kausal_common/configs/ruff.toml"
-extend-exclude = ["./paths_integration/_generated_"]
-
+extend-exclude = ["./paths_integration/_generated_", "./mcp_server/__generated__"]
 
 
 [tool.pytest.ini_options]
@@ -155,6 +154,7 @@ exclude = [
   "^kausal_common/deployment/gunicorn\\.py$",
   "node_modules",
   "^.*/_generated_/.*$",
+  "^.*/__generated__/.*$",
   #"^kausal_common/typings/",
 ]
 check_untyped_defs = true
@@ -217,6 +217,13 @@ module = [
   "xlsxwriter.*",
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = [
+  "mcp_server.__generated__.*",
+  "paths_integration._generated_.*",
+]
+ignore_errors = true
 
 [tool.mypy-baseline]
 baseline_path = ".mypy-baseline.txt"
@@ -321,6 +328,9 @@ lint = [
     "types-psutil",
     "types-python-dateutil",
     "types-uwsgi",
+]
+mcp = [
+    "fastmcp>=2.14.2",
 ]
 prod = [
     "gunicorn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "elasticsearch",
     "elasticsearch-dsl",
     "factory-boy",
+    "fastmcp>=2.14.2",
     "graphene-django",
     "graphene-django-optimizer",
     "graphene-pydantic",
@@ -328,9 +329,6 @@ lint = [
     "types-psutil",
     "types-python-dateutil",
     "types-uwsgi",
-]
-mcp = [
-    "fastmcp>=2.14.2",
 ]
 prod = [
     "gunicorn",

--- a/uv.lock
+++ b/uv.lock
@@ -1722,6 +1722,7 @@ dependencies = [
     { name = "elasticsearch", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "elasticsearch-dsl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "factory-boy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fastmcp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "graphene-django", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "graphene-django-optimizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "graphene-pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1825,9 +1826,6 @@ lint = [
     { name = "types-python-dateutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-uwsgi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-mcp = [
-    { name = "fastmcp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
 prod = [
     { name = "gunicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rustface", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1874,6 +1872,7 @@ requires-dist = [
     { name = "elasticsearch" },
     { name = "elasticsearch-dsl" },
     { name = "factory-boy" },
+    { name = "fastmcp", specifier = ">=2.14.2" },
     { name = "graphene-django" },
     { name = "graphene-django-optimizer", url = "https://github.com/kausaltech/graphene-django-optimizer/archive/f18d827d0d58c1148288b6b886c167dd2fc1931a.zip" },
     { name = "graphene-pydantic" },
@@ -1972,7 +1971,6 @@ lint = [
     { name = "types-python-dateutil" },
     { name = "types-uwsgi" },
 ]
-mcp = [{ name = "fastmcp", specifier = ">=2.14.2" }]
 prod = [
     { name = "gunicorn" },
     { name = "rustface" },

--- a/uv.lock
+++ b/uv.lock
@@ -109,6 +109,18 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.6.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+]
+
+[[package]]
 name = "autobahn"
 version = "24.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -163,6 +175,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4f/a5/691d02a30bda15acb6a5727bb696dd7f3fcae1ad5b9f2708020c2645af8c/basedpyright-1.32.1.tar.gz", hash = "sha256:ce979891a3c4649e7c31d665acb06fd451f33fedfd500bc7796ee0950034aa54", size = 22757919, upload-time = "2025-10-23T12:53:28.169Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/d5/17d24fd7ba9d899b82859ee04f4599a1e8a02a85c0753bc15eb3ca7ffff7/basedpyright-1.32.1-py3-none-any.whl", hash = "sha256:06b5cc56693e3690653955e19fbe5d2e38f2a343563b40ef95fd1b10fa556fb6", size = 11841548, upload-time = "2025-10-23T12:53:25.541Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
 ]
 
 [[package]]
@@ -234,6 +255,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/60/9ec251a0e2d3994f3eac8bd9741576757c3aad189abbdec8fab6011f5a1a/botocore-1.37.34.tar.gz", hash = "sha256:2909b6dbf9c90347c71a6fa0364acee522d6a7664f13d6f7996c9dd1b1f46fac", size = 13817141, upload-time = "2025-04-14T19:26:01.366Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/51/19fff717cc5000708c4ce3d081bb0e63ca117c6823975b33101d52fdd9f5/botocore-1.37.34-py3-none-any.whl", hash = "sha256:bd9af0db1097befd2028ba8525e32cacc04f26ccb9dbd5d48d6ecd05bc16c27a", size = 13483679, upload-time = "2025-04-14T19:25:55.56Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/ede8680603f6016887c062a2cf4fc8fdba905866a3ab8831aa8aa651320c/cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607", size = 31731, upload-time = "2025-12-15T18:24:53.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/fc/1d7b80d0eb7b714984ce40efc78859c022cd930e402f599d8ca9e39c78a4/cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51", size = 11551, upload-time = "2025-12-15T18:24:52.332Z" },
 ]
 
 [[package]]
@@ -384,6 +414,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -464,6 +503,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "docstring-parser", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich-rst", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/c4/60b6068e703c78656d07b249919754f8f60e9e7da3325560574ee27b4e39/cyclopts-4.4.4.tar.gz", hash = "sha256:f30c591c971d974ab4f223e099f881668daed72de713713c984ca41479d393dd", size = 160046, upload-time = "2026-01-05T03:40:18.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/5b/0eceb9a5990de9025733a0d212ca43649ba9facd58b8552b6bf93c11439d/cyclopts-4.4.4-py3-none-any.whl", hash = "sha256:316f798fe2f2a30cb70e7140cfde2a46617bfbb575d31bbfdc0b2410a447bd83", size = 197398, upload-time = "2026-01-05T03:40:17.141Z" },
+]
+
+[[package]]
 name = "dal-admin-filters"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -532,6 +586,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b4/42/4aae9b5e73333803ca82a01652c4a10caeebdc719272527469727ddf1bb2/diffsync-2.0.1.tar.gz", hash = "sha256:7f6fe7705b0669f0249b18c97231b74bdfa2530117ad98f3b79a563c07ff7728", size = 31784, upload-time = "2024-10-22T05:43:10.617Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/53/b827778d2cd06db4c623ff931c10e53c550cfefc9b48ee197c16095e9dff/diffsync-2.0.1-py3-none-any.whl", hash = "sha256:c375139d2d0c060106ef4f724044bd70ec03296f90255cd41831946e0544a585", size = 39886, upload-time = "2024-10-22T05:43:09.002Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -920,6 +983,24 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
 name = "draftjs-exporter"
 version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -999,12 +1080,34 @@ wheels = [
 ]
 
 [[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "idna", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
 ]
 
 [[package]]
@@ -1041,12 +1144,57 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "sortedcontainers", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f9/57464119936414d60697fcbd32f38909bb5688b616ae13de6e98384433e0/fakeredis-2.33.0.tar.gz", hash = "sha256:d7bc9a69d21df108a6451bbffee23b3eba432c21a654afc7ff2d295428ec5770", size = 175187, upload-time = "2025-12-16T19:45:52.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl", hash = "sha256:de535f3f9ccde1c56672ab2fdd6a8efbc4f2619fc2f1acc87b8737177d71c965", size = 119605, upload-time = "2025-12-16T19:45:51.08Z" },
+]
+
+[package.optional-dependencies]
+lua = [
+    { name = "lupa", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
 name = "fancycompleter"
 version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/4c/d11187dee93eff89d082afda79b63c79320ae1347e49485a38f05ad359d0/fancycompleter-0.11.1.tar.gz", hash = "sha256:5b4ad65d76b32b1259251516d0f1cb2d82832b1ff8506697a707284780757f69", size = 341776, upload-time = "2025-05-26T12:59:11.045Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/c3/6f0e3896f193528bbd2b4d2122d4be8108a37efab0b8475855556a8c4afa/fancycompleter-0.11.1-py3-none-any.whl", hash = "sha256:44243d7fab37087208ca5acacf8f74c0aa4d733d04d593857873af7513cdf8a6", size = 11207, upload-time = "2025-05-26T12:59:09.857Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cyclopts", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "exceptiongroup", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jsonschema-path", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "mcp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "openapi-pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "platformdirs", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydocket", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyperclip", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-dotenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "uvicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "websockets", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/1e/e3528227688c248283f6d86869b1e900563ffc223eff00f4f923d2750365/fastmcp-2.14.2.tar.gz", hash = "sha256:bd23d1b808b6f446444f10114dac468b11bfb9153ed78628f5619763d0cf573e", size = 8272966, upload-time = "2025-12-31T15:26:13.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/67/8456d39484fcb7afd0defed21918e773ed59a98b39e5b633328527c88367/fastmcp-2.14.2-py3-none-any.whl", hash = "sha256:e33cd622e1ebd5110af6a981804525b6cd41072e3c7d68268ed69ef3be651aca", size = 413279, upload-time = "2025-12-31T15:26:11.178Z" },
 ]
 
 [[package]]
@@ -1259,6 +1407,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1394,6 +1551,39 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7d/41acf8e22d791bde812cb6c2c36128bb932ed8ae066bcb5e39cb198e8253/jaraco_context-6.0.2.tar.gz", hash = "sha256:953ae8dddb57b1d791bf72ea1009b32088840a7dd19b9ba16443f62be919ee57", size = 14994, upload-time = "2025-12-24T19:21:35.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0c/1e0096ced9c55f9c6c6655446798df74165780375d3f5ab5f33751e087ae/jaraco_context-6.0.2-py3-none-any.whl", hash = "sha256:55fc21af4b4f9ca94aa643b6ee7fe13b1e4c01abf3aeb98ca4ad9c80b741c786", size = 6988, upload-time = "2025-12-24T19:21:34.557Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1403,6 +1593,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -1439,6 +1638,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778, upload-time = "2024-07-08T18:40:05.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462, upload-time = "2024-07-08T18:40:00.165Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "referencing", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159, upload-time = "2025-01-24T14:33:16.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/58/3485da8cb93d2f393bce453adeef16896751f14ba3e2024bc21dc9597646/jsonschema_path-0.3.4-py3-none-any.whl", hash = "sha256:f502191fdc2b22050f9a81c9237be9d27145b9001c55842bece5e94e382e52f8", size = 14810, upload-time = "2025-01-24T14:33:14.652Z" },
 ]
 
 [[package]]
@@ -1611,6 +1825,9 @@ lint = [
     { name = "types-python-dateutil", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "types-uwsgi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+mcp = [
+    { name = "fastmcp", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 prod = [
     { name = "gunicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "rustface", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -1755,6 +1972,7 @@ lint = [
     { name = "types-python-dateutil" },
     { name = "types-uwsgi" },
 ]
+mcp = [{ name = "fastmcp", specifier = ">=2.14.2" }]
 prod = [
     { name = "gunicorn" },
     { name = "rustface" },
@@ -1769,6 +1987,22 @@ source = { registry = "https://pypi.kausal.tech/" }
 sdist = { url = "https://pypi.kausal.tech/packages/kausal_watch_extensions-0.1.163.tar.gz", hash = "sha256:2092061ea0515c1a184f5bd33f32d484453b51743625c147f91d2083da617de3" }
 wheels = [
     { url = "https://pypi.kausal.tech/packages/kausal_watch_extensions-0.1.163-py3-none-any.whl", hash = "sha256:f46266e1b8e1d4b6cd7ff1af696ae213dbe7b36c16174fcaad3e547cef9a457b" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jaraco-context", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jaraco-functools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jeepney", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "secretstorage", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1822,6 +2056,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "lupa"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/d9427394e54d22a35d1139ef12e845fd700d4872a67a34db32516170b746/lupa-2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcb6d0a3264873e1653bc188499f48c1fb4b41a779e315eba45256cfe7bc33c1", size = 953818, upload-time = "2025-10-24T07:18:53.378Z" },
+    { url = "https://files.pythonhosted.org/packages/10/41/27bbe81953fb2f9ecfced5d9c99f85b37964cfaf6aa8453bb11283983721/lupa-2.6-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a37e01f2128f8c36106726cb9d360bac087d58c54b4522b033cc5691c584db18", size = 1915850, upload-time = "2025-10-24T07:18:55.259Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c6/a04e9cef7c052717fcb28fb63b3824802488f688391895b618e39be0f684/lupa-2.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8faddd9d198688c8884091173a088a8e920ecc96cda2ffed576a23574c4b3f6", size = 2073458, upload-time = "2025-10-24T07:19:03.369Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/e318b628d4643c278c96ab3ddea07fc36b075a57383c837f5b11e537ba9d/lupa-2.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e4dadf77b9fedc0bfa53417cc28dc2278a26d4cbd95c29f8927ad4d8fe0a7ef9", size = 2166641, upload-time = "2025-10-24T07:19:10.485Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3c/a1f23b01c54669465f5f4c4083107d496fbe6fb45998771420e9aadcf145/lupa-2.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0e21b716408a21ab65723f8841cf7f2f37a844b7a965eeabb785e27fca4099cf", size = 999343, upload-time = "2025-10-24T07:19:12.519Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/501994291cb640bfa2ccf7f554be4e6914afa21c4026bd01bff9ca8aac57/lupa-2.6-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:589db872a141bfff828340079bbdf3e9a31f2689f4ca0d88f97d9e8c2eae6142", size = 2000730, upload-time = "2025-10-24T07:19:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/42/d8125f8e420714e5b52e9c08d88b5329dfb02dcca731b4f21faaee6cc5b5/lupa-2.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aa58454ccc13878cc177c62529a2056be734da16369e451987ff92784994ca7", size = 2058324, upload-time = "2025-10-24T07:19:24.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/89e6a024c3b4485b89ef86881c9d55e097e7cb0bdb74efb746f2fa6a9a76/lupa-2.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9abb98d5a8fd27c8285302e82199f0e56e463066f88f619d6594a450bf269d80", size = 2153693, upload-time = "2025-10-24T07:19:31.379Z" },
 ]
 
 [[package]]
@@ -1892,6 +2146,30 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx-sse", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "jsonschema", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic-settings", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyjwt", extra = ["crypto"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-multipart", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "sse-starlette", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "starlette", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "uvicorn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1910,6 +2188,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/37/9c/100deced3999e748500dda3027e2a19b0074199ba27cdc5a6988d22919b8/milksnake-0.1.6.tar.gz", hash = "sha256:0198f8932b4e136c29c0d0d490ff1bac03f82c3a7b2ee6f666e3683b64314fd9", size = 10483, upload-time = "2023-10-12T11:34:39.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/5b/1688cbd7244f039a2c1a762e246f04f7fc3eff07932776ac9944da3ea208/milksnake-0.1.6-py2.py3-none-any.whl", hash = "sha256:31e3eafaf2a48e177bb4b2dacef2c7ae8c5b2147a19c6d626209b819490e6f1d", size = 11136, upload-time = "2023-10-12T11:34:37.927Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -2028,6 +2315,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2041,46 +2340,46 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.36.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/d2/c782c88b8afbf961d6972428821c302bd1e9e7bc361352172f0ca31296e2/opentelemetry_api-1.36.0.tar.gz", hash = "sha256:9a72572b9c416d004d492cbc6e61962c0501eaf945ece9b5a0f56597d8348aa0", size = 64780, upload-time = "2025-07-29T15:12:06.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/ee/6b08dde0a022c463b88f55ae81149584b125a42183407dc1045c486cc870/opentelemetry_api-1.36.0-py3-none-any.whl", hash = "sha256:02f20bcacf666e1333b6b1f04e647dc1d5111f86b8e510238fcc56d7762cda8c", size = 65564, upload-time = "2025-07-29T15:11:47.998Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
 ]
 
 [[package]]
 name = "opentelemetry-distro"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-instrumentation", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/43/ce73692f61dded23c696d8df9d6c591f07fe9fc118a4ca026faa471ecf1a/opentelemetry_distro-0.57b0.tar.gz", hash = "sha256:b9f69d4636cf2b6b986e9737d6f3f8fade802f8d0d97bf4003a0e43144885a23", size = 2581, upload-time = "2025-07-29T15:42:43.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/77/f0b1f2bcf451ec5bc443d53bc7437577c3fc8444b3eb0d416ac5f7558b7b/opentelemetry_distro-0.60b1.tar.gz", hash = "sha256:8b7326b83a55ff7b17bb92225a86e2736a004f6af7aff00cb5d87b2d8e5bc283", size = 2584, upload-time = "2025-12-11T13:36:39.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/3b/9871e54c7b32fd859efd94e560a5e6689bff33207c1741f3152e25e55652/opentelemetry_distro-0.57b0-py3-none-any.whl", hash = "sha256:cd216037ae815c9478bb7b683e2e6d9e623eda368cafd73858f7ef6685931e66", size = 3343, upload-time = "2025-07-29T15:41:38.11Z" },
+    { url = "https://files.pythonhosted.org/packages/24/70/78a86531495040fcad9569d7daa630eca06d27d37c825a8aad448b7c1c5b/opentelemetry_distro-0.60b1-py3-none-any.whl", hash = "sha256:581104a786f5df252f4dfe725e0ae16337a26da902acb92d8b3e7aee29f0c76e", size = 3343, upload-time = "2025-12-11T13:35:28.462Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.36.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/da/7747e57eb341c59886052d733072bc878424bf20f1d8cf203d508bbece5b/opentelemetry_exporter_otlp_proto_common-1.36.0.tar.gz", hash = "sha256:6c496ccbcbe26b04653cecadd92f73659b814c6e3579af157d8716e5f9f25cbf", size = 20302, upload-time = "2025-07-29T15:12:07.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/ed/22290dca7db78eb32e0101738366b5bbda00d0407f00feffb9bf8c3fdf87/opentelemetry_exporter_otlp_proto_common-1.36.0-py3-none-any.whl", hash = "sha256:0fc002a6ed63eac235ada9aa7056e5492e9a71728214a61745f6ad04b923f840", size = 18349, upload-time = "2025-07-29T15:11:51.327Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.36.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2091,28 +2390,28 @@ dependencies = [
     { name = "requests", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/85/6632e7e5700ba1ce5b8a065315f92c1e6d787ccc4fb2bdab15139eaefc82/opentelemetry_exporter_otlp_proto_http-1.36.0.tar.gz", hash = "sha256:dd3637f72f774b9fc9608ab1ac479f8b44d09b6fb5b2f3df68a24ad1da7d356e", size = 16213, upload-time = "2025-07-29T15:12:08.932Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/04/2a08fa9c0214ae38880df01e8bfae12b067ec0793446578575e5080d6545/opentelemetry_exporter_otlp_proto_http-1.39.1.tar.gz", hash = "sha256:31bdab9745c709ce90a49a0624c2bd445d31a28ba34275951a6a362d16a0b9cb", size = 17288, upload-time = "2025-12-11T13:32:42.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/41/a680d38b34f8f5ddbd78ed9f0042e1cc712d58ec7531924d71cb1e6c629d/opentelemetry_exporter_otlp_proto_http-1.36.0-py3-none-any.whl", hash = "sha256:3d769f68e2267e7abe4527f70deb6f598f40be3ea34c6adc35789bea94a32902", size = 18752, upload-time = "2025-07-29T15:11:53.164Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f1/b27d3e2e003cd9a3592c43d099d2ed8d0a947c15281bf8463a256db0b46c/opentelemetry_exporter_otlp_proto_http-1.39.1-py3-none-any.whl", hash = "sha256:d9f5207183dd752a412c4cd564ca8875ececba13be6e9c6c370ffb752fd59985", size = 19641, upload-time = "2025-12-11T13:32:22.248Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-prometheus"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "prometheus-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/d8/5f04c6d51c0823c3d8ac973a2a38db6fcf2d040ca3f08fc66b3c14b6e164/opentelemetry_exporter_prometheus-0.57b0.tar.gz", hash = "sha256:9eb15bdc189235cf03c3f93abf56f8ff0ab57a493a189263bd7fe77a4249e689", size = 14906, upload-time = "2025-07-29T15:12:09.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/1c/40fb93a7b7e495985393bbc734104d5d20e470811644dd56c2402d683739/opentelemetry_exporter_prometheus-0.57b0-py3-none-any.whl", hash = "sha256:c5b893d1cdd593fb022af2c7de3258c2d5a4d04402ae80d9fa35675fed77f05c", size = 12922, upload-time = "2025-07-29T15:11:54.055Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2120,14 +2419,14 @@ dependencies = [
     { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wrapt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/37/cf17cf28f945a3aca5a038cfbb45ee01317d4f7f3a0e5209920883fe9b08/opentelemetry_instrumentation-0.57b0.tar.gz", hash = "sha256:f2a30135ba77cdea2b0e1df272f4163c154e978f57214795d72f40befd4fcf05", size = 30807, upload-time = "2025-07-29T15:42:44.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/6f/f20cd1542959f43fb26a5bf9bb18cd81a1ea0700e8870c8f369bd07f5c65/opentelemetry_instrumentation-0.57b0-py3-none-any.whl", hash = "sha256:9109280f44882e07cec2850db28210b90600ae9110b42824d196de357cbddf7e", size = 32460, upload-time = "2025-07-29T15:41:40.883Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-dbapi"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2135,14 +2434,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wrapt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/dc/5a17b2fb593901ba5257278073b28d0ed31497e56985990c26046e4da2d9/opentelemetry_instrumentation_dbapi-0.57b0.tar.gz", hash = "sha256:7ad9e39c91f6212f118435fd6fab842a1f78b2cbad1167f228c025bba2a8fc2d", size = 14176, upload-time = "2025-07-29T15:42:56.249Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b5/1e1f0642892a2abb6e75b7009ccee946e801cded88caac3d803cf46c8c73/opentelemetry_instrumentation_dbapi-0.60b1.tar.gz", hash = "sha256:a239d328249b86fba5e42900b98bf31ee99c07092530feca18afde92c600f901", size = 16311, upload-time = "2025-12-11T13:36:55.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/71/21a7e862dead70267b7c7bd5aa4e0b61fbc9fa9b4be57f4e183766abbad9/opentelemetry_instrumentation_dbapi-0.57b0-py3-none-any.whl", hash = "sha256:c1b110a5e86ec9b52b970460917523f47afa0c73f131e7f03c6a7c1921822dc4", size = 12466, upload-time = "2025-07-29T15:41:59.775Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/08/d4c78b6e317d9975d473dd98f7854f5731ff4a1d470c65d2630fa68a1484/opentelemetry_instrumentation_dbapi-0.60b1-py3-none-any.whl", hash = "sha256:5577189f678de5b9828c930c8fb72e8f1999b304131777b60099e5c4b3948193", size = 13968, upload-time = "2025-12-11T13:35:56.316Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-django"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2151,28 +2450,28 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-util-http", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/88/d88268c37aabbd2bcc54f4f868394316fa6fdfd3b91e011d229617d862d3/opentelemetry_instrumentation_django-0.57b0.tar.gz", hash = "sha256:df4116d2ea2c6bbbbf8853b843deb74d66bd0d573ddd372ec84fd60adaf977c6", size = 25005, upload-time = "2025-07-29T15:42:56.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/dc/a42fb5ff5c4ea8128d7c61a322e0cfbeae0fd204fc63a679f73caeec266e/opentelemetry_instrumentation_django-0.60b1.tar.gz", hash = "sha256:765b69c7ccdea7e9ebfd0b9e68387956b8f74816f3e39775d5b06a20f16b0522", size = 26599, upload-time = "2025-12-11T13:36:56.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/f0/1d5022f2fe16d50b79d9f1f5b70bd08d0e59819e0f6b237cff82c3dbda0f/opentelemetry_instrumentation_django-0.57b0-py3-none-any.whl", hash = "sha256:3d702d79a9ec0c836ccf733becf34630c6afb3c86c25c330c5b7601debe1e7c5", size = 19597, upload-time = "2025-07-29T15:42:00.657Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/05/6b348ea989f7a9e1e6311fa653e113bd39f4506771323e27a639c2a1ea54/opentelemetry_instrumentation_django-0.60b1-py3-none-any.whl", hash = "sha256:3f6b4ba201eee35406dab965b254eed0c64fa1ef42e4a7b0296ad1b30e8e3f81", size = 21172, upload-time = "2025-12-11T13:35:57.365Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-psycopg"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-instrumentation", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-instrumentation-dbapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/11/4145fafc6ae1f4d5b3badf2532caf8813944cb32c9894d33b1b58c09c5b7/opentelemetry_instrumentation_psycopg-0.57b0.tar.gz", hash = "sha256:6ba89a1f2bfd5fa9e5109a12c5748e33eb3857c807d5a8822c3f61a7594c74f1", size = 10488, upload-time = "2025-07-29T15:43:05.097Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3e/c158da3e2bd3211234c6f440ec8fb2773c63b126e9082dfb0cf03fbec396/opentelemetry_instrumentation_psycopg-0.60b1.tar.gz", hash = "sha256:c13a81a898307ebdaa8aa4a0ac17753cb308270fcb07a17a857f74b6021b5a12", size = 11524, upload-time = "2025-12-11T13:37:06.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/04/4de9645fab3174d189b5acbf64450657d0ee83ac93c792e096b25e4b7c8e/opentelemetry_instrumentation_psycopg-0.57b0-py3-none-any.whl", hash = "sha256:81b465ebc3c5285dfadf4ca370a53023e92569c1b2b321c42ca5255f69624631", size = 11031, upload-time = "2025-07-29T15:42:14.921Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ff/99e333b617c19041ba2f0311ecf91b735b914fff2b29d5e85b3081e77d12/opentelemetry_instrumentation_psycopg-0.60b1-py3-none-any.whl", hash = "sha256:67fa627561f00b903020843b9254a1be6f3f8c64501033afe629a574a2325ec2", size = 11630, upload-time = "2025-12-11T13:36:12.775Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-redis"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2180,28 +2479,28 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wrapt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/a0/e82d8dbb5e3856b4795e74e3a199aab00872daa40b6ebef1ac8e9a85e9d6/opentelemetry_instrumentation_redis-0.57b0.tar.gz", hash = "sha256:54fcd749dee6eebcd137c0f2d840d810fc4225368caf5f4cc91bfe0d13eb9176", size = 13971, upload-time = "2025-07-29T15:43:10.367Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1e/225364fab4db793f6f5024ed9f3dd53774fd7c7c21fa242460234dcdf8d9/opentelemetry_instrumentation_redis-0.60b1.tar.gz", hash = "sha256:ecafa8f81c88917b59f0d842fb3d157f3a8edc71fb4b85bebca3bc19432ce7b8", size = 14774, upload-time = "2025-12-11T13:37:11.201Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/c2/8b075769f62e0ecf2f1eaa3872825fbd930673dcafd4eef87efc777b13ac/opentelemetry_instrumentation_redis-0.57b0-py3-none-any.whl", hash = "sha256:4e988016e74d8fabc0be93a30462bce223423874c3fa53f0a154b0fe050041f9", size = 14926, upload-time = "2025-07-29T15:42:22.871Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bd/d55d3b34fd49df08d9d9fa3701dff0051b216e2c7e9adaaa4ff6aa1de8d7/opentelemetry_instrumentation_redis-0.60b1-py3-none-any.whl", hash = "sha256:33bef0ff9af6f2d88de90c1cd7e25675c10a16d4f9ee5ae7592b28bb08b78139", size = 15502, upload-time = "2025-12-11T13:36:21.481Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-threading"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-instrumentation", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "wrapt", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/f7/089b6c5b087ae96bf674b47431cc03351916eea777c7e7a946bcdbb9e6e3/opentelemetry_instrumentation_threading-0.57b0.tar.gz", hash = "sha256:06fa4c98d6bfe4670e7532497670ac202db42afa647ff770aedce0e422421c6e", size = 8768, upload-time = "2025-07-29T15:43:14.774Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/0a/e36123ec4c0910a3936b92982545a53e9bca5b26a28df06883751a783f84/opentelemetry_instrumentation_threading-0.60b1.tar.gz", hash = "sha256:20b18a68abe5801fa9474336b7c27487d4af3e00b66f6a8734e4fdd75c8b0b43", size = 8768, upload-time = "2025-12-11T13:37:16.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/09/db74038a99fe396779c5be09aa6491142e8c172f1d8ba05415a6b0c9f198/opentelemetry_instrumentation_threading-0.57b0-py3-none-any.whl", hash = "sha256:adfd64857c8c78d6111cf80552311e1713bad64272dd81abdd61f07b892a161b", size = 9312, upload-time = "2025-07-29T15:42:32Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a3/448738b927bcc1843ace7d4ed55dd54441a71363075eeeee89c5944dd740/opentelemetry_instrumentation_threading-0.60b1-py3-none-any.whl", hash = "sha256:92a52a60fee5e32bc6aa8f5acd749b15691ad0bc4457a310f5736b76a6d9d1de", size = 9312, upload-time = "2025-12-11T13:36:28.434Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-wsgi"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2209,57 +2508,57 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-util-http", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/3f/d1ab49d68f2f6ebbe3c2fa5ff609ee5603a9cc68915203c454afb3a38d5b/opentelemetry_instrumentation_wsgi-0.57b0.tar.gz", hash = "sha256:d7e16b3b87930c30fc4c1bbc8b58c5dd6eefade493a3a5e7343bc24d572bc5b7", size = 18376, upload-time = "2025-07-29T15:43:17.683Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/24/5632d31506a27650567fdff8f9be37fc4d98396b6331617be69bd332bf77/opentelemetry_instrumentation_wsgi-0.60b1.tar.gz", hash = "sha256:eb553eec7ebfcf2945cc10d787a265e7abadb9ed1d1ebce8b13988d44fa0cf45", size = 19167, upload-time = "2025-12-11T13:37:20.3Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/0c/7760f9e14f4f8128e4880b4fd5f232ef4eb00cb29ee560c972dbf7801369/opentelemetry_instrumentation_wsgi-0.57b0-py3-none-any.whl", hash = "sha256:b9cf0c6e61489f7503fc17ef04d169bd214e7a825650ee492f5d2b4d73b17b54", size = 14450, upload-time = "2025-07-29T15:42:37.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/98/c637d9e5cab1355d6765de2304199a1d79a43aa94c33d8eddb475327d81a/opentelemetry_instrumentation_wsgi-0.60b1-py3-none-any.whl", hash = "sha256:5e7b432778ebf5a39af136227884a6ab2efc3c4e73e2dbb1d05ecf03ea196705", size = 14583, upload-time = "2025-12-11T13:36:33.164Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.36.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/02/f6556142301d136e3b7e95ab8ea6a5d9dc28d879a99f3dd673b5f97dca06/opentelemetry_proto-1.36.0.tar.gz", hash = "sha256:0f10b3c72f74c91e0764a5ec88fd8f1c368ea5d9c64639fb455e2854ef87dd2f", size = 46152, upload-time = "2025-07-29T15:12:15.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/57/3361e06136225be8180e879199caea520f38026f8071366241ac458beb8d/opentelemetry_proto-1.36.0-py3-none-any.whl", hash = "sha256:151b3bf73a09f94afc658497cf77d45a565606f62ce0c17acb08cd9937ca206e", size = 72537, upload-time = "2025-07-29T15:12:02.243Z" },
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.36.0"
+version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "opentelemetry-semantic-conventions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/85/8567a966b85a2d3f971c4d42f781c305b2b91c043724fa08fd37d158e9dc/opentelemetry_sdk-1.36.0.tar.gz", hash = "sha256:19c8c81599f51b71670661ff7495c905d8fdf6976e41622d5245b791b06fa581", size = 162557, upload-time = "2025-07-29T15:12:16.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/59/7bed362ad1137ba5886dac8439e84cd2df6d087be7c09574ece47ae9b22c/opentelemetry_sdk-1.36.0-py3-none-any.whl", hash = "sha256:19fe048b42e98c5c1ffe85b569b7073576ad4ce0bcb6e9b4c6a39e890a6c45fb", size = 119995, upload-time = "2025-07-29T15:12:03.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/31/67dfa252ee88476a29200b0255bda8dfc2cf07b56ad66dc9a6221f7dc787/opentelemetry_semantic_conventions-0.57b0.tar.gz", hash = "sha256:609a4a79c7891b4620d64c7aac6898f872d790d75f22019913a660756f27ff32", size = 124225, upload-time = "2025-07-29T15:12:17.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/75/7d591371c6c39c73de5ce5da5a2cc7b72d1d1cd3f8f4638f553c01c37b11/opentelemetry_semantic_conventions-0.57b0-py3-none-any.whl", hash = "sha256:757f7e76293294f124c827e514c2a3144f191ef175b069ce8d1211e1e38e9e78", size = 201627, upload-time = "2025-07-29T15:12:04.174Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.57b0"
+version = "0.60b1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/1b/6229c45445e08e798fa825f5376f6d6a4211d29052a4088eed6d577fa653/opentelemetry_util_http-0.57b0.tar.gz", hash = "sha256:f7417595ead0eb42ed1863ec9b2f839fc740368cd7bbbfc1d0a47bc1ab0aba11", size = 9405, upload-time = "2025-07-29T15:43:19.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/fc/c47bb04a1d8a941a4061307e1eddfa331ed4d0ab13d8a9781e6db256940a/opentelemetry_util_http-0.60b1.tar.gz", hash = "sha256:0d97152ca8c8a41ced7172d29d3622a219317f74ae6bb3027cfbdcf22c3cc0d6", size = 11053, upload-time = "2025-12-11T13:37:25.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/a6/b98d508d189b9c208f5978d0906141747d7e6df7c7cafec03657ed1ed559/opentelemetry_util_http-0.57b0-py3-none-any.whl", hash = "sha256:e54c0df5543951e471c3d694f85474977cd5765a3b7654398c83bab3d2ffb8e9", size = 7643, upload-time = "2025-07-29T15:42:41.744Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5c/d3f1733665f7cd582ef0842fb1d2ed0bc1fba10875160593342d22bba375/opentelemetry_util_http-0.60b1-py3-none-any.whl", hash = "sha256:66381ba28550c91bee14dcba8979ace443444af1ed609226634596b4b0faf199", size = 8947, upload-time = "2025-12-11T13:36:37.151Z" },
 ]
 
 [[package]]
@@ -2311,12 +2610,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
 ]
 
 [[package]]
@@ -2530,6 +2847,47 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "py-key-value-shared", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+]
+
+[package.optional-dependencies]
+disk = [
+    { name = "diskcache", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pathvalidate", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+keyring = [
+    { name = "keyring", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+memory = [
+    { name = "cachetools", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+redis = [
+    { name = "redis", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
+name = "py-key-value-shared"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2585,6 +2943,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.33.2"
@@ -2603,6 +2966,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-dotenv", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-inspection", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
+]
+
+[[package]]
+name = "pydocket"
+version = "0.16.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "fakeredis", extra = ["lua"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-exporter-prometheus", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-instrumentation", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "prometheus-client", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "python-json-logger", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "redis", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/00/26befe5f58df7cd1aeda4a8d10bc7d1908ffd86b80fd995e57a2a7b3f7bd/pydocket-0.16.6.tar.gz", hash = "sha256:b96c96ad7692827214ed4ff25fcf941ec38371314db5dcc1ae792b3e9d3a0294", size = 299054, upload-time = "2026-01-09T22:09:15.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/3f/7483e5a6dc6326b6e0c640619b5c5bd1d6e3c20e54d58f5fb86267cef00e/pydocket-0.16.6-py3-none-any.whl", hash = "sha256:683d21e2e846aa5106274e7d59210331b242d7fb0dce5b08d3b82065663ed183", size = 67697, upload-time = "2026-01-09T22:09:13.436Z" },
 ]
 
 [[package]]
@@ -2691,6 +3091,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/8c/cd89ad05804f8e3c17dea8f178c3f40eeab5694c30e0c9f5bcd49f576fc3/pyopenssl-25.1.0.tar.gz", hash = "sha256:8d031884482e0c67ee92bf9a4d8cceb08d92aba7136432ffb0703c5280fc205b", size = 179937, upload-time = "2025-05-17T16:28:31.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/28/2659c02301b9500751f8d42f9a6632e1508aa5120de5e43042b8b30f8d5d/pyopenssl-25.1.0-py3-none-any.whl", hash = "sha256:2b11f239acc47ac2e5aca04fd7fa829800aeee22a2eb30d744572a157bd8a1ab", size = 56771, upload-time = "2025-05-17T16:28:29.197Z" },
+]
+
+[[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
 ]
 
 [[package]]
@@ -2808,12 +3217,30 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
+]
+
+[[package]]
 name = "python-magic"
 version = "0.4.27"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
 ]
 
 [[package]]
@@ -2913,6 +3340,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2989,6 +3429,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "jeepney", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3028,6 +3481,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -3089,6 +3551,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.6"
 source = { registry = "https://pypi.org/simple" }
@@ -3104,6 +3575,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/3c/fa6517610dc641262b77cc7bf994ecd17465812c1b0585fe33e11be758ab/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971", size = 21943, upload-time = "2025-10-30T18:44:20.117Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/a0/984525d19ca5c8a6c33911a0c164b11490dd0f90ff7fd689f704f84e9a11/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431", size = 11765, upload-time = "2025-10-30T18:44:18.834Z" },
 ]
 
 [[package]]
@@ -3274,6 +3757,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "rich", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "shellingham", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
+]
+
+[[package]]
 name = "types-oauthlib"
 version = "3.3.0.20250822"
 source = { registry = "https://pypi.org/simple" }
@@ -3341,23 +3839,23 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222, upload-time = "2025-02-25T17:27:59.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125, upload-time = "2025-02-25T17:27:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Add MCP (Model Context Protocol) server at `/mcp` endpoint to enable AI assistants (LibreChat, Claude.ai, etc.) to query climate action plan data. This implements read-only tools for listing and retrieving plans, actions, and user details.

Also adds `CLAUDE.md` with AI agent instructions and codebase documentation, and improves the `destructively_trim_db` management command.

## Screenshots/Videos (if applicable)
N/A - backend API changes

## Related issue
N/A

## Requirements, dependencies and related PRs
- Requires `fastmcp` package (added to dependencies)
- Uses existing GraphQL schema and authentication

## Additional Notes
- MCP tools reuse existing GraphQL queries and permission logic
- Auto-generated GraphQL client code in `mcp_server/__generated__/` (turms)
- Test with `uv run mcp_server/mcp_client_tool.py --list-tools`

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Authorization is tested** (permissions and access controls verified - reuses existing GraphQL auth)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    1. Start server: `uvicorn aplans.asgi:application --reload`
    2. Set `MCP_CLIENT_TOKEN` in `.env` with valid OAuth2 token
    3. Test: `uv run mcp_server/mcp_client_tool.py --list-tools`

### Internationalization & Accessibility
- [x] **New strings are translatable** (no user-facing text - API only)
- [x] **Accessibility** standards met (N/A - backend only)

### Integrations (if applicable)
- [x] **Moderation** integration implemented (N/A - read-only)
- [x] **Reporting** integration implemented (N/A)
- [x] **Copy plan feature** integration implemented (N/A)

### Dependencies
- [x] **Dependencies are merged** (no external PR dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces AI assistant integration and real-time updates while tightening maintenance utilities.
> 
> - **MCP server (@ `/mcp`)**: New `mcp_server/` app (FastMCP) with tools `list_plans`, `get_plan`, `list_actions`, `get_action`, `user_details`; OAuth-bearing auth middleware; queries and codegen (`queries.graphql`, `__generated__/schema.py`); CLI tester.
> - **ASGI/Settings**: Channels enabled with Redis/InMemory backends; optional `ENABLE_MCP_SERVER`; ASGI router mounts MCP with auth; separate async GraphQL schema for WS.
> - **GraphQL**: New `plans` query (superusers), `me` field, and Strawberry Subscription `plan_cache_invalidations`; `Plan.invalidate_cache` broadcasts via Channels.
> - **Admin UI**: Adds Select2/Autocomplete styling in `admin-styles.css`.
> - **Maintenance**: Revamps `destructively_trim_db` with `--thorough`, safer env checks, muted signals, and broader deletions (logs, thumbnails `Source`, sessions) via helpers.
> - **Docs/Config**: Adds `CLAUDE.md`, MCP architecture docs, GraphQL config; updates `.gitignore`, dependencies (`fastmcp`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f36d2e1522898f99980b489f311a9d41102f331. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->