### PR TITLE
Ability to read/write indicator level (of a specific plan) via REST API

### DIFF
--- a/indicators/api.py
+++ b/indicators/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast, override
 
 from django.db import transaction
+from django.db.models import ObjectDoesNotExist
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, serializers, status, viewsets
 from rest_framework.decorators import action
@@ -13,13 +14,14 @@ import django_filters as filters
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 
-from kausal_common.api.bulk import BulkListSerializer, BulkModelViewSet
+from kausal_common.api.bulk import BulkListSerializer
 from kausal_common.api.utils import register_view_helper
 from kausal_common.users import user_or_bust, user_or_none
 
 from aplans.permissions import WatchObjectPermissions
+from aplans.rest_api import get_plan_from_view
 
-from actions.api import AuditLoggingBulkModelViewSet, get_plan_from_view, plan_router
+from actions.api import AuditLoggingBulkModelViewSet, plan_router
 from actions.models import Plan
 from people.models import Person
 
@@ -461,13 +463,17 @@ class IndicatorSerializerMixin:
                 fields[field_name].context['_cache'] = cache
 
 
-class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer):
+class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer[Indicator]):
     _modifiable_indicators_cache: IndicatorQuerySet
 
     uuid = serializers.UUIDField(required=False)
     latest_value = IndicatorValueSerializer(read_only=True, required=False, label=_('Latest value'))
     contact_persons = IndicatorContactPersonSerializer(required=False, label=_('Contact persons'))
     categories = IndicatorCategoriesSerializer(required=False)
+    # The level is in singular because an indicator is always manipulated in the
+    # context of a single plan. The other levels of the indicator should be left
+    # intact.
+    level = serializers.ChoiceField(choices=Indicator.LEVELS, required=False, allow_null=True, label=_('Level'))
 
     class Meta:
         model = Indicator
@@ -475,12 +481,23 @@ class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer)
         fields = (
             'id', 'uuid', 'name', 'quantity', 'unit', 'time_resolution', 'organization', 'updated_values_due_at',
             'latest_value', 'reference', 'internal_notes', 'visibility', 'contact_persons', 'categories',
-            'description',
+            'description', 'level',
         )
+
+    def to_representation(self, instance: Indicator) -> dict[str, Any]:
+        representation = super().to_representation(instance)
+        plan = self.context['plan']
+        try:
+            representation['level'] = instance.levels.get(plan=plan).level
+        except ObjectDoesNotExist:
+            representation['level'] = None
+        return representation
 
     def create(self, validated_data: dict):
         contact_persons_data = validated_data.pop('contact_persons', None)
         categories_data = validated_data.pop('categories', None)
+        _not_provided = object()
+        level = validated_data.pop('level', _not_provided)
         instance = super().create(validated_data)
 
         fields = cast(dict[str, serializers.Field], self.fields)
@@ -490,15 +507,18 @@ class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer)
         if contact_persons_data is not None and hasattr(fields['contact_persons'], 'update'):
             fields['contact_persons'].update(instance, contact_persons_data)
         assert not instance.levels.exists()
-        plan = self.context['request'].user.get_active_admin_plan()
-        level = 'strategic'
-        assert level in [v for v, _ in Indicator.LEVELS]
-        instance.levels.create(plan=plan, level=level)
+        plan = self.context['plan']
+        if level is _not_provided:
+            level = 'strategic'
+        if level is not None:
+            assert level in [v for v, _ in Indicator.LEVELS]
+            instance.levels.create(plan=plan, level=level)
         return instance
 
     def update(self, instance, validated_data):
         contact_persons_data = validated_data.pop('contact_persons', None)
         categories_data = validated_data.pop('categories', None)
+        level = validated_data.pop('level', None)
         instance = super().update(instance, validated_data)
 
         fields = cast(dict[str, serializers.Field], self.fields)
@@ -508,6 +528,19 @@ class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer)
         if contact_persons_data is not None and hasattr(fields['contact_persons'], 'update'):
             fields['contact_persons'].update(instance, contact_persons_data)
         instance.save()
