### PR TITLE
Implement simple hostname based redirects in middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,35 @@ Each Django app follows consistent naming conventions for different functionalit
   ```
 - Always include `from __future__ import annotations` at the top of files.
 
+### Code Structure Conventions
+- **Avoid deeply nested logic** - Prefer flat, readable code over nested conditionals
+- **Use early returns** - Check for exceptional/edge cases first and return early
+- **Reverse conditionals** - Instead of `if condition: main_logic`, use `if not condition: return` then `main_logic`
+
+**Example - Avoid nesting:**
+```python
+# Bad: nested logic
+def process_request(request):
+    if request.user.is_authenticated:
+        if request.user.is_active:
+            if has_permission(request.user):
+                # main logic here
+                return do_something()
+    return None
+
+# Good: early returns
+def process_request(request):
+    if not request.user.is_authenticated:
+        return None
+    if not request.user.is_active:
+        return None
+    if not has_permission(request.user):
+        return None
+
+    # main logic is not nested
+    return do_something()
+```
+
 ### Key Models Hierarchy
 - `actions/models/plan.py` - Plan, PlanDomain, PlanFeatures
 - `actions/models/action.py` - Action (main entity)

--- a/aplans/middleware.py
+++ b/aplans/middleware.py
@@ -2,19 +2,23 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Mapping
+from collections.abc import Coroutine, Mapping
+from typing import Any
 
 from django import http
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import MiddlewareNotUsed
 from django.db import connection, transaction
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.decorators import sync_and_async_middleware
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.translation import activate, gettext_lazy as _
 from wagtail.users.models import UserProfile
 
 import sentry_sdk
+from asgiref.sync import iscoroutinefunction
 from loguru import logger
 from social_core.exceptions import SocialAuthBaseException
 
@@ -154,3 +158,122 @@ class PrintQueryCountMiddleware:
 
         logger.log(level, f"⛁ {query_count} SQL queries took {sqltime} ms {request.path} {graphql_operation_name}")
         return response
+
+
+def _matches_hostname_pattern(hostname: str, pattern: str) -> bool:
+    """
+    Check if hostname matches pattern with strict wildcard rules.
+
+    Wildcards (*) match only valid subdomain parts (no periods).
+    Example: '*.example.com' matches 'test.example.com' but not 'foo.bar.example.com'.
+
+    Args:
+        hostname: The hostname to check (e.g., 'test.example.com')
+        pattern: The pattern with optional wildcards (e.g., '*.example.com')
+
+    Returns:
+        True if hostname matches the pattern, False otherwise.
+
+    """
+    hostname_parts = hostname.split('.')
+    pattern_parts = pattern.split('.')
+
+    # Must have same number of parts
+    if len(hostname_parts) != len(pattern_parts):
+        return False
+
+    for hostname_part, pattern_part in zip(hostname_parts, pattern_parts, strict=True):
+        if pattern_part == '*':
+            # Wildcard matches any valid subdomain part
+            # Valid: alphanumeric and hyphens, not starting/ending with hyphen
+            if not hostname_part:
+                return False
+            if not re.match(r'^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$', hostname_part):
+                return False
+        elif hostname_part != pattern_part:
+            # Exact match required
+            return False
+
+    return True
+
+
+def _check_hostname_redirect(request: http.HttpRequest, redirect_hostnames: list[tuple[str, str]]) -> http.HttpResponse | None:
+    """
+    Check if request should be redirected based on hostname patterns.
+
+    Returns:
+        HttpResponsePermanentRedirect if redirect needed, None otherwise.
+
+    """
+    # Get hostname directly from META to avoid ALLOWED_HOSTS validation
+    hostname = request.META.get('HTTP_HOST', '')
+    if not hostname:
+        return None
+
+    for from_pattern, to_hostname in redirect_hostnames:
+        if not _matches_hostname_pattern(hostname, from_pattern):
+            continue
+
+        redirect_url = f"{request.scheme}://{to_hostname}{request.get_full_path()}"
+
+        # Log to application logs
+        logger.info(f"Redirecting hostname '{hostname}' to '{to_hostname}' (pattern: '{from_pattern}')")
+
+        # Send to Sentry for monitoring
+        sentry_sdk.capture_message(
+            f"Hostname redirect: {hostname} -> {to_hostname}",
+            level='info',
+            extras={
+                'from_hostname': hostname,
+                'to_hostname': to_hostname,
+                'pattern': from_pattern,
+                'redirect_url': redirect_url,
+                'original_path': request.get_full_path(),
+            },
+        )
+        return http.HttpResponsePermanentRedirect(redirect_url)
+
+    return None
+
+
+@sync_and_async_middleware
+def hostname_redirect_middleware(get_response):
+    """
+    Redirect requests based on hostname wildcard patterns.
+
+    Checks incoming request hostname against patterns defined in settings.REDIRECT_HOSTNAMES
+    and performs HTTP 301 redirects when a match is found.
+
+    Wildcard rules:
+        - '*' matches any valid subdomain part (letters, numbers, hyphens)
+        - '*' does NOT match multiple levels (no periods in matched part)
+        - Example: '*.app.example.com' matches 'test.app.example.com'
+                   but NOT 'foo.bar.app.example.com'
+
+    Settings format:
+        REDIRECT_HOSTNAMES = (
+            ('*.app.example.com', 'app.example.com'),
+            ('old.example.com', 'new.example.com'),
+        )
+    """
+    redirect_hostnames = getattr(settings, 'REDIRECT_HOSTNAMES', ())
+    if not redirect_hostnames:
+        raise MiddlewareNotUsed('REDIRECT_HOSTNAMES not configured')
+    if iscoroutinefunction(get_response):
+        async def middleware(request: http.HttpRequest):  # pyright: ignore[reportRedeclaration]  # type: ignore[misc]  # noqa: ANN202
+            redirect_response = _check_hostname_redirect(request, redirect_hostnames)
+            if redirect_response:
+                return redirect_response
+            return await get_response(request)
+    else:
+        def middleware(request: http.HttpRequest):  # type: ignore[misc]  # noqa: ANN202
+            redirect_response = _check_hostname_redirect(request, redirect_hostnames)
+            if redirect_response:
+                return redirect_response
+            return get_response(request)
+
+    return middleware
+
+
+# Backward compatibility alias for existing tests and settings
+HostnameRedirectMiddleware = hostname_redirect_middleware

--- a/aplans/middleware.py
+++ b/aplans/middleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Mapping
+
 from django import http
 from django.conf import settings
 from django.contrib import messages

--- a/aplans/middleware.py
+++ b/aplans/middleware.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Mapping
-from typing import Any
-
 from django import http
 from django.conf import settings
 from django.contrib import messages

--- a/aplans/middleware.py
+++ b/aplans/middleware.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from collections.abc import Coroutine, Mapping
+from collections.abc import Mapping
 from typing import Any
 
 from django import http

--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -105,6 +105,7 @@ env = environ.FileAwareEnv(
     ENABLE_MCP_SERVER=(bool, False),
     GDAL_LIBRARY_PATH=(str, ''),
     GEOS_LIBRARY_PATH=(str, ''),
+    REDIRECT_HOSTNAMES=(list, []),
     **COMMON_ENV_SCHEMA,
 )
 
@@ -183,6 +184,21 @@ DEPLOY_TASK_GITOPS_REPO = env('DEPLOY_TASK_GITOPS_REPO')
 DEPLOY_YAML_FILE_PATH = env('DEPLOY_YAML_FILE_PATH')
 
 WATCH_BACKEND_REGION_URLS = env('WATCH_BACKEND_REGION_URLS')
+
+# Hostname redirect configuration for HostnameRedirectMiddleware
+# Performs HTTP 301 redirects based on incoming request hostname patterns.
+#
+# Environment variable format (comma-separated list):
+#   REDIRECT_HOSTNAMES=from_pattern:to_hostname,from_pattern:to_hostname,...
+#
+# read more in docs/middleware/redirects.md
+_redirect_hostnames_raw = env.list('REDIRECT_HOSTNAMES', default=[])  # pyright: ignore
+if _redirect_hostnames_raw is None or isinstance(_redirect_hostnames_raw, environ.NoValue):
+    REDIRECT_HOSTNAMES = None
+else:
+    REDIRECT_HOSTNAMES = tuple(
+        tuple(item.split(':', 1)) for item in _redirect_hostnames_raw if ':' in item  # pyright: ignore
+    )
 
 KAUSAL_PATHS_URL = env('KAUSAL_PATHS_URL')
 
@@ -274,6 +290,7 @@ INSTALLED_APPS += WATCH_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    f'{PROJECT_NAME}.middleware.HostnameRedirectMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/aplans/tests/test_middleware.py
+++ b/aplans/tests/test_middleware.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from django.core.exceptions import MiddlewareNotUsed
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+import pytest
+
+from aplans.middleware import HostnameRedirectMiddleware
+
+
+def get_response_success(request):
+    """Mock get_response that returns success."""
+    return HttpResponse("OK")
+
+
+@pytest.fixture
+def request_factory():
+    """Fixture providing a RequestFactory instance."""
+    return RequestFactory()
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))
+def test_wildcard_hostname_redirect(request_factory):
+    """Test wildcard pattern matching and redirect."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='test.watch.example.com')
+
+    response = middleware(request)
+
+    assert response.status_code == 301
+    assert response['Location'] == 'http://watch.example.com/'
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))
+def test_wildcard_does_not_match_multiple_levels(request_factory):
+    """Test that wildcard does not match multiple subdomain levels."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='foo.bar.watch.example.com')
+
+    response = middleware(request)
+
+    # Should NOT redirect - passes through
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))
+def test_path_preservation(request_factory):
+    """Test that redirect preserves the original path and query string."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/admin/?foo=bar', HTTP_HOST='test.watch.example.com')
+
+    response = middleware(request)
+
+    assert response.status_code == 301
+    assert response['Location'] == 'http://watch.example.com/admin/?foo=bar'
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))
+def test_https_scheme_preservation(request_factory):
+    """Test that HTTPS scheme is preserved in redirect."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='test.watch.example.com', secure=True)
+
+    response = middleware(request)
+
+    assert response.status_code == 301
+    assert response['Location'] == 'https://watch.example.com/'
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com:8080'),))
+def test_port_in_target_hostname(request_factory):
+    """Test redirecting to target hostname with port."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='test.watch.example.com')
+
+    response = middleware(request)
+
+    assert response.status_code == 301
+    assert response['Location'] == 'http://watch.example.com:8080/'
+
+
+@override_settings(REDIRECT_HOSTNAMES=(
+    ('*.watch.example.com', 'watch.example.com'),
+    ('*.old.example.com', 'new.example.com'),
+))
+def test_multiple_patterns_first_match_wins(request_factory):
+    """Test that first matching pattern is used."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+
+    # Test first pattern
+    request1 = request_factory.get('/', HTTP_HOST='test.watch.example.com')
+    response1 = middleware(request1)
+    assert response1['Location'] == 'http://watch.example.com/'
+
+    # Test second pattern
+    request2 = request_factory.get('/', HTTP_HOST='foo.old.example.com')
+    response2 = middleware(request2)
+    assert response2['Location'] == 'http://new.example.com/'
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))
+def test_no_match_passes_through(request_factory):
+    """Test that non-matching hostname returns normal response."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='example.com')
+
+    response = middleware(request)
+
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+
+@override_settings(REDIRECT_HOSTNAMES=())
+def test_empty_redirect_hostnames(request_factory):
+    """Test that empty REDIRECT_HOSTNAMES throws."""
+    with pytest.raises(MiddlewareNotUsed):
+        HostnameRedirectMiddleware(get_response_success)
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('old.example.com', 'new.example.com'),))
+def test_exact_hostname_match(request_factory):
+    """Test exact hostname match without wildcards."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='old.example.com')
+
+    response = middleware(request)
+
+    assert response.status_code == 301
+    assert response['Location'] == 'http://new.example.com/'
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('old.example.com', 'new.example.com'),))
+def test_exact_hostname_no_match(request_factory):
+    """Test that exact hostname pattern doesn't match different hostname."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+    request = request_factory.get('/', HTTP_HOST='other.example.com')
+
+    response = middleware(request)
+
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.example.com', 'example.com'),))
+def test_wildcard_matches_valid_subdomain_chars(request_factory):
+    """Test that wildcard matches alphanumeric and hyphens."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+
+    # Valid subdomain parts
+    valid_subdomains = ['test', 'test-123', 'a', '123', 'foo-bar-baz']
+    for subdomain in valid_subdomains:
+        request = request_factory.get('/', HTTP_HOST=f'{subdomain}.example.com')
+        response = middleware(request)
+        assert response.status_code == 301, f"Should redirect for subdomain: {subdomain}"
+
+
+@override_settings(REDIRECT_HOSTNAMES=(('*.example.com', 'example.com'),))
+def test_wildcard_rejects_invalid_subdomain_chars(request_factory):
+    """Test that wildcard rejects invalid subdomain characters."""
+    middleware = HostnameRedirectMiddleware(get_response_success)
+
+    # Invalid subdomain parts
+    request = request_factory.get('/', HTTP_HOST='-test.example.com')  # starts with hyphen
+    response = middleware(request)
+    assert response.status_code == 200  # Should NOT redirect
+
+    request = request_factory.get('/', HTTP_HOST='test-.example.com')  # ends with hyphen
+    response = middleware(request)
+    assert response.status_code == 200  # Should NOT redirect

--- a/docs/middleware/redirects.md
+++ b/docs/middleware/redirects.md
@@ -1,0 +1,33 @@
+# HostnameRedirectMiddleware
+
+Hostname redirect configuration for HostnameRedirectMiddleware
+Performs HTTP 301 redirects based on incoming request hostname patterns.
+
+The middleware is configured with an ENV variable of the following format:
+
+Environment variable format (comma-separated list):
+  REDIRECT_HOSTNAMES=from_pattern:to_hostname,from_pattern:to_hostname,...
+
+Examples:
+  # Single rule - redirect any subdomain
+  REDIRECT_HOSTNAMES=*.app.example.com:app.example.com
+
+  # Multiple rules
+  REDIRECT_HOSTNAMES=*.app.example.com:app.example.com,*.old.example.com:new.example.com
+
+  # With port number in target
+  REDIRECT_HOSTNAMES=*.dev.local:localhost:8000
+
+  # Exact hostname match (no wildcard)
+  REDIRECT_HOSTNAMES=staging.myapp.com:myapp.com
+
+Wildcard rules:
+  - '*' matches exactly ONE subdomain level (letters, numbers, hyphens)
+  - '*.example.com' matches 'test.example.com' but NOT 'foo.bar.example.com'
+  - Matched part cannot contain periods or start/end with hyphens
+
+Behavior:
+  - HTTP 301 (permanent redirect) is returned when pattern matches
+  - Original path, query string, and scheme (http/https) are preserved
+  - First matching pattern wins (order matters)
+  - Redirects are logged to application logs and sent to Sentry


### PR DESCRIPTION
## Description
Simple ENV-variable-configured middleware to redirect away from legacy hostnames in urls

## Screenshots/Videos (if applicable)
N/A

## Related issue
N/A
## Requirements, dependencies and related PRs
N/A

## Additional Notes
In the future, we will want to replace this with a user-visible redirect view so that they can update their bookmarks.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Set up the .env so that it contains for example `REDIRECT_HOSTNAMES=*.bar.com:localhost:8000`. Then use curl to manually set the hostname with `-H "Host: foo.bar.com"`. It should redirect to localhost:8000 with a 301

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new early-request `301` redirect layer based on the incoming `Host` header; misconfiguration could unintentionally redirect or break access across domains, but the change is isolated and covered by unit tests.
> 
> **Overview**
> Adds an env-configured `HostnameRedirectMiddleware` that performs permanent (`301`) redirects when the incoming `Host` matches an exact or single-level wildcard pattern, preserving scheme/path/query and emitting both logs and Sentry messages.
> 
> Wires the middleware into the global `MIDDLEWARE` chain and introduces `REDIRECT_HOSTNAMES` parsing from `REDIRECT_HOSTNAMES=from:to,...`, with new unit tests and documentation covering matching rules and behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 798137dfe8346488e21dc330bf85ba08d2693fd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->