### PR TITLE
Use capture_message instead of capture_exception for org validation

### DIFF
--- a/orgs/models.py
+++ b/orgs/models.py
@@ -291,8 +291,9 @@ class Organization(BaseOrganization, IndirectPlanRelatedModel, Node[Organization
 
         for parent_path in missing_parent_paths:
             cls._reported_missing_parent_paths.add(parent_path)
-            sentry_sdk.capture_exception(
-                KeyError(parent_path),
+            sentry_sdk.capture_message(
+                f"Organization parent path not found: {parent_path}",
+                level="warning",
                 contexts={
                     'validation': {
                         'missing_parent_path': parent_path,


### PR DESCRIPTION
Using capture_message with stack=True provides a better stack trace compared to creating a synthetic KeyError exception.

## Description
Brief description of the changes made in this PR.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to Sentry reporting behavior during org validation; no functional changes to organization data or access control.
> 
> **Overview**
> Switches org tree validation reporting in `Organization._validate_orgs_by_path` from `sentry_sdk.capture_exception(KeyError(...))` to `sentry_sdk.capture_message(...)` with `level="warning"`, keeping the same context payload.
> 
> This avoids emitting synthetic exceptions when an organization’s parent path is missing and instead records a structured warning message (reducing error noise while still tracking unique missing parent paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84db2b9dc00ec59e147f72beb16ae6cd3445d861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->