### PR TITLE
Make the UI /admin page redirect always work

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -439,7 +439,7 @@ class PlanNode(DjangoNode[Plan]):
 
     @staticmethod
     def resolve_admin_url(root: Plan, info: GQLInfo):
-        if not root.features.show_admin_link or not root.is_visible_for_user(info.context.user):
+        if not root.is_visible_for_user(info.context.user):
             return None
         client_plan = root.clients.first()
         if client_plan is None:

--- a/actions/tests/test_graphql_plan.py
+++ b/actions/tests/test_graphql_plan.py
@@ -132,11 +132,7 @@ def test_plan_admin_url(graphql_client_query_data, plan, show_admin_link):
         """,
         variables=dict(plan=plan.identifier),
     )
-    if show_admin_link:
-        admin_url = settings.ADMIN_BASE_URL
-        assert data == {'plan': {'adminUrl': admin_url}}
-    else:
-        assert data == {'plan': {'adminUrl': None}}
+    assert data == {'plan': {'adminUrl': settings.ADMIN_BASE_URL}}
 
 
 def test_categorytypes(graphql_client_query_data, plan, category_type, category_factory):


### PR DESCRIPTION
The UI will now use the explicit is_visible_for_user feature when deciding when to render the link in the footer. We want to always return a value for published plans for the redirect to work though.

## Description
N/A

## Screenshots/Videos (if applicable)
N/A

## Related issue
https://app.asana.com/1/1201243246741462/task/1212623057408317

## Requirements, dependencies and related PRs
First merge this into the UI: 
https://github.com/kausaltech/kausal-watch-ui/pull/635

## Additional Notes
N/A


------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
