### PR TITLE
Fix bulk API object permissions

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast, override
 from uuid import UUID
 
 import rest_framework.fields
@@ -30,8 +30,8 @@ from kausal_common.people.api import PersonSerializer as BasePersonSerializer
 from kausal_common.users import user_or_none
 
 from aplans.api_router import router
-from aplans.permissions import AnonReadOnly
-from aplans.rest_api import PlanRelatedModelSerializer
+from aplans.permissions import AnonReadOnly, WatchObjectPermissions
+from aplans.rest_api import PlanRelatedModelSerializer, get_plan_from_view
 from aplans.utils import generate_identifier, public_fields
 
 from actions.models.action import ActionContactPerson, ActionImplementationPhase, ActionQuerySet
@@ -61,6 +61,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from django.db.models import Model, QuerySet
+    from django.views.generic import View
     from rest_framework.request import Request
     from rest_framework.routers import BaseRouter
 
@@ -220,52 +221,24 @@ plan_router.register(
 )
 
 
-class ActionPermission(permissions.DjangoObjectPermissions):
-    # TODO: Refactor duplicated code with ActionPermission, CategoryPermission, OrganizationPermission and PersonPermission
-    def check_permission(self, user: User, perm: str, plan: Plan, action: Action | None = None):
-        # Check for object permissions first
-        if not user.has_perms([perm]):
-            return False
-        if perm == 'actions.change_action':
-            if not user.can_modify_action(action=action, plan=plan):
-                return False
-        elif perm == 'actions.add_action':
-            if not user.can_create_action(plan=plan):
-                return False
-        elif perm == 'actions.delete_action':
-            if not user.can_delete_action(plan=plan):
-                return False
-        else:
-            return False
-        return True
+class ActionPermission(WatchObjectPermissions):
+    model = Action
 
-    def has_permission(self, request: Request, view):
-        plan_pk = view.kwargs.get('plan_pk')
-        if plan_pk:
-            plan = Plan.objects.filter(id=plan_pk).first()
-            if plan is None:
-                raise exceptions.NotFound(detail='Plan not found')
-        else:
-            plan = Plan.objects.get_queryset().live().first()
-            assert plan is not None
-        if request.method is None:
-            return False
-        perms = self.get_required_permissions(request.method, Action)
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, plan) for perm in perms)
-
-    def has_object_permission(self, request, view, obj):
-        if request.method is None:
-            return False
-        perms = self.get_required_object_permissions(request.method, Action)
-        if not perms and request.method in permissions.SAFE_METHODS:
-            return True
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, obj.plan, obj) for perm in perms)
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        plan = get_plan_from_view(view)
+        match perm:
+            case 'actions.change_action':
+                assert obj is None or isinstance(obj, Action)
+                return user.can_modify_action(action=obj, plan=plan)
+            case 'actions.add_action':
+                assert obj is None
+                return user.can_create_action(plan=plan)
+            case 'actions.delete_action':
+                # For now we don't have object-specific delete permissions
+                assert obj is None
+                return user.can_delete_action(plan=plan)
+        return False
 
 
 @extend_schema_field(
@@ -1157,12 +1130,9 @@ class ActionViewSet(ViewSetWithPlanContext, HandleProtectedErrorMixin, BulkModel
     serializer_class = ActionSerializer
 
     def get_permissions(self):
-        permission_classes: list[type[permissions.BasePermission]]
         if self.action == 'list':
-            permission_classes = [AnonReadOnly]
-        else:
-            permission_classes = [ActionPermission]
-        return [permission() for permission in permission_classes]
+            return [AnonReadOnly()]
+        return [ActionPermission()]
 
     def get_queryset(self):
         if getattr(self, 'swagger_fake_view', False):
@@ -1223,52 +1193,28 @@ class CategoryTypeSerializer(serializers.HyperlinkedModelSerializer[CategoryType
         fields = '__all__'
 
 
-class CategoryPermission(permissions.DjangoObjectPermissions):
-    # TODO: Refactor duplicated code with ActionPermission, CategoryPermission, OrganizationPermission and PersonPermission
-    def check_permission(self, user: User, perm: str, category_type: CategoryType, category: Category | None = None) -> bool:
-        # Check for object permissions first
-        if not user.has_perms([perm]):
-            return False
-        if perm == 'actions.change_category':
-            if not user.can_modify_category(category=category):
-                return False
-        elif perm == 'actions.add_category':
-            if not user.can_create_category(category_type=category_type):
-                return False
-        elif perm == 'actions.delete_category':
-            if not user.can_delete_category(category_type=category_type):
-                return False
-        else:
-            return False
-        return True
+class CategoryPermission(WatchObjectPermissions):
+    model = Category
 
-    def has_permission(self, request: Request, view) -> bool:
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
         category_type_pk = view.kwargs.get('category_type_pk')
-        if category_type_pk:
-            category_type = CategoryType.objects.filter(id=category_type_pk).first()
-            if category_type is None:
-                raise exceptions.NotFound(detail='Category type not found')
-        else:
-            category_type = CategoryType.objects.first()
-            assert category_type is not None
-        if request.method is None:
-            return False
-        perms = self.get_required_permissions(request.method, Category)
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, category_type) for perm in perms)
-
-    def has_object_permission(self, request: Request, view, obj):
-        if request.method is None:
-            return False
-        perms = self.get_required_object_permissions(request.method, Category)
-        if not perms and request.method in permissions.SAFE_METHODS:
-            return True
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, obj.type, obj) for perm in perms)
+        try:
+            category_type = CategoryType.objects.get(id=category_type_pk)
+        except CategoryType.DoesNotExist as e:
+            raise exceptions.NotFound(detail='Category type not found') from e
+        match perm:
+            case 'actions.change_category':
+                assert obj is None or isinstance(obj, Category)
+                return user.can_modify_category(category=obj)
+            case 'actions.add_category':
+                assert obj is None
+                return user.can_create_category(category_type=category_type)
+            case 'actions.delete_category':
+                # For now we don't have object-specific delete permissions
+                assert obj is None
+                return user.can_delete_category(category_type=category_type)
+        return False
 
 
 class CategoryTypeViewSet(viewsets.ModelViewSet[CategoryType]):
