### PR TITLE
Fix indicator deadline bump logic to handle multiple year gaps

### DIFF
--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -450,11 +450,17 @@ class Indicator(
             self.latest_value = latest_value
             update_fields.append('latest_value')
 
-        if self.updated_values_due_at is not None:
-            # If latest_value is newer than updated_values_due_at - 1 year, add 1 year to updated_values_due_at
+        if self.updated_values_due_at is not None and latest_value is not None:
+            # If latest_value is within (or past) the reporting period, bump updated_values_due_at forward.
+            # The reporting period is the year preceding the deadline.
+            # We loop in case the deadline was set far in the past and needs multiple bumps.
+            bumped = False
             reporting_period_start = self.updated_values_due_at - relativedelta(years=1)
-            if latest_value is not None and latest_value.date >= reporting_period_start:
+            while latest_value.date >= reporting_period_start:
                 self.updated_values_due_at += relativedelta(years=1)
+                reporting_period_start = self.updated_values_due_at - relativedelta(years=1)
+                bumped = True
+            if bumped:
                 update_fields.append('updated_values_due_at')
 
         if self.common is not None:

--- a/indicators/tests/test_models.py
+++ b/indicators/tests/test_models.py
@@ -51,3 +51,42 @@ def test_indicator_plans_with_access_dont_include_other_plans(plan):
 def test_indicator_plans_with_access_includes_indicator_plan(plan, indicator):
     indicator.plans.add(plan)
     assert plan in indicator.get_plans_with_access()
+
+
+def test_indicator_handle_values_update_bumps_deadline_multiple_times():
+    """
+    Test that handle_values_update() bumps updated_values_due_at multiple times if needed.
+
+    This covers the edge case where an indicator has an old deadline that's far behind the
+    latest value date. A single 1-year bump isn't sufficient to pass the validation in clean().
+
+    Fixes WATCH-BACKEND-3E4.
+    """
+    # Create indicator with a deadline that's way in the past
+    indicator = IndicatorFactory.create(updated_values_due_at=date(2023, 6, 1))
+
+    # Add a value for a much later date
+    value = IndicatorValueFactory(indicator=indicator, date=date(2025, 12, 31))
+
+    # Before handle_values_update, the deadline is way too early
+    # (2023-06-01 is more than 1 year before 2025-12-31)
+    assert indicator.updated_values_due_at == date(2023, 6, 1)
+
+    # Call handle_values_update - this should bump the deadline enough times
+    # so that it's more than 1 year after the latest value
+    indicator.handle_values_update()
+
+    # Verify latest_value was updated
+    assert indicator.latest_value == value
+
+    # The deadline should have been bumped to be > latest_value.date + 1 year
+    # 2025-12-31 + 1 year = 2026-12-31, so deadline should be > 2026-12-31
+    # Starting from 2023-06-01:
+    # +1 year = 2024-06-01 (still <= 2026-12-31)
+    # +1 year = 2025-06-01 (still <= 2026-12-31)
+    # +1 year = 2026-06-01 (still <= 2026-12-31)
+    # +1 year = 2027-06-01 (> 2026-12-31) ✓
+    assert indicator.updated_values_due_at == date(2027, 6, 1)
+
+    # Verify that full_clean passes (no ValidationError)
+    indicator.full_clean()


### PR DESCRIPTION
The handle_values_update() method only bumped updated_values_due_at by one year, but if the deadline was far behind the latest value date, a single bump wasn't enough to pass the validation in clean().

Now loops until the deadline is past the reporting period.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
WATCH-BACKEND-3E4
https://sentry.kausal.tech/organizations/kausal/issues/13381/?project=3

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
