### PR TITLE
Include main organization in plan when creating a plan

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -916,6 +916,8 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):
         plan.create_default_site(hostname)
         plan.save()
 
+        plan.related_organizations.add(plan.organization)
+
         with translation.override(plan.primary_language):
             from actions.models import ActionImplementationPhase, ActionStatus
 


### PR DESCRIPTION
## Description
When a new plan is created, include the chosen main organization of the plan in the plan automatically.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1212995297338145?focus=true)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
#### Manual testing instructions
1. Create a new plan (note which organization you choose as the main organization)
2. Go to `Organizations`
3. Click the three dots next to your chosen main organization
4. See that the options say `Exclude from active plan` instead of `Include in Active plan`

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [x] **Moderation** integration implemented
- [x] **Reporting** integration implemented
- [x] **Copy plan feature** integration implemented

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to plan initialization that only adds a missing M2M association and should not affect existing plans unless they are newly created.
> 
> **Overview**
> When creating a plan via `Plan.apply_defaults`, the plan’s main `organization` is now automatically added to `related_organizations` immediately after the initial save, so new plans start with their primary organization included in the active plan organization set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39d1d4ed64261524301968eb5fb90d8ccc33458b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->