@@ -1387,12 +1333,9 @@ class CategoryViewSet(ViewSetWithPlanContext, HandleProtectedErrorMixin, BulkMod
     serializer_class = CategorySerializer
 
     def get_permissions(self):
-        permission_classes: list[type[permissions.BasePermission]]
         if self.action == 'list':
-            permission_classes = [AnonReadOnly]
-        else:
-            permission_classes = [CategoryPermission]
-        return [permission() for permission in permission_classes]
+            return [AnonReadOnly()]
+        return [CategoryPermission()]
 
     def get_queryset(self):
         if getattr(self, 'swagger_fake_view', False):
@@ -1410,51 +1353,24 @@ class CategoryViewSet(ViewSetWithPlanContext, HandleProtectedErrorMixin, BulkMod
 category_type_router.register('categories', CategoryViewSet, basename='category')
 
 
-class OrganizationPermission(permissions.DjangoObjectPermissions):
-    # TODO: Refactor duplicated code with ActionPermission, CategoryPermission, OrganizationPermission and PersonPermission
-    def check_permission(self, user: User, perm: str, organization: Organization | None = None):
-        # Check for object permissions first
-        if not user.has_perms([perm]):
-            return False
-        if perm == 'orgs.change_organization':
-            if not user.can_modify_organization(organization=organization):
-                return False
-        elif perm == 'orgs.add_organization':
-            if not user.can_create_organization():
-                return False
-        elif perm == 'orgs.delete_organization':
-            if not user.can_delete_organization():
-                return False
-        else:
-            return False
-        return True
+class OrganizationPermission(WatchObjectPermissions):
+    model = Organization
 
-    def has_permission(self, request: Request, view):
-        # plan_pk = view.kwargs.get('plan_pk')
-        # if plan_pk:
-        #     plan = Plan.objects.filter(id=plan_pk).first()
-        #     if plan is None:
-        #         raise exceptions.NotFound(detail='Plan not found')
-        # else:
-        #     plan = Plan.objects.live().first()
-        if request.method is None:
-            return False
-        perms = self.get_required_permissions(request.method, Organization)
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm) for perm in perms)
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        match perm:
+            case 'orgs.change_organization':
+                assert obj is None or isinstance(obj, Organization)
+                return user.can_modify_organization(organization=obj)
+            case 'orgs.add_organization':
+                assert obj is None
+                return user.can_create_organization()
+            case 'orgs.delete_organization':
+                # For now we don't have object-specific delete permissions
+                assert obj is None
+                return user.can_delete_organization()
+        return False
 