+
+        plan = self.context['plan']
+        if level is None:
+            instance.levels.filter(plan=plan).delete()
+        else:
+            try:
+                plan_level = instance.levels.get(plan=plan)
+            except ObjectDoesNotExist:
+                instance.levels.create(plan=plan, level=level)
+            else:
+                plan_level.level = level
+                plan_level.save()
+
         return instance
 
     def get_fields(self):
@@ -593,7 +626,7 @@ class IndicatorPermission(WatchObjectPermissions):
         OpenApiParameter(name='plan_id', type=OpenApiTypes.STR, location=OpenApiParameter.PATH),
     ],
 )
-class IndicatorViewSet(AuditLoggingBulkModelViewSet):
+class IndicatorViewSet(AuditLoggingBulkModelViewSet[Indicator]):
     serializer_class = IndicatorSerializer
     filterset_class = IndicatorFilter
 
@@ -608,6 +641,11 @@ class IndicatorViewSet(AuditLoggingBulkModelViewSet):
         if not plan:
             return Indicator.objects.none()
         return Indicator.objects.available_for_plan(plan).prefetch_related('contact_persons', 'categories')  # type: ignore[attr-defined]
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['plan'] = self.get_plan()
+        return context
 
     def get_permissions(self):
         if self.action == 'update_values':

