### PR TITLE
Be more robust in face of stale attributechoice references

### DIFF
--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -7,15 +7,16 @@ from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelatio
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Q
+from django.db.models import ObjectDoesNotExist, Q
 from django.db.models.constraints import Deferrable
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, gettext_lazy as _
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
 from modeltrans.fields import TranslationField
 from modeltrans.manager import MultilingualManager, MultilingualQuerySet
 from wagtail.fields import RichTextField
 
+import sentry_sdk
 from autoslug.fields import AutoSlugField
 
 from kausal_common.i18n.helpers import get_supported_languages
@@ -325,7 +326,21 @@ class AttributeChoice(Attribute):
         unique_together = ('type', 'content_type', 'object_id')
 
     def __str__(self):
-        return str(self.choice)
+        try:
+            choice = self.choice
+        except ObjectDoesNotExist as e:
+            # The choice can be missing if it has been deleted
+            # but an old reference exists in a serialized revision or snapshot
+            sentry_sdk.set_extra(
+                'serializedReferenceError',
+                'Deleted AttributeChoice instance referenced. '
+                'Probable cause: serialized report representation has stale reference to choice.'
+            )
+            sentry_sdk.set_extra("attributeType", self.type.pk)
+            sentry_sdk.set_extra("attributeChoicePk", self.choice_id)
+            sentry_sdk.capture_exception(e)
+            return gettext('Missing value')
+        return str(choice)
 
 
 @reversion.register(follow=['choice'])


### PR DESCRIPTION
We still need to fix the underlying problem but at least we do not crash the admin UI.

## Description
Prevent admin UI crashing if old reports reference deleted AttributeChoices by pk.

## Screenshots/Videos (if applicable)
N/A

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212937973495947?focus=true

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A
------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
