### PR TITLE
Fix mismatch between model log entry queryset and user filter qs

### DIFF
--- a/audit_logging/views.py
+++ b/audit_logging/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from django.db.models import Q
+from django.contrib.auth import get_user_model
+from django.db.models import IntegerField, Value
 from django.forms import CheckboxSelectMultiple
 from django.utils.translation import gettext_lazy as _, pgettext_lazy
 from wagtail.admin.filters import ContentTypeFilter, MultipleUserFilter
@@ -9,13 +10,15 @@ from wagtail.admin.views.reports.audit_logging import (
     SiteHistoryReportFilterSet,
     get_content_types_for_filter,
 )
+from wagtail.log_actions import registry as log_action_registry
 from wagtail.models import ModelLogEntry, PageLogEntry
 from wagtail.permissions import ModelPermissionPolicy
 
 import django_filters
 
 from audit_logging.models import PlanScopedModelLogEntry
-from people.models import Person
+
+LOG_MODELS_TO_EXCLUDE = (ModelLogEntry, PageLogEntry)
 
 
 class CustomSiteHistoryReportFilterSet(SiteHistoryReportFilterSet):
@@ -36,35 +39,76 @@ class CustomSiteHistoryReportFilterSet(SiteHistoryReportFilterSet):
     )
 
     def get_users_queryset(self):
-        plan = self.request.user.get_active_admin_plan()
-        qs = super().get_users_queryset()
-        if not plan:
-            return qs.none()
-        persons_available_for_plan = Person.objects.available_for_plan(plan, include_contact_persons=True)
-        return qs.filter(Q(person__in=persons_available_for_plan) | Q(is_superuser=True))
+        """
+        Get users who have made changes in the log models we actually display.
+
+        This must iterate through the same log models as get_filtered_queryset()
+        to avoid showing users in the filter who have no matching log entries.
+
+        Since items can be shared between plans, we show all users who have
+        entries in the displayed log models, without plan-specific filtering.
+        """
+        # Collect user IDs from only the log models we want to display
+        user_ids = set()
+        for log_model in log_action_registry.get_log_entry_models():
+            if log_model not in LOG_MODELS_TO_EXCLUDE:
+                user_ids.update(
+                    log_model.objects.viewable_by_user(self.request.user).get_user_ids()
+                )
+
+        User = get_user_model()
+        return User.objects.filter(pk__in=user_ids).order_by(User.USERNAME_FIELD)
 
 
 class PlanScopedLogEntriesView(LogEntriesView):
     results_template_name = "site_history_results.html"
     page_title = pgettext_lazy("page title for history of changes", "Change history")
-    LOG_MODELS_TO_EXCLUDE = ModelLogEntry, PageLogEntry
     permission_policy: ModelPermissionPolicy = ModelPermissionPolicy(PlanScopedModelLogEntry)
     filterset_class = CustomSiteHistoryReportFilterSet
     permission_required = 'view'
 
-    # We want to show only PlanScopedModelEntries
-    #
-    # You might think overriding get_filtered_queryset would be better
-    # than overriding get_context_data, but due to the way the view
-    # is implemented, that does not work.
-    #
-    # def get_filtered_queryset(self):
-    #     queryset = super().get_filtered_queryset()
-    #     indexes_to_ignore = set(self.log_models.index(model) for model in self.LOG_MODELS_TO_EXCLUDE)
-    #     return [x for x in queryset if x['log_model_index'] not in indexes_to_ignore]
-    #
-    def get_context_data(self, *, object_list=None, **kwargs):
-        queryset = object_list if object_list is not None else self.object_list
-        indexes_to_ignore = set(self.log_models.index(model) for model in self.LOG_MODELS_TO_EXCLUDE)
-        queryset = [x for x in queryset if x['log_model_index'] not in indexes_to_ignore]
-        return super().get_context_data(object_list=queryset, **kwargs)
+    def get_log_models(self):
+        """
+        Return the list of log entry models to display, excluding unwanted models.
+
+        This is used by both get_filtered_queryset() and indirectly by the
+        filterset's get_users_queryset() to ensure consistency.
+        """
+        all_models = list(log_action_registry.get_log_entry_models())
+        return [model for model in all_models if model not in LOG_MODELS_TO_EXCLUDE]
+
+    def get_filtered_queryset(self):
+        """
+        Override to exclude certain log models from the union query.
+
+        This is a copy of the parent implementation with one key change:
+        we use get_log_models() instead of getting all registered models.
+
+        This ensures that:
+        1. Only desired log entries appear in the results
+        2. The filterset's user filter matches the actual displayed entries
+        """
+        queryset = None
+
+        # CUSTOMIZATION: Use filtered list instead of all registered models
+        self.log_models = self.get_log_models()
+
+        # Rest is identical to parent implementation
+        for log_model_index, log_model in enumerate(self.log_models):
+            sub_queryset = (
+                log_model.objects.viewable_by_user(self.request.user)
+                .values("pk", "timestamp")
+                .annotate(
+                    log_model_index=Value(log_model_index, output_field=IntegerField())
+                )
+            )
+            sub_queryset = self.filter_queryset(sub_queryset)
+            sub_queryset = sub_queryset.order_by()
+            if queryset is None:
+                queryset = sub_queryset
+            else:
+                queryset = queryset.union(sub_queryset)
+
+        if queryset is None:
+            return None
+        return queryset.order_by("-timestamp")


### PR DESCRIPTION
## Description
Fixes a bug which caused wrong users to be shown in the "changed by" filter of the Change history view

## Screenshots/Videos (if applicable)
N/A

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212716389148788?focus=true
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212716389148788?focus=true

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