--- a/indicators/api.py
+++ b/indicators/api.py
@@ -493,7 +493,7 @@ class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer[
             representation['level'] = None
         return representation
 
-    def create(self, validated_data: dict):
+    def create(self, validated_data: dict[str, Any]):
         contact_persons_data = validated_data.pop('contact_persons', None)
         categories_data = validated_data.pop('categories', None)
         _not_provided = object()
@@ -515,10 +515,11 @@ class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer[
             instance.levels.create(plan=plan, level=level)
         return instance
 
-    def update(self, instance, validated_data):
+    def update(self, instance, validated_data: dict[str, Any]):
         contact_persons_data = validated_data.pop('contact_persons', None)
         categories_data = validated_data.pop('categories', None)
-        level = validated_data.pop('level', None)
+        _not_provided = object()
+        level = validated_data.pop('level', _not_provided)
         instance = super().update(instance, validated_data)
 
         fields = cast(dict[str, serializers.Field], self.fields)
@@ -530,7 +531,9 @@ class IndicatorSerializer(IndicatorSerializerMixin, serializers.ModelSerializer[
         instance.save()
 
         plan = self.context['plan']
-        if level is None:
+        if level is _not_provided:
+            pass
+        elif level is None:
             instance.levels.filter(plan=plan).delete()
         else:
             try:

--- a/indicators/tests/test_api.py
+++ b/indicators/tests/test_api.py
@@ -683,3 +683,25 @@ def test_update_indicator_with_invalid_level_returns_400(
     })
     assert response.status_code == 400
     assert 'level' in response.data
+
+
+def test_update_indicator_omitting_level_leaves_level_intact(
+        api_client, plan, plan_admin_user, indicator_factory):
+    indicator = indicator_factory(plans=[])
+    indicator.levels.create(plan=plan, level='strategic')
+    indicator.organization.related_plans.add(plan)
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+
+    api_client.force_login(plan_admin_user)
+
+    response = api_client.put(detail_url, data={
+        'name': 'Updated Name',
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+    })
+    assert response.status_code == 200
+
+    indicator.refresh_from_db()
+    assert indicator.name == 'Updated Name'
+    level = indicator.levels.get(plan=plan)
+    assert level.level == 'strategic'

--- a/indicators/tests/test_api.py
+++ b/indicators/tests/test_api.py
@@ -464,3 +464,222 @@ def test_bulk_indicator_put_creates_individual_log_entries(
     for indicator in indicators:
         total_logs = count_log_entries(instance=indicator, plan=plan)
         assert total_logs >= 1, f"Expected at least 1 log entry for indicator {indicator.name}"
+
+
+def test_get_indicator_returns_level_for_plan(api_client, plan, plan_admin_user, indicator_factory):
+    indicator = indicator_factory(plans=[])
+    indicator.levels.create(plan=plan, level='strategic')
+    indicator.organization.related_plans.add(plan)
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+
+    api_client.force_login(plan_admin_user)
+    response = api_client.get(detail_url)
+    assert response.status_code == 200
+    assert 'level' in response.data
+    assert response.data['level'] == 'strategic'
+
+
+def test_get_indicator_returns_null_level_when_no_level_exists(
+        api_client, plan, plan_admin_user, indicator_factory, unit_factory, organization_factory):
+    indicator = indicator_factory(plans=[])
+    indicator.organization.related_plans.add(plan)
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+
+    api_client.force_login(plan_admin_user)
+    response = api_client.get(detail_url)
+    assert response.status_code == 200
+    assert response.data['level'] is None
+
+
+def test_create_indicator_sets_strategic_level(
+        api_client, plan, person_factory, unit_factory, organization_factory, indicator_list_url):
+    admin_person = person_factory(general_admin_plans=[plan])
+    api_client.force_login(admin_person.user)
+
+    unit = unit_factory()
+    org = organization_factory()
+    org.related_plans.add(plan)
+
+    response = api_client.post(indicator_list_url, data={
+        'name': 'New Indicator',
+        'unit': unit.pk,
+        'organization': org.pk,
+    })
+    assert response.status_code == 201
+
+    created_indicator = Indicator.objects.get(name='New Indicator')
+    assert created_indicator.levels.count() == 1
+    level = created_indicator.levels.first()
+    assert level is not None
+    assert level.plan == plan
+    assert level.level == 'strategic'
+
+
+def test_create_indicator_with_custom_level(
+        api_client, plan, person_factory, unit_factory, organization_factory, indicator_list_url):
+    admin_person = person_factory(general_admin_plans=[plan])
+    api_client.force_login(admin_person.user)
+
+    unit = unit_factory()
+    org = organization_factory()
+    org.related_plans.add(plan)
+
+    response = api_client.post(indicator_list_url, data={
+        'name': 'Tactical Indicator',
+        'unit': unit.pk,
+        'organization': org.pk,
+        'level': 'tactical',
+    })
+    assert response.status_code == 201
+
+    created_indicator = Indicator.objects.get(name='Tactical Indicator')
+    assert created_indicator.levels.count() == 1
+    level = created_indicator.levels.first()
+    assert level is not None
+    assert level.plan == plan
+    assert level.level == 'tactical'
+
+
+def test_create_indicator_with_null_level_creates_no_level(
+        api_client, plan, person_factory, unit_factory, organization_factory, indicator_list_url):
+    admin_person = person_factory(general_admin_plans=[plan])
+    api_client.force_login(admin_person.user)
+
+    unit = unit_factory()
+    org = organization_factory()
+    org.related_plans.add(plan)
+
+    response = api_client.post(indicator_list_url, data={
+        'name': 'No Level Indicator',
+        'unit': unit.pk,
+        'organization': org.pk,
+        'level': None,
+    })
+    assert response.status_code == 201
+
+    created_indicator = Indicator.objects.get(name='No Level Indicator')
+    assert created_indicator.levels.count() == 0
+
+
+def test_update_indicator_level_changes_level(api_client, plan, plan_admin_user, indicator, indicator_detail_url):
+    api_client.force_login(plan_admin_user)
+
+    response = api_client.put(indicator_detail_url, data={
+        'name': indicator.name,
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+        'level': 'tactical',
+    })
+    assert response.status_code == 200
+
+    indicator.refresh_from_db()
+    level = indicator.levels.get(plan=plan)
+    assert level.level == 'tactical'
+
+
+def test_update_indicator_level_to_null_removes_level(api_client, plan, plan_admin_user, indicator, indicator_detail_url):
+    api_client.force_login(plan_admin_user)
+
+    response = api_client.put(indicator_detail_url, data={
+        'name': indicator.name,
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+        'level': None,
+    })
+    assert response.status_code == 200
+
+    indicator.refresh_from_db()
+    assert not indicator.levels.filter(plan=plan).exists()
+
+
+def test_update_indicator_adds_level_when_none_exists(
+        api_client, plan, plan_admin_user, indicator_factory, indicator_contact_factory):
+    indicator = indicator_factory(plans=[])
+    indicator.organization.related_plans.add(plan)
+    indicator_contact_factory(indicator=indicator, person=plan_admin_user.person)
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+
+    api_client.force_login(plan_admin_user)
+
+    assert not indicator.levels.filter(plan=plan).exists()
+
+    response = api_client.put(detail_url, data={
+        'name': indicator.name,
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+        'level': 'operational',
+    })
+    assert response.status_code == 200
+
+    indicator.refresh_from_db()
+    level = indicator.levels.get(plan=plan)
+    assert level.level == 'operational'
+
+
+def test_update_indicator_level_does_not_affect_other_plans(
+        api_client, plan, plan_admin_user, indicator_factory, plan_factory):
+    other_plan = plan_factory()
+    indicator = indicator_factory(plans=[])
+    indicator.organization.related_plans.add(plan)
+    indicator.organization.related_plans.add(other_plan)
+    indicator.levels.create(plan=plan, level='strategic')
+    indicator.levels.create(plan=other_plan, level='tactical')
+
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+    api_client.force_login(plan_admin_user)
+
+    response = api_client.put(detail_url, data={
+        'name': indicator.name,
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+        'level': 'operational',
+    })
+    assert response.status_code == 200
+
+    indicator.refresh_from_db()
+    assert indicator.levels.get(plan=plan).level == 'operational'
+    assert indicator.levels.get(plan=other_plan).level == 'tactical'
+
+
+def test_remove_indicator_level_does_not_affect_other_plans(
+        api_client, plan, plan_admin_user, indicator_factory, plan_factory):
+    other_plan = plan_factory()
+    indicator = indicator_factory(plans=[])
+    indicator.organization.related_plans.add(plan)
+    indicator.organization.related_plans.add(other_plan)
+    indicator.levels.create(plan=plan, level='strategic')
+    indicator.levels.create(plan=other_plan, level='tactical')
+
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+    api_client.force_login(plan_admin_user)
+
+    response = api_client.put(detail_url, data={
+        'name': indicator.name,
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+        'level': None,
+    })
+    assert response.status_code == 200
+
+    indicator.refresh_from_db()
+    assert not indicator.levels.filter(plan=plan).exists()
+    assert indicator.levels.get(plan=other_plan).level == 'tactical'
+
+
+def test_update_indicator_with_invalid_level_returns_400(
+        api_client, plan, plan_admin_user, indicator_factory):
+    indicator = indicator_factory(plans=[])
+    indicator.levels.create(plan=plan, level='strategic')
+    indicator.organization.related_plans.add(plan)
+    detail_url = reverse('indicator-detail', kwargs={'plan_pk': plan.pk, 'pk': indicator.pk})
+
+    api_client.force_login(plan_admin_user)
+
+    response = api_client.put(detail_url, data={
+        'name': indicator.name,
+        'unit': indicator.unit.pk,
+        'organization': indicator.organization.pk,
+        'level': 'invalid_level',
+    })
+    assert response.status_code == 400
+    assert 'level' in response.data


### PR DESCRIPTION
## Description
Ability to read/write indicator levels (of a specific plan) via REST API

## Screenshots/Videos (if applicable)
N/A

## Related issue

## Requirements, dependencies and related PRs
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1206286256572076?focus=true


## Additional Notes
This is based on the fact that an indicator is exposed nested under a plan. Hence, the field "level" is in singular and it only exposes the level of that specific plan, if any.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
