### PR TITLE
Add commitment count column to Pledges admin list view

### DIFF
--- a/actions/models/pledge.py
+++ b/actions/models/pledge.py
@@ -174,6 +174,7 @@ class Pledge(
         index.SearchField('name', boost=10),
         index.SearchField('description'),
         index.SearchField('body'),
+        index.FilterField('plan_id')
     ]
 
     class Meta:

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
+from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import (
     FieldPanel,
     MultiFieldPanel,
     ObjectList,
 )
+from wagtail.admin.ui.tables import Column
 from wagtail.images.widgets import AdminImageChooser
 from wagtail.snippets.models import register_snippet
 
@@ -198,7 +200,10 @@ class PledgeViewSet(WatchViewSet[Pledge]):
     menu_icon = 'kausal-pledge'
     menu_order = 41  # After Indicators (40)
     add_to_admin_menu = True
-    list_display = ['name', 'plan']
+    list_display = [
+        'name',
+        Column('commitment_count', label=_('Commitments'), sort_key='commitment_count'),
+    ]
     search_fields = ['name']
     ordering = ['plan', 'order']
     add_view_class = PledgeCreateView  # type: ignore[assignment]
@@ -257,7 +262,7 @@ class PledgeViewSet(WatchViewSet[Pledge]):
             qs = self.model._default_manager.all()
         user = user_or_bust(request.user)
         plan = user.get_active_admin_plan()
-        return qs.filter(plan=plan)
+        return qs.filter(plan=plan).annotate(commitment_count=Count('commitments'))
 
 
 register_snippet(PledgeViewSet)


### PR DESCRIPTION
## Description
Annotate the queryset with a count of related PledgeCommitments and display it as a sortable "Commitments" column in the Wagtail admin index for Pledges.

## Screenshots/Videos (if applicable)
<img width="1218" height="437" alt="image" src="https://github.com/user-attachments/assets/66a17935-447f-46e7-a694-a7b4bf08f87d" />


## Related issue
https://app.asana.com/1/1201243246741462/project/1212972057511748/task/1213227360496308

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
