### PR TITLE
Fix clean_organization for IndicatorForm: organization for indicator changeable if primary_language matches

### DIFF
--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -314,7 +314,7 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
         # Disallow changing organization to one with different language for now because which language variants of
         # translatable form fields are present depends on the organization's language.
         organization = self.cleaned_data['organization']
-        if self.instance.pk is not None and self.instance.organization != organization:
+        if self.instance.pk is not None and self.instance.organization.primary_language != organization.primary_language:
             raise ValidationError(
                 _("Changing the organization to one with a different primary language is currently not supported"),
             )


### PR DESCRIPTION
## Description
Fix clean_organization for IndicatorForm: check if organizations primary language matches.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212714793714110

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
