### PR TITLE
Fix ShapeError crash when report type has duplicate fields

### DIFF
--- a/reports/models.py
+++ b/reports/models.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, ClassVar, cast
 
 import reversion
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Q
 from django.utils import timezone
@@ -25,6 +26,7 @@ from actions.models.action import Action
 from kausal_common.blocks.registry import FieldBlockContext
 from pages.models import ActionListPage
 from reports.blocks.action_content import ReportFieldBlock
+from reports.utils import get_field_unique_key
 
 # The following model is for very specialized use and is only imported here so that Django finds it
 from actions.blocks.base import ActionReportContentField
@@ -138,6 +140,30 @@ class ReportType(PlanRelatedModelWithRevision):
 
     def __str__(self):
         return f'{self.name} ({self.plan.identifier})'
+
+    def clean(self):
+        super().clean()
+
+        if not self.fields:
+            return
+
+        seen_keys: set[str] = set()
+        duplicates: list[str] = []
+        for field in self.fields:
+            if field is None or field.value is None:
+                continue
+            field_key = get_field_unique_key(field)
+            if field_key in seen_keys:
+                duplicates.append(field_key)
+            seen_keys.add(field_key)
+
+        if duplicates:
+            raise ValidationError({
+                'fields': _(
+                    "Duplicate fields detected: %(duplicates)s. "
+                    "Each field type (attribute type, category type) can only be added once."
+                ) % {'duplicates': ', '.join(duplicates)}
+            })
 
 
 @reversion.register()

--- a/reports/spreadsheets/excel_report.py
+++ b/reports/spreadsheets/excel_report.py
@@ -17,7 +17,7 @@ from loguru import logger
 
 from actions.models.action import Action, ActionImplementationPhase, ActionStatus
 from orgs.models import Organization
-from reports.utils import ReportCellValue, group_by_model
+from reports.utils import ReportCellValue, get_field_unique_key, group_by_model
 
 from .action_print_layout import write_action_summaries
 from .cursor_writer import Cell, CursorWriter
@@ -301,11 +301,21 @@ class ExcelReport:
         }
 
         fields = []
+        seen_field_keys: set[str] = set()
         for field in self.report.type.fields:
             if field is not None and field.value is not None and 'attribute_type' in field.value and \
                     field.value['attribute_type'] is None:
                 logger.error(f"Field has NoneType attribute_type in report type {self.report.type.name}.")
                 continue
+            # Generate a unique key for this field to detect duplicates
+            field_key = get_field_unique_key(field)
+            if field_key in seen_field_keys:
+                logger.warning(
+                    f"Duplicate field '{field_key}' detected in report type '{self.report.type.name}'. "
+                    "Skipping duplicate to prevent DataFrame column length mismatch."
+                )
+                continue
+            seen_field_keys.add(field_key)
             fields.append(field)
         for action in all_actions:
             action_identifier = action.data['identifier']
@@ -328,7 +338,7 @@ class ExcelReport:
                     self, field.value, action.data, related_objects, attribute_versions,
                 )
                 field_name = field.block.name
-                if field_name == 'attribute_type':
+                if field_name == 'attribute':
                     field_name = f'{field_name}.{field.value.get("attribute_type").identifier}'
                 assert len(labels) == len(values)
                 self.formats.set_for_field(field, labels)

