### PR TITLE
Allow plan admins to edit plan features

### DIFF
--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -19,6 +19,7 @@ from wagtail.admin.messages import validation_error
 from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,
+    MultiFieldPanel,
     ObjectList,
     TabbedInterface,
 )
@@ -52,7 +53,10 @@ from admin_site.chooser import ClientChooser
 from admin_site.menu import PlanSpecificSingletonModelMenuItem
 from admin_site.mixins import SuccessUrlEditPageMixin
 from admin_site.models import Client, ClientPlan
-from admin_site.permissions import PlanSpecificSingletonModelSuperuserPermissionPolicy
+from admin_site.permissions import (
+    PlanSpecificSingletonModelPermissionPolicy,
+    PlanSpecificSingletonModelSuperuserPermissionPolicy,
+)
 from admin_site.viewsets import (
     BaseChangeLogMessageCreateView,
     BaseChangeLogMessageDeleteView,
@@ -451,14 +455,19 @@ class PlanFeaturesViewSet(WatchViewSet[PlanFeatures]):
     menu_label = _('Plan features')
     menu_order = 501
 
-    panels = [
+    plan_admin_panels = [
         FieldPanel('enable_search'),
         FieldPanel('enable_indicator_comparison'),
         FieldPanel('indicator_ordering'),
-        # Arbitrary string as the 'permission' parameter, here 'superuser', can
-        # be used as a way to restrict a panel only to superusers. This is the
-        # recommended approach given in Wagtail docs as of writing:
-        # https://docs.wagtail.org/en/v6.1.3/reference/pages/panels.html#wagtail.admin.panels.FieldPanel.permission
+        FieldPanel('indicators_open_in_modal'),
+        FieldPanel('enable_change_log'),
+    ]
+
+    # Arbitrary string as the 'permission' parameter, here 'superuser', can
+    # be used as a way to restrict a panel only to superusers. This is the
+    # recommended approach given in Wagtail docs as of writing:
+    # https://docs.wagtail.org/en/v6.1.3/reference/pages/panels.html#wagtail.admin.panels.FieldPanel.permission
+    superuser_only_panels = [
         FieldPanel('allow_images_for_actions', permission='superuser'),
         FieldPanel('show_admin_link', permission='superuser'),
         FieldPanel('allow_public_site_login', permission='superuser'),
@@ -478,9 +487,13 @@ class PlanFeaturesViewSet(WatchViewSet[PlanFeatures]):
         FieldPanel('display_field_visibility_restrictions', permission='superuser'),
         FieldPanel('output_report_action_print_layout', permission='superuser'),
         FieldPanel('password_protected', permission='superuser'),
-        FieldPanel('indicators_open_in_modal', permission='superuser'),
-        FieldPanel('enable_change_log', permission='superuser'),
     ]
+
+    # Define all panels explicitly to prevent Wagtail from auto-generating form fields
+    # for all model attributes. This list is overridden by ActivePlanFeaturesEditView.get_panel()
+    # which dynamically constructs panels based on user permissions using the plan_admin_panels
+    # and superuser_only_panels defined above.
+    panels = plan_admin_panels + superuser_only_panels
 
     def get_queryset(self, request):
         qs = self.model.objects.get_queryset()
@@ -504,6 +517,28 @@ class ActivePlanFeaturesEditView(SuccessUrlEditPageMixin, WatchEditView[PlanFeat
     def user_has_permission(self, permission):
         return self.permission_policy.user_has_permission_for_instance(self.request.user, permission, self.object)
 
+    def get_panel(self):
+        user = user_or_bust(self.request.user)
+
+        if user.is_superuser:
+            # Show grouped panels for superusers
+            panels: list = [
+                MultiFieldPanel(
+                    PlanFeaturesViewSet.plan_admin_panels,
+                    heading=_('Plan features that plan admins are allowed to change'),
+                ),
+                MultiFieldPanel(
+                    PlanFeaturesViewSet.superuser_only_panels,
+                    heading=_('Plan features that only superusers are allowed to change'),
+                    permission='superuser',
+                ),
+            ]
+        else:
+            # Show only plan admin fields without grouping for non-superusers
+            panels = PlanFeaturesViewSet.plan_admin_panels
+
+        return ObjectList(panels).bind_to_model(self.model)
+
 
 class ActivePlanFeaturesViewSet(PlanFeaturesViewSet):
     edit_view_class = ActivePlanFeaturesEditView
@@ -514,12 +549,7 @@ class ActivePlanFeaturesViewSet(PlanFeaturesViewSet):
 
     @property
     def permission_policy(self):
-        # TODO: Commit history looks like this viewset was meant to be open for
-        # plan admins, but due to a bug was really open only for superusers.
-        # Restrict access to superusers to keep the functionality same for now.
-        # Check in the future if this viewset should be opened up for plan
-        # admins.
-        return PlanSpecificSingletonModelSuperuserPermissionPolicy(self.model)
+        return PlanSpecificSingletonModelPermissionPolicy(self.model)
 
 
 register_snippet(ActivePlanFeaturesViewSet)

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -1150,6 +1150,7 @@ class ActivePlanAdmin(PlanAdmin):
     menu_label = _('Plan')
     menu_icon = 'kausal-plan'
     add_to_settings_menu = True
+    menu_order = 500
 
     def get_menu_item(self, order=None):
         item = ActivePlanMenuItem(self, order or self.get_menu_order())

--- a/admin_site/permissions.py
+++ b/admin_site/permissions.py
@@ -1,7 +1,9 @@
 from contextlib import contextmanager
-from typing import Optional
 
 from django.conf import settings
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.models import AnonymousUser
+from django.db.models import Model
 from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.permission_policies.collections import (
     CollectionOwnershipPermissionPolicy,
@@ -37,11 +39,41 @@ class PlanRelatedCollectionOwnershipPermissionPolicy(CollectionOwnershipPermissi
 
 
 class PlanSpecificSingletonModelSuperuserPermissionPolicy(ModelPermissionPolicy):
-    """Allow access to edit a plan specific singleton model only if user is superuser."""
+    """Allow access to edit a plan-specific singleton model only if user is superuser."""
 
-    def user_has_permission(self, user, action):
-        if action == 'change' and user.is_superuser:
+    def user_has_permission(self, user: AbstractBaseUser | AnonymousUser, action: str) -> bool:
+        if action == 'change' and getattr(user, 'is_superuser', False):
             return True
+        return False
+
+
+class PlanSpecificSingletonModelPermissionPolicy(ModelPermissionPolicy):
+    """Allow access to edit a plan-specific singleton model for plan admins and superusers."""
+
+    def user_has_permission(self, user: AbstractBaseUser | AnonymousUser, action: str) -> bool:
+        if not isinstance(user, User):
+            return False
+        if action == 'change':
+            if user.is_superuser:
+                return True
+            # Allow plan admins to edit
+            plan = user.get_active_admin_plan(required=False)
+            if plan is not None and user.is_general_admin_for_plan(plan):
+                return True
+        return False
+
+    def user_has_permission_for_instance(
+        self, user: AbstractBaseUser | AnonymousUser, action: str, instance: Model
+    ) -> bool:
+        if not isinstance(user, User):
+            return False
+        if action == 'change':
+            if user.is_superuser:
+                return True
+            # Check if user is a plan admin for the instance's plan
+            plan = getattr(instance, 'plan', None)
+            if plan is not None and user.is_general_admin_for_plan(plan):
+                return True
         return False
 
 


### PR DESCRIPTION
## Description

Allow plan admins to edit plan features

Previously only superusers could edit plan features. This change allows plan admins to edit a subset of plan settings while keeping some advanced features restricted to superusers only.

Changes:
- Split PlanFeatures panels into plan_admin_panels and superuser_only_panels
- Add PlanSpecificSingletonModelPermissionPolicy to check plan admin status
- Update ActivePlanFeaturesViewSet to use new permission policy
- Dynamically construct edit form based on user permissions
- Group panels for superusers to distinguish available access levels

Plan admins can now edit:
- Search settings
- Indicator comparison
- Indicator ordering
- Indicators open in modal
- Enable change log

While not part of the Asana task mentioned below, the first three settings were in fact already meant for display for plan admins according to the existing code, even though this was so far not followed through completely.

Superuser-only settings remain unchanged (e.g., public site login, admin accessibility, experimental features).

In today's back-end meeting we decided to group the panels that can be edited by plan admins and those that cannot in different section. This grouping is only shown for superusers. Plan admins only see the panels they can set without any grouping.

Also fixes ordering of settings menu items.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212836499180393?focus=true)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