-    def has_object_permission(self, request, view, obj):
-        if request.method is None:
-            return False
-        perms = self.get_required_object_permissions(request.method, Organization)
-        if not perms and request.method in permissions.SAFE_METHODS:
-            return True
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, obj) for perm in perms)
 
 class OrganizationSerializer(TreebeardModelSerializerMixin[Organization], serializers.ModelSerializer[Organization]):  # type: ignore[misc]
     uuid = serializers.UUIDField(required=False)
@@ -1490,12 +1406,9 @@ class OrganizationViewSet(HandleProtectedErrorMixin, BulkModelViewSet):
         return self.bulk_update(request, *args, **kwargs)
 
     def get_permissions(self):
-        permission_classes: list[type[permissions.BasePermission]]
         if self.action == 'list':
-            permission_classes = [AnonReadOnly]
-        else:
-            permission_classes = [OrganizationPermission]
-        return [permission() for permission in permission_classes]
+            return [AnonReadOnly()]
+        return [OrganizationPermission()]
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -1510,51 +1423,26 @@ class OrganizationViewSet(HandleProtectedErrorMixin, BulkModelViewSet):
 
 
 
-class PersonPermission(permissions.DjangoObjectPermissions):
-    # TODO: Refactor duplicated code with ActionPermission, CategoryPermission, OrganizationPermission and PersonPermission
-    def check_permission(self, user: User, perm: str, person: Person = None, plan: Plan = None):
-        # Check for object permissions first
-        if not user.has_perms([perm]):
-            return False
-        if perm == 'people.change_person':
-            if not user.can_modify_person(person=person):
-                return False
-        elif perm == 'people.add_person':
-            if not user.can_create_person():
-                return False
-        elif perm == 'people.delete_person':
-            if person is None:
-                #  Does the user have deletion rights in general
-                if not user.is_general_admin_for_plan(plan) and not user.is_superuser:
-                    return False
-            # Does the user have deletion rights to this person in this plan
-            elif not user.can_edit_or_delete_person_within_plan(person, plan=plan):
-                return False
-        else:
-            return False
-        return True
+class PersonPermission(WatchObjectPermissions):
+    model = Person
 
-    def has_permission(self, request: Request, view):
-        if request.method is None:
-            return False
-        perms = self.get_required_permissions(request.method, Person)
-        plan = request.get_active_admin_plan()
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, plan=plan) for perm in perms)
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        match perm:
+            case 'people.change_person':
+                assert obj is None or isinstance(obj, Person)
+                return user.can_modify_person(person=obj)
+            case 'people.add_person':
+                assert obj is None
+                return user.can_create_person()
+            case 'people.delete_person':
+                plan = get_plan_from_view(view)
+                if obj is None:
+                    return user.is_superuser or user.is_general_admin_for_plan(plan)
+                assert isinstance(obj, Person)
+                return user.can_edit_or_delete_person_within_plan(obj, plan=plan)
+        return False
 
-    def has_object_permission(self, request, view, obj):
-        if request.method is None:
-            return False
-        perms = self.get_required_object_permissions(request.method, Person)
-        plan = request.get_active_admin_plan()
-        if not perms and request.method in permissions.SAFE_METHODS:
-            return True
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, person=obj, plan=plan) for perm in perms)
 
 class PersonSerializer(BasePersonSerializer):
     def __init__(self, *args, **kwargs):
@@ -1584,12 +1472,9 @@ class PersonViewSet(ModelWithImageViewMixin, BulkModelViewSet[Person]):
         instance.delete_and_deactivate_corresponding_user(acting_admin_user)
 
     def get_permissions(self):