--- a/reports/tests/test_excel_roundtrip.py
+++ b/reports/tests/test_excel_roundtrip.py
@@ -100,3 +100,112 @@ def test_excel_export_action_filter(
     included_actions = [actions_having_attributes[0], actions_having_attributes[1]]
     excel = excel_file_from_report_factory(action_ids=[a.id for a in included_actions])
     assert_report_dimensions(excel, report_with_all_attributes, included_actions)
+
+
+def test_excel_export_with_duplicate_attribute_fields(
+        plan,
+        action_attribute_type__text,
+        report_type_factory,
+        report_factory,
+        actions_having_attributes,
+):
+    """
+    Test that duplicate attribute fields don't cause a ShapeError crash.
+
+    Regression test for WATCH-BACKEND-3DJ: When a report type has the same
+    attribute type configured twice, the Excel export would fail with:
+    ShapeError: could not create a new DataFrame: height of column X does not match height of column Y
+
+    The fix skips duplicate fields during DataFrame construction.
+    """
+    # Create a report type with the SAME attribute type added twice
+    report_type = report_type_factory(
+        plan=plan,
+        fields__0='implementation_phase',
+        fields__1__attribute__attribute_type=action_attribute_type__text,
+        fields__2__attribute__attribute_type=action_attribute_type__text,  # Duplicate!
+    )
+
+    report = report_factory(type=report_type)
+    report.fields = report_type.fields
+    report.save()
+
+    # This should NOT crash - duplicates should be skipped with a warning
+    exporter = report.get_xlsx_exporter()
+    excel_output = exporter.generate_xlsx()
+
+    # Verify we got valid Excel output
+    assert excel_output is not None
+    assert len(excel_output) > 0
+
+    # Verify the DataFrame was created successfully by reading it back
+    df = polars.read_excel(BytesIO(excel_output), sheet_name=pgettext('Action model', 'Actions'), engine='openpyxl')
+    assert df.height == len(actions_having_attributes)
+
+    # The duplicate field should have been skipped, so we should have fewer columns
+    # than if both fields were included
+    # Expected: Identifier + Action + implementation_phase + 1 attribute (duplicate skipped)
+    assert df.width == 4  # identifier, action name, impl phase, 1 attribute
+
+
+def test_excel_export_with_duplicate_category_fields(
+        plan,
+        category_type,
+        report_type_factory,
+        report_factory,
+        actions_having_attributes,
+):
+    """
+    Test that duplicate category fields don't cause a ShapeError crash.
+
+    Similar to test_excel_export_with_duplicate_attribute_fields but for category fields.
+    """
+    # Create a report type with the SAME category type added twice
+    report_type = report_type_factory(
+        plan=plan,
+        fields__0='implementation_phase',
+        fields__1__categories__category_type=category_type,
+        fields__2__categories__category_type=category_type,  # Duplicate!
+    )
+
+    report = report_factory(type=report_type)
+    report.fields = report_type.fields
+    report.save()
+
+    # This should NOT crash
+    exporter = report.get_xlsx_exporter()
+    excel_output = exporter.generate_xlsx()
+
+    assert excel_output is not None
+    df = polars.read_excel(BytesIO(excel_output), sheet_name=pgettext('Action model', 'Actions'), engine='openpyxl')
+    assert df.height == len(actions_having_attributes)
+
+    # Expected: Identifier + Action + implementation_phase + 1 category (duplicate skipped)
+    assert df.width == 4
+
+
+def test_report_type_validation_rejects_duplicate_fields(
+        plan,
+        action_attribute_type__text,
+        report_type_factory,
+):
+    """
+    Test that ReportType.clean() raises ValidationError for duplicate fields.
+
+    This ensures that users cannot accidentally configure duplicate fields
+    in the admin interface.
+    """
+    from django.core.exceptions import ValidationError
+
+    report_type = report_type_factory(
+        plan=plan,
+        fields__0='implementation_phase',
+        fields__1__attribute__attribute_type=action_attribute_type__text,
+        fields__2__attribute__attribute_type=action_attribute_type__text,  # Duplicate!
+    )
+
+    with pytest.raises(ValidationError) as exc_info:
+        report_type.clean()
+
+    assert 'fields' in exc_info.value.message_dict
+    assert 'Duplicate fields detected' in str(exc_info.value.message_dict['fields'])

--- a/reports/utils.py
+++ b/reports/utils.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import typing
 from datetime import date, datetime
+from typing import Any
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Literal
+    from typing import Literal
 
     from django.db.models import Model
 
@@ -55,6 +56,29 @@ def group_by_model(serialized_versions: list[SerializedVersion]) -> dict[str, li
 
 
 type ReportCellValue = str | datetime | date | float | None
+
+
+def get_field_unique_key(field: Any) -> str:
+    """
+    Generate a unique key for a report field to detect duplicates.
+
+    Different field types need different strategies:
+    - attribute fields: use the attribute type's identifier
+    - categories fields: use the category type's id
+    - other fields: use the block name (they're typically singletons)
+    """
+    block_name = field.block.name
+    # Attribute fields use block name 'attribute' and have an attribute_type in their value
+    if block_name == 'attribute' and field.value.get('attribute_type'):
+        return f'{block_name}.{field.value["attribute_type"].identifier}'
+    if block_name == 'categories' and field.value.get('category_type'):
+        category_type = field.value['category_type']
+        level = field.value.get('category_level')
+        key = f'{block_name}.{category_type.id}'
+        if level:
+            key = f'{key}.level_{level.id}'
+        return key
+    return block_name
 
 # These are magic numbers referring to the Excel built-in, non-custom,
 # and locale-independent formats for date with or without time. It is used to make


### PR DESCRIPTION
When a report type had the same attribute type or category type configured twice in its fields StreamField, the Excel export would crash with a Polars ShapeError because columns had mismatched lengths

Changes:
- Add defensive handling in create_populated_actions_dataframe() to detect and skip duplicate fields with a warning log
- Add validation in ReportType.clean() to prevent duplicate fields from being saved in the admin
- Existing bug fix: 'attribute_type' -> 'attribute'
- Add regression tests for duplicate attribute and category fields

Fixes WATCH-BACKEND-3DJ

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://kausaltech.slack.com/archives/C01CB95BT0C/p1768975260391599?thread_ts=1768902071.216909&cid=C01CB95BT0C

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
The original report that caused this didnt exist anymore, so couldn't recreate exactly.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
