### PR TITLE
Fix budget button not showing for CategoryType-scoped datasets

### DIFF
--- a/aplans/cache.py
+++ b/aplans/cache.py
@@ -117,14 +117,19 @@ class PlanSpecificCache:
 
     @cached_property
     def category_type_dataset_schemas_by_id(self) -> dict[int, list[DatasetSchema]]:
+        ct_content_type = ContentType.objects.get_for_model(CategoryType)
+        plan_category_type_ids = set(self.plan.category_types.values_list('id', flat=True))
         qs = (
             DatasetSchema.objects.get_queryset()
             .for_model(CategoryType)
-            .filter(scopes__scope_id__in=self.plan.category_types.values_list('id', flat=True))
+            .filter(scopes__scope_id__in=plan_category_type_ids)
+            .prefetch_related('scopes')
         )
         by_id: dict[int, list[DatasetSchema]] = {}
         for ds in qs:
-            by_id.setdefault(ds.pk, []).append(ds)
+            for scope in ds.scopes.all():
+                if scope.scope_content_type_id == ct_content_type.pk and scope.scope_id in plan_category_type_ids:
+                    by_id.setdefault(scope.scope_id, []).append(ds)
         return by_id
 
     def get_dataset_schemas_for_object(self, instance: DatasetScopeType) -> list[DatasetSchema]:

--- a/datasets/tests/test_cache.py
+++ b/datasets/tests/test_cache.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from aplans.cache import PlanSpecificCache
+
+from actions.tests.factories import CategoryFactory, CategoryTypeFactory
+from datasets.tests.factories import DatasetSchemaFactory, DatasetSchemaScopeFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestCategoryTypeDatasetSchemaLookup:
+    """Tests for looking up DatasetSchemas scoped to CategoryTypes via PlanSpecificCache."""
+
+    def test_get_dataset_schemas_for_category_with_category_type_scope(self, plan):
+        """Test that schemas scoped to a CategoryType are returned for categories of that type."""
+        # Create a CategoryType linked to the plan
+        category_type = CategoryTypeFactory.create(plan=plan)
+        category = CategoryFactory.create(type=category_type)
+
+        # Create a schema scoped to the category's CategoryType
+        schema = DatasetSchemaFactory.create()
+        DatasetSchemaScopeFactory.create(schema=schema, scope=category_type)
+
+        cache = PlanSpecificCache(plan)
+        schemas = cache.get_dataset_schemas_for_object(category)
+
+        assert len(schemas) == 1
+        assert schemas[0] == schema
+
+    def test_get_dataset_schemas_for_category_returns_empty_for_other_category_type(self, plan):
+        """Test that schemas scoped to a different CategoryType are not returned."""
+        # Create two CategoryTypes in the same plan
+        category_type1 = CategoryTypeFactory.create(plan=plan)
+        category_type2 = CategoryTypeFactory.create(plan=plan)
+        category1 = CategoryFactory.create(type=category_type1)
+        category2 = CategoryFactory.create(type=category_type2)
+
+        # Create a schema scoped to category_type1 only
+        schema = DatasetSchemaFactory.create()
+        DatasetSchemaScopeFactory.create(schema=schema, scope=category_type1)
+
+        cache = PlanSpecificCache(plan)
+
+        # The schema should be found for category1
+        schemas_for_cat1 = cache.get_dataset_schemas_for_object(category1)
+        assert len(schemas_for_cat1) == 1
+        assert schemas_for_cat1[0] == schema
+
+        # But not for category2 (different CategoryType)
+        schemas_for_cat2 = cache.get_dataset_schemas_for_object(category2)
+        assert len(schemas_for_cat2) == 0
+
+    def test_get_dataset_schemas_for_category_multiple_schemas_same_type(self, plan):
+        """Test that multiple schemas scoped to the same CategoryType are all returned."""
+        category_type = CategoryTypeFactory.create(plan=plan)
+        category = CategoryFactory.create(type=category_type)
+
+        schema1 = DatasetSchemaFactory.create()
+        schema2 = DatasetSchemaFactory.create()
+        DatasetSchemaScopeFactory.create(schema=schema1, scope=category_type)
+        DatasetSchemaScopeFactory.create(schema=schema2, scope=category_type)
+
+        cache = PlanSpecificCache(plan)
+        schemas = cache.get_dataset_schemas_for_object(category)
+
+        assert len(schemas) == 2
+        assert set(schemas) == {schema1, schema2}


### PR DESCRIPTION
The category_type_dataset_schemas_by_id cache was incorrectly keyed by DatasetSchema pk instead of CategoryType id. This caused lookups by category.type_id to always return empty, hiding the "Add budget" button for categories even when a DatasetSchemaScope existed for their type.

## Description
Brief description of the changes made in this PR.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