-        permission_classes: list[type[permissions.BasePermission]]
         if self.action == 'list':
-            permission_classes = [AnonReadOnly]
-        else:
-            permission_classes = [PersonPermission]
-        return [permission() for permission in permission_classes]
+            return [AnonReadOnly()]
+        return [PersonPermission()]
 
     def get_plan(self):
         plan_identifier = self.request.query_params.get('plan', None)
@@ -1688,12 +1573,9 @@ class ActionTaskViewSet(ViewSetWithPlanContext, BulkModelViewSet[ActionTask]):
     serializer_class = ActionTaskSerializer
 
     def get_permissions(self):
-        permission_classes: list[type[permissions.BasePermission]]
         if self.action == 'list':
-            permission_classes = [AnonReadOnly]
-        else:
-            permission_classes = [ActionTaskPermission]
-        return [permission() for permission in permission_classes]
+            return [AnonReadOnly()]
+        return [ActionTaskPermission()]
 
     def get_queryset(self):
         if getattr(self, 'swagger_fake_view', False):
@@ -1719,49 +1601,20 @@ action_task_router = NestedBulkRouter(plan_router, 'action-tasks', lookup='actio
 all_routers.append(action_task_router)
 
 
-class ActionTaskPermission(permissions.DjangoObjectPermissions):
-    def check_permission(self, user: User, perm: str, plan: Plan, task: ActionTask | None = None):
-        # Check for object permissions first
-        if not user.has_perms([perm]):
-            return False
-        if task:
-            action = task.action
+class ActionTaskPermission(WatchObjectPermissions):
+    model = ActionTask
+
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        if obj:
+            assert isinstance(obj, ActionTask)
+            action = obj.action
         else:
             action = None
         if perm in (f'actions.{op}_actiontask' for op in ('change', 'add', 'delete')):
-            if not user.can_modify_action(action=action, plan=plan):
-                return False
-        else:
-            return False
-        return True
-
-    def has_permission(self, request: Request, view):
-        plan_pk = view.kwargs.get('plan_pk')
-        if plan_pk:
-            plan = Plan.objects.filter(id=plan_pk).first()
-            if plan is None:
-                raise exceptions.NotFound(detail='Plan not found')
-        else:
-            plan = Plan.objects.get_queryset().live().first()
-            assert plan is not None
-        if request.method is None:
-            return False
-        perms = self.get_required_permissions(request.method, ActionTask)
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, plan) for perm in perms)
-
-    def has_object_permission(self, request, view, obj):
-        if request.method is None:
-            return False
-        perms = self.get_required_object_permissions(request.method, ActionTask)
-        if not perms and request.method in permissions.SAFE_METHODS:
-            return True
-        user = user_or_none(request.user)
-        if user is None:
-            return False
-        return all(self.check_permission(user, perm, obj.action.plan, obj) for perm in perms)
+            plan = get_plan_from_view(view)
+            return user.can_modify_action(action=action, plan=plan)
+        return False
 
 
 class ScenarioSerializer(serializers.HyperlinkedModelSerializer):

--- a/actions/api.py
+++ b/actions/api.py
@@ -236,7 +236,6 @@ class ActionPermission(WatchObjectPermissions):
                 return user.can_create_action(plan=plan)
             case 'actions.delete_action':
                 # For now we don't have object-specific delete permissions
-                assert obj is None
                 return user.can_delete_action(plan=plan)
         return False
 
@@ -1212,7 +1211,6 @@ class CategoryPermission(WatchObjectPermissions):
                 return user.can_create_category(category_type=category_type)
             case 'actions.delete_category':
                 # For now we don't have object-specific delete permissions
-                assert obj is None
                 return user.can_delete_category(category_type=category_type)
         return False
 
@@ -1367,7 +1365,6 @@ class OrganizationPermission(WatchObjectPermissions):
                 return user.can_create_organization()
             case 'orgs.delete_organization':
                 # For now we don't have object-specific delete permissions
-                assert obj is None
                 return user.can_delete_organization()
         return False
 

--- a/actions/api.py
+++ b/actions/api.py
@@ -1436,7 +1436,7 @@ class PersonPermission(WatchObjectPermissions):
                 assert obj is None
                 return user.can_create_person()
             case 'people.delete_person':
