### PR TITLE
Fix: organization plan admins cannot list persons via REST API

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1490,6 +1490,7 @@ class PersonViewSet(ModelWithImageViewMixin, BulkModelViewSet[Person]):
             and (
                 user.is_general_admin_for_plan(plan)
                 or user.is_contact_person_in_plan(plan)
+                or user.is_organization_admin_in_plan(plan)
             )
         )
 

--- a/actions/tests/test_api.py
+++ b/actions/tests/test_api.py
@@ -7,8 +7,9 @@ from django.urls import reverse
 import pytest
 
 from actions.api import ActionSerializer
-from actions.tests.factories import ActionContactFactory, ActionFactory
-from orgs.tests.factories import OrganizationFactory
+from actions.tests.factories import ActionContactFactory, ActionFactory, PlanFactory
+from orgs.tests.factories import OrganizationFactory, OrganizationPlanAdminFactory
+from people.tests.factories import PersonFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -80,29 +81,45 @@ def test_person_api_get_for_plan_unauthenticated(api_client, person_list_url, pl
     assert 'detail' in keys
 
 
+@pytest.mark.parametrize('admin_type', ['plan_admin', 'organization_plan_admin'])
 def test_person_api_get_authenticated_and_authorized_for_single_plan(
-        client, person_list_url, api_client,
-        plan_factory, person_factory, action_contact_factory):
+    client, person_list_url, api_client, admin_type
+):
+    plan_of_admin_person = PlanFactory.create()
 
-    plan_of_admin_person = plan_factory()
-    admin_person = person_factory(general_admin_plans=[plan_of_admin_person])
+    match admin_type:
+        case 'plan_admin':
+            admin_person = PersonFactory.create(
+                organization=plan_of_admin_person.organization,
+                general_admin_plans=[plan_of_admin_person],
+            )
+        case 'organization_plan_admin':
+            admin_person = PersonFactory.create(organization=plan_of_admin_person.organization)
+            OrganizationPlanAdminFactory.create(
+                person=admin_person,
+                organization=plan_of_admin_person.organization,
+                plan=plan_of_admin_person
+            )
+        case _:
+            pytest.fail('Unexpected admin_type')
 
-    plan_not_accessible_by_admin_person = plan_factory()
+    plan_not_accessible_by_admin_person = PlanFactory.create()
 
-    persons_found = [action_contact_factory(action__plan=plan_of_admin_person).person for _ in range(PERSON_COUNT)]
-    person_not_found = action_contact_factory(action__plan=plan_not_accessible_by_admin_person).person
+    persons_found = [ActionContactFactory.create(action__plan=plan_of_admin_person).person for _ in range(PERSON_COUNT)]
+    person_not_found = ActionContactFactory.create(action__plan=plan_not_accessible_by_admin_person).person
 
     api_client.force_login(admin_person.user)
 
     response = api_client.get(person_list_url, {'plan': plan_of_admin_person.identifier})
     data = response.json_data
+    assert response.status_code == 200
 
-    assert len(data['results']) == PERSON_COUNT
-    for person_found in persons_found:
+    assert len(data['results']) == PERSON_COUNT + 1  # +1 for the admin themselves
+    for person_found in (*persons_found, admin_person):
         result_person_data = next(x for x in data['results'] if x['id'] == person_found.id)
         assert result_person_data['first_name'] == person_found.first_name
         assert result_person_data['last_name'] == person_found.last_name
-        assert result_person_data['last_name'] == person_found.last_name
+        assert result_person_data['email'] == person_found.email
 
     assert person_not_found.id not in (d['id'] for d in data['results'])
 

--- a/users/models.py
+++ b/users/models.py
@@ -277,6 +277,14 @@ class User(AbstractUser):
             return bool(plans)
         return plan.pk in plans
 
+    def is_organization_admin_in_plan(self, plan: Plan | None = None) -> bool:
+        if self.is_superuser:
+            return True
+        person = self.get_corresponding_person()
+        if not person:
+            return False
+        return person.organization_plan_admins.filter(plan=plan).exists()
+
     def _get_editable_roles[Role: ModelWithRole.Role](
             self, action: Action, _class: type[ModelWithRole[Role]],
         ) -> Sequence[Role | None]:


### PR DESCRIPTION
## Description
This fixes a crash of the action table editor (and potentially others) that would occur when the user is not a contact person or (general) plan admin but an organization plan admin. The crash was a result of the person endpoint returning 403.

Also adds a unit test.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212870374465606?focus=true)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
