### PR TITLE
Order organizations returned by REST API

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1552,11 +1552,11 @@ class OrganizationViewSet(HandleProtectedErrorMixin, AuditLoggingBulkModelViewSe
             raise exceptions.NotFound(detail='Plan not found') from None
 
     def get_queryset(self):
-        queryset = super().get_queryset()
+        queryset = super().get_queryset().order_by('id')
         plan = self.get_plan()
         if plan is None:
             return queryset
-        return Organization.objects.qs.available_for_plan(plan)
+        return Organization.objects.qs.available_for_plan(plan).order_by('id')
 
 
 


### PR DESCRIPTION
## Description
Order the organizations returned by REST API to make sure paginated list of organizations stays consistent.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Asana](https://app.asana.com/1/1201243246741462/task/1212995297338145)

## Requirements, dependencies and related PRs
\-

## Additional Notes
This is a bit of a blind attempt to fix an issue in production that does not happen locally.

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
#### Manual testing instructions
- Go to organization table view
- Use network tab in developer tools and find the response from API
- See that the API response is ordered by organization ID

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [x] **Moderation** integration implemented
- [x] **Reporting** integration implemented
- [x] **Copy plan feature** integration implemented

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change that only adds explicit ordering to organization querysets; minimal behavioral impact beyond deterministic pagination.
> 
> **Overview**
> Ensures the organizations list endpoint returns a *stable, deterministic order* by explicitly sorting querysets by `id` in `OrganizationViewSet.get_queryset()`.
> 
> When filtering organizations by `plan` (`available_for_plan(plan)`), the results are also ordered by `id`, improving pagination consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12f37e93bfa7288fa9e34c50a79e8ad5051e2033. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->