-                plan = get_plan_from_view(view)
+                plan = user.get_active_admin_plan()
                 if obj is None:
                     return user.is_superuser or user.is_general_admin_for_plan(plan)
                 assert isinstance(obj, Person)

--- a/actions/tests/test_api.py
+++ b/actions/tests/test_api.py
@@ -177,7 +177,24 @@ def test_action_put_as_contact_person_denied_for_other_action(api_client, action
     response = api_client.put(action_detail_url, data={
         'identifier': 'ID-1',
         'id': action.id,
-        'name': 'bar'})
+        'name': 'bar',
+    })
+    assert response.status_code == 403
+
+
+def test_action_bulk_put_as_contact_person_denied_for_other_action(api_client, action, action_list_url):
+    contact = ActionContactFactory.create(action__plan=action.plan)
+    user = contact.person.user
+    assert user
+    assert not user.is_superuser
+    assert action.plan not in user.person.general_admin_plans.all()
+    assert contact.action != action
+    api_client.force_login(user)
+    response = api_client.put(action_list_url, data=[{
+        'identifier': 'ID-1',
+        'id': action.id,
+        'name': 'bar',
+    }])
     assert response.status_code == 403
 
 
@@ -193,6 +210,20 @@ def test_action_put_as_contact_person_allowed_for_own_action(api_client, plan):
         'identifier': 'ID-1',
         'id': contact.action.id,
         'name': 'bar'})
+    assert response.status_code == 200
+
+
+def test_action_bulk_put_as_contact_person_allowed_for_own_action(api_client, plan, action_list_url):
+    contact = ActionContactFactory.create(action__plan=plan)
+    user = contact.person.user
+    assert user
+    assert not user.is_superuser
+    assert contact.action.plan not in user.person.general_admin_plans.all()
+    api_client.force_login(user)
+    response = api_client.put(action_list_url, data=[{
+        'identifier': 'ID-1',
+        'id': contact.action.id,
+        'name': 'bar'}])
     assert response.status_code == 200
 
 

--- a/actions/tests/test_graphql_planpage.py
+++ b/actions/tests/test_graphql_planpage.py
@@ -145,9 +145,10 @@ def test_category_list_block(graphql_client_query_data, category_list_block, pla
     )
 
 
-def test_indicator_group_block(graphql_client_query_data, indicator_block, plan_with_pages):
+@pytest.mark.parametrize('indicator__plans', [[]])
+def test_indicator_group_block(graphql_client_query_data, indicator, indicator_block, plan_with_pages):
     plan = plan_with_pages
-    indicator = indicator_block['indicator']
+    assert indicator == indicator_block['indicator']
     assert not indicator.goals.exists()
     assert not indicator.levels.exists()
     assert indicator.latest_value is None

--- a/aplans/permissions.py
+++ b/aplans/permissions.py
@@ -1,6 +1,58 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
 from rest_framework import permissions
