### PR TITLE
Fix release impersonation button visibility in sidebar

### DIFF
--- a/admin_site/static/css/admin-styles.css
+++ b/admin_site/static/css/admin-styles.css
@@ -471,3 +471,25 @@ with Wagtail's styles but so far these are required.
 .select2-container--default .select2-selection--multiple .select2-selection__clear:hover {
   color: var(--w-color-text-context);
 }
+
+/* Impersonation warning styles */
+/* Style the account menu button with warning background when impersonating */
+.sidebar-footer__account--impersonating {
+  background-color: #FAA500 !important; /* Wagtail warning-100 color */
+  color: #2E1F5E !important; /* Wagtail primary color for proper contrast */
+}
+
+.sidebar-footer__account--impersonating:hover,
+.sidebar-footer__account--impersonating:focus {
+  background-color: #FDD074 !important; /* Wagtail warning-75 color for hover state */
+}
+
+/* Ensure the account label text also uses the proper contrast color */
+.sidebar-footer__account--impersonating .sidebar-footer__account-label {
+  color: #2E1F5E !important;
+}
+
+/* Ensure the chevron icon also uses the proper contrast color */
+.sidebar-footer__account--impersonating .icon {
+  color: #2E1F5E !important;
+}

--- a/admin_site/templates/admin_site/release_impersonation.html
+++ b/admin_site/templates/admin_site/release_impersonation.html
@@ -1,14 +1,25 @@
 {% load i18n %}
 <script>
     $(document).ready(function() {
-        $('.sidebar').append(
-            `<div class="release-impersonation">
+        // Hide the logout button when impersonating. This makes space for the release impersonation button.
+        $('.sidebar-footer ul li').has('form[action*="logout"]').hide();
+
+        // Add the release impersonation button
+        $('.sidebar-footer ul').append(
+            `<li class="sidebar-menu-item">
                 <form method="POST" action="{% url 'hijack:release' %}">
                     {% csrf_token %}
-                    <button type="submit" class="button bicolor icon icon-warning">{% trans 'Back to own user' %}</button>
+                    <button type="submit" class="sidebar-menu-item__link ">
+                        <svg class="icon icon-logout icon--menuitem" aria-hidden="true">
+                            <use href="#icon-logout"></use>
+                        </svg>
+                        <span class="menuitem">
+                            <span class="menuitem-label">{% trans 'Back to own user' %}</span>
+                        </span>
+                    </button>
                     <input type="hidden" name="next" value="{{ request.path }}">
                 </form>
-            </div>`
+            </li>`
         );
     });
 </script>

--- a/admin_site/templates/admin_site/release_impersonation.html
+++ b/admin_site/templates/admin_site/release_impersonation.html
@@ -1,7 +1,41 @@
 {% load i18n %}
+<style>
+    /* Informational text item styling */
+    .sidebar-footer ul li.sidebar-menu-item--info {
+        padding: 0.625rem 1rem !important;
+        color: var(--w-color-text-label-menus-default) !important;
+        font-size: 0.875rem !important;
+        font-weight: 500 !important;
+        line-height: 1.5 !important;
+        white-space: normal !important;
+        word-wrap: break-word !important;
+        overflow-wrap: break-word !important;
+        background-color: rgba(250, 165, 0, 0.15) !important;
+        border-bottom: 1px solid rgba(250, 165, 0, 0.3) !important;
+        pointer-events: none !important;
+        user-select: none !important;
+    }
+
+    /* Make the account menu scrollable when expanded */
+    .sidebar-footer button[aria-expanded="true"] ~ ul {
+        max-height: 300px !important;
+        overflow-y: auto !important;
+        overflow-x: hidden !important;
+    }
+</style>
 <script>
     $(document).ready(function() {
-        // Hide the logout button when impersonating. This makes space for the release impersonation button.
+        // Style the account menu button with warning background
+        $('.sidebar-footer__account').addClass('sidebar-footer__account--impersonating');
+
+        // Add informational text at the top of the account menu
+        $('.sidebar-footer ul').prepend(
+            `<li class="sidebar-menu-item sidebar-menu-item--info">
+                {% trans "Viewing site as another user" %}
+            </li>`
+        );
+
+        // Hide the logout button when impersonating
         $('.sidebar-footer ul li').has('form[action*="logout"]').hide();
 
         // Add the release impersonation button
@@ -9,7 +43,7 @@
             `<li class="sidebar-menu-item">
                 <form method="POST" action="{% url 'hijack:release' %}">
                     {% csrf_token %}
-                    <button type="submit" class="sidebar-menu-item__link ">
+                    <button type="submit" class="sidebar-menu-item__link" title="{% trans 'Back to own user' %}">
                         <svg class="icon icon-logout icon--menuitem" aria-hidden="true">
                             <use href="#icon-logout"></use>
                         </svg>


### PR DESCRIPTION
The "Back to own user" button was not visible because it was appended to the sidebar outside the visible area. Fixed by:
- Adding button as list item to sidebar-footer ul
- Hiding the logout button when impersonating
- Styling button to match the logout button appearance
- Positioning button in the same location as logout button
- Showing text in the account menu informing user that they are impersonating
- Styling the menu item displaying the username to further indicate this

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