+
+from kausal_common.users import user_or_none
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+    from django.views.generic import View
+    from rest_framework.request import Request
+
+    from users.models import User
 
 
 class AnonReadOnly(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.method in permissions.SAFE_METHODS
+
+
+class WatchObjectPermissions(permissions.DjangoObjectPermissions):
+    model: type[Model]
+
+    @abstractmethod
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        """
+        Return true if the user has the permission `perm`.
+
+        If `obj` is None, we check model permissions, otherwise for permissions on the given object.
+        """
+        pass
+
+    def check_permissions(self, perms: list[str], request: Request, view: View, obj: Model | None = None):
+        """
+        Return true if the user has all permissions in `perms`.
+
+        If `obj` is None, this checks model permissions, otherwise object permissions.
+        """
+        if not perms and request.method in permissions.SAFE_METHODS:
+            return True
+        user = user_or_none(request.user)
+        if user is None:
+            return False
+        return all(self.check_permission(perm, user, view, obj) for perm in perms)
+
+    def has_permission(self, request: Request, view: View):
+        if not request.method:
+            return False
+        perms = self.get_required_permissions(request.method, self.model)
+        return self.check_permissions(perms, request, view)
+
+    def has_object_permission(self, request: Request, view: View, obj: Model):
+        if request.method is None:
+            return False
+        perms = self.get_required_object_permissions(request.method, self.model)
+        return self.check_permissions(perms, request, view, obj)

--- a/aplans/rest_api.py
+++ b/aplans/rest_api.py
@@ -7,11 +7,24 @@ from rest_framework import exceptions, serializers
 from actions.models import Plan
 
 if typing.TYPE_CHECKING:
+    from django.views.generic import View
+
     from aplans.utils import PlanRelatedModel
 
 
 def get_default_plan() -> Plan:
     return Plan.objects.get_queryset().live()[0]
+
+
+def get_plan_from_view(view: View) -> Plan:
+    plan_pk = view.kwargs.get('plan_pk')
+    if plan_pk:
+        plan = Plan.objects.filter(id=plan_pk).first()
+    else:
+        plan = Plan.objects.get_queryset().live().first()
+    if plan is None:
+        raise exceptions.NotFound(detail='Plan not found')
+    return plan
 
 
 class PlanRelatedModelSerializer[Model: PlanRelatedModel](serializers.ModelSerializer[Model]):

--- a/conftest.py
+++ b/conftest.py
@@ -106,7 +106,7 @@ register(documents_factories.AplansDocumentFactory)
 register(images_factories.AplansImageFactory)
 register(indicators_factories.CommonIndicatorFactory)
 register(indicators_factories.CommonIndicatorNormalizatorFactory)
-register(indicators_factories.IndicatorFactory)
+register(indicators_factories.IndicatorFactory, plans=LazyFixture(lambda plan: [plan]))
 register(indicators_factories.IndicatorValueFactory)
 register(indicators_factories.IndicatorBlockFactory)
 # NOTE: Due to a presumed bug in wagtail-factories, we deliberately do not register factories containing a

--- a/indicators/api.py
+++ b/indicators/api.py
@@ -574,7 +574,6 @@ class IndicatorPermission(WatchObjectPermissions):
                 return user.can_create_indicator(plan=plan)
             case 'indicators.delete_indicator':
                 # For now we don't have object-specific delete permissions
-                assert obj is None
                 return user.can_delete_indicator(plan=plan)
         return False
 

--- a/indicators/api.py
+++ b/indicators/api.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _
-from rest_framework import exceptions, permissions, serializers, status, viewsets
+from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -17,10 +17,11 @@ from kausal_common.api.bulk import BulkListSerializer, BulkModelViewSet
 from kausal_common.api.utils import register_view_helper
 from kausal_common.users import user_or_bust, user_or_none
 
-from actions.api import plan_router
+from aplans.permissions import WatchObjectPermissions
+
+from actions.api import get_plan_from_view, plan_router
 from actions.models import Plan
 from people.models import Person
-from users.models import User
 
 from .models import (
     ActionIndicator,
@@ -35,9 +36,12 @@ from .models import (
 )
 
 if TYPE_CHECKING:
+    from django.db.models import Model
+    from django.views.generic import View
     from rest_framework.request import Request
 
     from indicators.models.indicator import IndicatorQuerySet
+    from users.models import User
 
 all_views = []
 
@@ -540,40 +544,39 @@ class IndicatorGoalSerializer(serializers.ModelSerializer, IndicatorDataPointMix
         fields = ['date', 'value']
 
 
-class IndicatorEditValuesPermission(permissions.DjangoObjectPermissions):
-    def check_permission(self, user: User, perm: str, indicator: Indicator | None = None):
-        # Check for object permissions first
-        if not user.has_perms([perm]):
-            return False
-        if perm in (
-            'indicators.change_indicatorvalue',
-            'indicators.add_indicatorvalue',
-            'indicators.delete_indicatorvalue',
-        ):
-            if not user.can_modify_indicator(indicator=indicator):
-                return False
-        else:
-            return False
-        return True
+class IndicatorEditValuesPermission(WatchObjectPermissions):
+    model = IndicatorValue
 
-    def has_permission(self, request, view):
-        indicator_pk = view.kwargs.get('pk')
-        try:
-            indicator = Indicator.objects.get(id=indicator_pk)
-        except Indicator.DoesNotExist as e:
-            raise exceptions.NotFound(detail='Indicator not found') from e
-        if not request.method or not request.user.is_authenticated or not isinstance(request.user, User):
-            return False  # linter bitches below otherwise
-        perms = self.get_required_permissions(request.method, IndicatorValue)
-        return all(self.check_permission(request.user, perm, indicator) for perm in perms)
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        if perm in (f'indicators.{op}_indicatorvalue' for op in ('change', 'add', 'delete')):
+            indicator_pk = view.kwargs.get('pk')
+            try:
+                indicator = Indicator.objects.get(id=indicator_pk)
+            except Indicator.DoesNotExist as e:
+                raise exceptions.NotFound(detail='Indicator not found') from e
+            return user.can_modify_indicator(indicator=indicator)
+        return False
 
-    def has_object_permission(self, request, view, obj):
-        if not request.method or not request.user.is_authenticated or not isinstance(request.user, User):
-            return False  # linter bitches below otherwise
-        perms = self.get_required_object_permissions(request.method, IndicatorValue)
-        if not perms and request.method in permissions.SAFE_METHODS:
-            return True
-        return all(self.check_permission(request.user, perm, obj) for perm in perms)
+
+class IndicatorPermission(WatchObjectPermissions):
+    model = Indicator
+
+    @override
+    def check_permission(self, perm: str, user: User, view: View, obj: Model | None = None) -> bool:
+        plan = get_plan_from_view(view)
+        match perm:
+            case 'indicators.change_indicator':
+                assert obj is None or isinstance(obj, Indicator)
+                return user.can_modify_indicator(indicator=obj)
+            case 'indicators.add_indicator':
+                assert obj is None
+                return user.can_create_indicator(plan=plan)
+            case 'indicators.delete_indicator':
+                # For now we don't have object-specific delete permissions
+                assert obj is None
+                return user.can_delete_indicator(plan=plan)
+        return False
 
 
 @extend_schema(
@@ -584,8 +587,6 @@ class IndicatorEditValuesPermission(permissions.DjangoObjectPermissions):
 )
 class IndicatorViewSet(BulkModelViewSet):
     serializer_class = IndicatorSerializer
-    permission_classes = (permissions.DjangoModelPermissionsOrAnonReadOnly,)
-
     filterset_class = IndicatorFilter
 
     def get_queryset(self):
@@ -597,10 +598,8 @@ class IndicatorViewSet(BulkModelViewSet):
 
     def get_permissions(self):
         if self.action == 'update_values':
-            perms = [IndicatorEditValuesPermission]
-        else:
-            perms = list(self.permission_classes)
-        return [perm() for perm in perms]
+            return [IndicatorEditValuesPermission()]
+        return [IndicatorPermission()]
 
     def check_object_permission(self, request, obj):
         super().check_object_permissions(request, obj)

--- a/indicators/tests/conftest.py
+++ b/indicators/tests/conftest.py
@@ -1,12 +1,6 @@
 from django.urls import reverse
 
 import pytest
-from pytest_factoryboy import register
-
-from .factories import IndicatorFactory, UnitFactory
-
-register(IndicatorFactory)
-register(UnitFactory)
 
 
 @pytest.fixture

--- a/indicators/tests/factories.py
+++ b/indicators/tests/factories.py
@@ -94,9 +94,7 @@ class IndicatorFactory(DjangoModelFactory[Indicator]):
     @post_generation
     @staticmethod
     def plans(obj: Indicator, create, extracted, **kwargs) -> None:
-        if not create:
-            return
-        if extracted:
+        if create and extracted:
             for plan in extracted:
                 obj.plans.add(plan)
 

--- a/indicators/tests/test_api.py
+++ b/indicators/tests/test_api.py
@@ -314,3 +314,25 @@ def test_get_indicator_with_contact_persons(api_client, plan_admin_user, indicat
     response = api_client.get(indicator_detail_url)
     assert response.status_code == 200
     assert response.data['contact_persons'] == [{'person': contact.person.id}]
+
+
+def test_bulk_update_indicator_without_permissions(api_client, plan, indicator_list_url):
+    indicator1 = IndicatorFactory.create(plans=[plan], organization=plan.organization)
+    indicator2 = IndicatorFactory.create(plans=[plan], organization=plan.organization)
+    contact = IndicatorContactFactory.create(indicator=indicator1)
+
+    # User in contact will try to modify indicator2, which they do not have permissions for
+    api_client.force_login(contact.person.user)
+    data = [{
+        'id': indicator2.id,
+        'name': f'updated {indicator2.name}',
+        'unit': indicator2.unit.pk,
+        'organization': indicator2.organization.id,
+    }]
+
+    response = api_client.put(indicator_list_url, data)
+    assert response.status_code == 403
+
+    old_name = indicator2.name
+    indicator2.refresh_from_db()
+    assert indicator2.name == old_name

--- a/indicators/tests/test_api.py
+++ b/indicators/tests/test_api.py
@@ -8,6 +8,7 @@ import pytest
 
 from actions.tests.factories import CategoryFactory, CategoryTypeFactory
 from indicators.tests.factories import CommonIndicatorNormalizatorFactory, IndicatorContactFactory, IndicatorFactory
+from people.tests.factories import PersonFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -204,8 +205,8 @@ def test_add_value_updates_due_date(client, plan, plan_admin_user):
 
 
 def test_update_contact_persons(api_client, plan, plan_admin_user, indicator, indicator_detail_url):
-    contact1 = IndicatorContactFactory()
-    contact2 = IndicatorContactFactory()
+    person1 = PersonFactory.create()
+    person2 = PersonFactory.create()
 
     api_client.force_login(plan_admin_user)
     data = {
@@ -213,8 +214,8 @@ def test_update_contact_persons(api_client, plan, plan_admin_user, indicator, in
         "unit": indicator.unit.id,
         "organization": indicator.organization.id,
         "contact_persons": [
-            {"person": contact1.person.id},
-            {"person": contact2.person.id},
+            {"person": person1.id},
+            {"person": person2.id},
         ],
     }
 
@@ -223,7 +224,7 @@ def test_update_contact_persons(api_client, plan, plan_admin_user, indicator, in
 
     indicator.refresh_from_db()
     assert indicator.contact_persons.count() == 2
-    assert set(indicator.contact_persons.values_list('person_id', flat=True)) == {contact1.person.id, contact2.person.id}
+    assert set(indicator.contact_persons.values_list('person_id', flat=True)) == {person1.id, person2.id}
 
 
 def test_update_categories(api_client, plan, plan_admin_user, indicator, indicator_detail_url):

--- a/users/models.py
+++ b/users/models.py
@@ -506,6 +506,9 @@ class User(AbstractUser):
             return True
         return self.is_general_admin_for_plan(plan)
 
+    def can_delete_indicator(self, plan):
+        return self.can_create_indicator(plan)
+
     def can_modify_indicator(self, indicator=None):
         if self.is_superuser:
             return True


### PR DESCRIPTION
## Description
This fixes some permission issues with the bulk REST API (but also some in the non-bulk API). It also refactors some code to reduce duplication and adds more tests.

## Requirements, dependencies and related PRs
Takes the related PR in [kausal-backend-common](https://github.com/kausaltech/kausal-backend-common/pull/76) that fixes permission issues into use.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates and fixes REST permissions, especially for bulk endpoints.
> 
> - Introduces `WatchObjectPermissions` and refactors `Action`, `Category`, `Organization`, `Person`, `ActionTask`, `Indicator` permissions to use a single pattern; keeps `AnonReadOnly` for list actions
> - Adds `get_plan_from_view` to centralize plan resolution in permission checks
> - Corrects bulk PUT/PATCH authorization for actions and indicators; adds tests for allowed/denied bulk updates (contacts vs. other objects)
> - Updates indicator permissions (`IndicatorPermission`, `IndicatorEditValuesPermission`) and adds `User.can_delete_indicator`
> - Test/fixture tweaks: ensure `IndicatorFactory` is linked to a plan by default, parametrize GraphQL indicator test, and simplify contact person updates using `PersonFactory`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b25a576a9fd1f61ce9505fdf749a13058ab51a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->