### PR TITLE
Warn users when deleting attribute types / choice options

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -717,7 +717,29 @@ class ActionEditView(
                 instance=self.instance,
                 locked_for_user=self.locked_for_user,
             )
+        # Display warnings for any attributes that were lost during draft deserialization
+        self._display_draft_attribute_warnings()
         return context
+
+    def _display_draft_attribute_warnings(self) -> None:
+        """Display warning messages for any attributes lost during draft deserialization."""
+        obj = self.object
+        if obj is None:
+            return
+        if not hasattr(obj, 'draft_attributes') or obj.draft_attributes is None:
+            return
+        draft_attributes = obj.draft_attributes
+        if not draft_attributes.deserialization_warnings:
+            return
+        for warning in draft_attributes.deserialization_warnings:
+            if warning.attribute_type_name:
+                msg = _('Attribute "%(attribute_type)s": %(message)s') % {
+                    'attribute_type': warning.attribute_type_name,
+                    'message': warning.message,
+                }
+            else:
+                msg = warning.message
+            messages.warning(self.request, msg)
 
     def get_description(self):
         action = self.instance

--- a/actions/apps.py
+++ b/actions/apps.py
@@ -173,3 +173,6 @@ class ActionsConfig(AppConfig):
         import actions.signals
         actions.signals.register_signal_handlers()
         monkeypatch_deferring_forward_many_to_many_manager()
+
+        from actions.attribute_type_admin import check_attribute_value_models
+        check_attribute_value_models()

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -12,10 +12,11 @@ from django.forms import ValidationError
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _, ngettext_lazy
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.panels import FieldPanel, ObjectList, Panel
+from wagtail.models import DraftStateMixin
 
 from loguru import logger
 from wagtail_modeladmin.helpers.button import ButtonHelper
@@ -44,7 +45,16 @@ from admin_site.wagtail import (
 
 from .attributes import AttributeType as AttributeTypeWrapper
 from .models import Action, AttributeType, AttributeTypeChoiceOption, Category, Pledge
-from .models.attributes import AttributeChoice, AttributeChoiceWithText
+from .models.attributes import (
+    Attribute,
+    AttributeCategoryChoice,
+    AttributeChoice,
+    AttributeChoiceWithText,
+    AttributeNumericValue,
+    AttributeRichText,
+    AttributeText,
+    ModelWithAttributes,
+)
 
 if TYPE_CHECKING:
     from django.http.request import HttpRequest
@@ -215,6 +225,165 @@ def _get_choice_option_usage(attribute_type: AttributeType) -> dict[int, ChoiceO
     return result
 
 
+ATTRIBUTE_VALUE_MODELS = [
+    AttributeChoice, AttributeChoiceWithText, AttributeText,
+    AttributeRichText, AttributeNumericValue, AttributeCategoryChoice,
+]
+_ATTRIBUTE_VALUE_MODELS_IGNORED: list[type[Attribute]] = []
+
+
+def check_attribute_value_models() -> None:
+    expected = {
+        cls for cls in Attribute.__subclasses__()
+        if not cls._meta.abstract and cls not in _ATTRIBUTE_VALUE_MODELS_IGNORED
+    }
+    actual = set(ATTRIBUTE_VALUE_MODELS)
+    missing = expected - actual
+    extra = actual - expected
+    if missing:
+        logger.warning('ATTRIBUTE_VALUE_MODELS is missing subclasses of Attribute: {cls}', cls=missing)
+    if extra:
+        logger.warning('ATTRIBUTE_VALUE_MODELS contains classes that are not subclasses of Attribute: {cls}', cls=extra)
+
+
+@dataclass
+class AttributeTypeUsageInfo:
+    """Usage information for an AttributeType across published objects and drafts."""
+
+    published_object_names: list[str] = field(default_factory=list)
+    draft_object_names: list[str] = field(default_factory=list)
+    published_label: str = ''
+    draft_label: str = ''
+
+    @property
+    def published_count(self) -> int:
+        return len(self.published_object_names)
+
+    @property
+    def draft_count(self) -> int:
+        return len(self.draft_object_names)
+
+    @property
+    def has_usage(self) -> bool:
+        return self.published_count > 0 or self.draft_count > 0
+
+
+def _collect_published_for_attribute_type(attribute_type: AttributeType) -> list[str]:
+    """Collect names of published objects that have attribute values for this type."""
+    object_model = attribute_type.object_content_type.model_class()
+    assert object_model is not None
+
+    object_ids: set[int] = set()
+    for model in ATTRIBUTE_VALUE_MODELS:
+        object_ids.update(
+            model.objects.filter(type=attribute_type).values_list('object_id', flat=True),  # type: ignore[attr-defined]
+        )
+
+    if not object_ids:
+        return []
+
+    return sorted(str(obj) for obj in object_model.objects.filter(id__in=object_ids))  # type: ignore[attr-defined]
+
+
+def _collect_drafts_for_attribute_type(attribute_type: AttributeType) -> list[str]:
+    """Collect names of objects with unpublished draft attribute values for this type."""
+    object_model = attribute_type.object_content_type.model_class()
+    assert object_model is not None
+
+    if not issubclass(object_model, DraftStateMixin):
+        return []
+
+    plan = attribute_type._get_plan()
+    if plan is None:
+        return []
+
+    # Scope to the plan so we don't load drafts from every plan in the system.
+    # This assumes every DraftStateMixin model has a plan_id field; if a future
+    # model breaks that assumption, this will fail with a FieldError.
+    objects_with_drafts = object_model.objects.filter(  # type: ignore[attr-defined]
+        plan_id=plan.pk,
+        has_unpublished_changes=True,
+    ).select_related('latest_revision')
+
+    format_key = str(attribute_type.format)
+    attr_type_key = str(attribute_type.pk)
+
+    draft_names = []
+    for obj in objects_with_drafts:
+        revision = obj.latest_revision
+        if not revision:
+            continue
+        attributes = revision.content.get('attributes', {})
+        value = attributes.get(format_key, {}).get(attr_type_key)
+        if value is not None:
+            draft_names.append(str(obj))
+
+    return sorted(draft_names)
+
+
+def _published_label(model: type[ModelWithAttributes], count: int) -> str:
+    """Return a translatable label for the number of published objects of a given model."""
+    if model is Action:
+        label = ngettext_lazy(
+            '%(count)d published action',
+            '%(count)d published actions',
+            count,
+        )
+    elif model is Category:
+        label = ngettext_lazy(
+            '%(count)d category',
+            '%(count)d categories',
+            count,
+        )
+    elif model is Pledge:
+        label = ngettext_lazy(
+            '%(count)d pledge',
+            '%(count)d pledges',
+            count,
+        )
+    else:
+        # So far the models above are the only ones that support attributes. Here we catch the issue of forgetting to
+        # update this function if at some point we create a new model that supports attributes.
+        raise TypeError(f'Unexpected model: {model}')
+    return label % {'count': count}
+
+
+def _draft_label(model: type[ModelWithAttributes], count: int) -> str:
+    """Return a translatable label for the number of unpublished draft objects of a given model."""
+    if model is Action:
+        label = ngettext_lazy(
+            '%(count)d action draft',
+            '%(count)d action drafts',
+            count,
+        )
+    else:
+        # So far the models above are the only ones that support attributes and drafts. Here we catch the issue of
+        # forgetting to update this function if at some point we create a new model that supports attributes and drafts.
+        raise TypeError(f'Unexpected model: {model}')
+    return label % {'count': count}
+
+
+def _get_attribute_type_usage(attribute_type: AttributeType) -> AttributeTypeUsageInfo:
+    """Compute usage info for an AttributeType across published objects and drafts."""
+    published = _collect_published_for_attribute_type(attribute_type)
+    drafts = _collect_drafts_for_attribute_type(attribute_type)
+
+    object_model = attribute_type.object_content_type.model_class()
+    assert object_model is not None
+    assert issubclass(object_model, ModelWithAttributes)
+
+    usage_info_kwargs = {
+        'published_object_names': published,
+        'draft_object_names': drafts,
+        'published_label': _published_label(object_model, len(published)),
+    }
+
+    if issubclass(object_model, DraftStateMixin):
+        usage_info_kwargs['draft_label'] = _draft_label(object_model, len(drafts))
+
+    return AttributeTypeUsageInfo(**usage_info_kwargs)
+
+
 class ChoiceOptionUsagePanel(Panel):
     """Panel that warns admins about choice option usage in drafts and reports."""
 
@@ -368,7 +537,13 @@ class AttributeTypeEditView(
 
 
 class AttributeTypeDeleteView(ContentTypeQueryParameterMixin, DeleteView):
-    pass
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['usage_info'] = _get_attribute_type_usage(self.instance)
+        return context
+
+    def get_template_names(self):
+        return ['aplans/attribute_type_delete.html']
 
 
 class AttributeTypeAdminButtonHelper(ButtonHelper):

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -84,6 +84,30 @@ class ChoiceOptionUsageInfo:
     def has_usage(self) -> bool:
         return self.draft_action_count > 0 or self.published_action_count > 0 or self.report_count > 0
 
+    @property
+    def published_action_label(self) -> str:
+        return ngettext_lazy(
+            '%(count)d published action',
+            '%(count)d published actions',
+            self.published_action_count,
+        ) % {'count': self.published_action_count}
+
+    @property
+    def draft_action_label(self) -> str:
+        return ngettext_lazy(
+            '%(count)d action draft',
+            '%(count)d action drafts',
+            self.draft_action_count,
+        ) % {'count': self.draft_action_count}
+
+    @property
+    def report_label(self) -> str:
+        return ngettext_lazy(
+            '%(count)d report',
+            '%(count)d reports',
+            self.report_count,
+        ) % {'count': self.report_count}
+
 
 def _extract_choice_pk_from_revision_value(format_key: str, value: object) -> int | None:
     """Extract the choice option PK from a serialized revision attribute value."""
@@ -252,6 +276,7 @@ class AttributeTypeUsageInfo:
 
     published_object_names: list[str] = field(default_factory=list)
     draft_object_names: list[str] = field(default_factory=list)
+    report_names: list[str] = field(default_factory=list)
     published_label: str = ''
     draft_label: str = ''
 
@@ -264,8 +289,20 @@ class AttributeTypeUsageInfo:
         return len(self.draft_object_names)
 
     @property
+    def report_count(self) -> int:
+        return len(self.report_names)
+
+    @property
+    def report_label(self) -> str:
+        return ngettext_lazy(
+            '%(count)d report',
+            '%(count)d reports',
+            self.report_count,
+        ) % {'count': self.report_count}
+
+    @property
     def has_usage(self) -> bool:
-        return self.published_count > 0 or self.draft_count > 0
+        return self.published_count > 0 or self.draft_count > 0 or self.report_count > 0
 
 
 def _collect_published_for_attribute_type(attribute_type: AttributeType) -> list[str]:
@@ -363,6 +400,19 @@ def _draft_label(model: type[ModelWithAttributes], count: int) -> str:
     return label % {'count': count}
 
 
+def _collect_reports_for_attribute_type(attribute_type: AttributeType) -> list[str]:
+    """Collect names of incomplete reports affected by this attribute type."""
+    if attribute_type.object_content_type.model != 'action':
+        return []
+
+    from reports.models import Report
+    return [
+        str(r) for r in Report.objects.filter(
+            is_complete=False, type__plan_id=attribute_type.scope_id,
+        )
+    ]
+
+
 def _get_attribute_type_usage(attribute_type: AttributeType) -> AttributeTypeUsageInfo:
     """Compute usage info for an AttributeType across published objects and drafts."""
     published = _collect_published_for_attribute_type(attribute_type)
@@ -372,16 +422,19 @@ def _get_attribute_type_usage(attribute_type: AttributeType) -> AttributeTypeUsa
     assert object_model is not None
     assert issubclass(object_model, ModelWithAttributes)
 
-    usage_info_kwargs = {
-        'published_object_names': published,
-        'draft_object_names': drafts,
-        'published_label': _published_label(object_model, len(published)),
-    }
+    report_names = _collect_reports_for_attribute_type(attribute_type) if published else []
 
+    extra_kwargs: dict[str, str] = {}
     if issubclass(object_model, DraftStateMixin):
-        usage_info_kwargs['draft_label'] = _draft_label(object_model, len(drafts))
+        extra_kwargs['draft_label'] = _draft_label(object_model, len(drafts))
 
-    return AttributeTypeUsageInfo(**usage_info_kwargs)
+    return AttributeTypeUsageInfo(
+        published_object_names=published,
+        draft_object_names=drafts,
+        report_names=report_names,
+        published_label=_published_label(object_model, len(published)),
+        **extra_kwargs,
+    )
 
 
 class ChoiceOptionUsagePanel(Panel):
@@ -414,6 +467,9 @@ class ChoiceOptionUsagePanel(Panel):
                 self.draft_action_names = info.draft_action_names
                 self.published_action_names = info.published_action_names
                 self.report_names = info.report_names
+                self.published_action_label = info.published_action_label
+                self.draft_action_label = info.draft_action_label
+                self.report_label = info.report_label
                 self.has_usage = info.has_usage
             else:
                 self.draft_action_count = 0
@@ -422,6 +478,9 @@ class ChoiceOptionUsagePanel(Panel):
                 self.draft_action_names = []
                 self.published_action_names = []
                 self.report_names = []
+                self.published_action_label = ''
+                self.draft_action_label = ''
+                self.report_label = ''
                 self.has_usage = False
 
         def is_shown(self):

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -64,41 +64,23 @@ logger = logger.bind(name='actions.attribute_type_admin')
 
 @dataclass
 class ChoiceOptionUsageInfo:
-    draft_action_names: list[str] = field(default_factory=list)
-    published_action_names: list[str] = field(default_factory=list)
+    published_object_names: list[str] = field(default_factory=list)
+    published_object_label: str = ''
+    draft_object_names: list[str] = field(default_factory=list)
+    draft_object_label: str = ''
     report_names: list[str] = field(default_factory=list)
 
     @property
-    def draft_action_count(self) -> int:
-        return len(self.draft_action_names)
+    def published_count(self) -> int:
+        return len(self.published_object_names)
 
     @property
-    def published_action_count(self) -> int:
-        return len(self.published_action_names)
+    def draft_count(self) -> int:
+        return len(self.draft_object_names)
 
     @property
     def report_count(self) -> int:
         return len(self.report_names)
-
-    @property
-    def has_usage(self) -> bool:
-        return self.draft_action_count > 0 or self.published_action_count > 0 or self.report_count > 0
-
-    @property
-    def published_action_label(self) -> str:
-        return ngettext_lazy(
-            '%(count)d published action',
-            '%(count)d published actions',
-            self.published_action_count,
-        ) % {'count': self.published_action_count}
-
-    @property
-    def draft_action_label(self) -> str:
-        return ngettext_lazy(
-            '%(count)d action draft',
-            '%(count)d action drafts',
-            self.draft_action_count,
-        ) % {'count': self.draft_action_count}
 
     @property
     def report_label(self) -> str:
@@ -107,6 +89,10 @@ class ChoiceOptionUsageInfo:
             '%(count)d reports',
             self.report_count,
         ) % {'count': self.report_count}
+
+    @property
+    def has_usage(self) -> bool:
+        return self.published_count > 0 or self.draft_count > 0 or self.report_count > 0
 
 
 def _extract_choice_pk_from_revision_value(format_key: str, value: object) -> int | None:
@@ -121,18 +107,25 @@ def _extract_choice_pk_from_revision_value(format_key: str, value: object) -> in
 def _collect_drafts_per_option(
     attribute_type: AttributeType, option_pks: set[int],
 ) -> dict[int, list[str]]:
-    """Collect action names of unpublished drafts referencing each choice option."""
-    draft_action_names: dict[int, list[str]] = defaultdict(list)
-    actions_with_drafts = Action.objects.filter(
-        plan_id=attribute_type.scope_id,
+    """Collect names of objects with unpublished drafts referencing each choice option."""
+    object_model = attribute_type.object_content_type.model_class()
+    assert object_model is not None
+
+    plan = attribute_type._get_plan()
+    if plan is None:
+        return {}
+
+    draft_names: dict[int, list[str]] = defaultdict(list)
+    objects_with_drafts = object_model.objects.filter(  # type: ignore[attr-defined]
+        plan_id=plan.pk,
         has_unpublished_changes=True,
     ).select_related('latest_revision')
 
     format_key = str(attribute_type.format)
     attr_type_key = str(attribute_type.pk)
 
-    for action in actions_with_drafts:
-        revision = action.latest_revision
+    for obj in objects_with_drafts:
+        revision = obj.latest_revision
         if not revision:
             continue
         attributes = revision.content.get('attributes', {})
@@ -141,57 +134,52 @@ def _collect_drafts_per_option(
             continue
         choice_pk = _extract_choice_pk_from_revision_value(format_key, value)
         if choice_pk is not None and choice_pk in option_pks:
-            draft_action_names[choice_pk].append(str(action))
+            draft_names[choice_pk].append(str(obj))
 
-    return draft_action_names
+    return draft_names
 
 
 def _collect_published_per_option(
     attribute_type: AttributeType, option_pks: set[int],
 ) -> dict[int, list[str]]:
-    """Collect action names of published actions referencing each choice option."""
-    published_action_names: dict[int, list[str]] = defaultdict(list)
-    action_ct = ContentType.objects.get_for_model(Action)
+    """Collect names of published objects referencing each choice option."""
+    object_model = attribute_type.object_content_type.model_class()
+    assert object_model is not None
+    obj_ct = attribute_type.object_content_type
 
-    # Collect choice_id -> action_id mappings
-    choice_to_action_ids: dict[int, list[int]] = defaultdict(list)
+    published_names: dict[int, list[str]] = defaultdict(list)
+    choice_to_obj_ids: dict[int, list[int]] = defaultdict(list)
 
-    # From AttributeChoice
-    for choice_id, action_id in AttributeChoice.objects.filter(
+    for choice_id, obj_id in AttributeChoice.objects.filter(
         type=attribute_type,
-        content_type=action_ct,
+        content_type=obj_ct,
         choice_id__in=option_pks,
     ).values_list('choice_id', 'object_id'):
-        choice_to_action_ids[choice_id].append(action_id)
+        choice_to_obj_ids[choice_id].append(obj_id)
 
-    # From AttributeChoiceWithText
-    for choice_id, action_id in AttributeChoiceWithText.objects.filter(
+    for choice_id, obj_id in AttributeChoiceWithText.objects.filter(
         type=attribute_type,
-        content_type=action_ct,
+        content_type=obj_ct,
         choice_id__in=option_pks,
     ).values_list('choice_id', 'object_id'):
-        choice_to_action_ids[choice_id].append(action_id)
+        choice_to_obj_ids[choice_id].append(obj_id)
 
-    # Fetch all actions in bulk
-    all_action_ids = []
-    for action_ids in choice_to_action_ids.values():
-        all_action_ids.extend(action_ids)
+    all_obj_ids = [oid for ids in choice_to_obj_ids.values() for oid in ids]
 
-    if all_action_ids:
-        actions_by_id = {
-            action.id: str(action)
-            for action in Action.objects.filter(id__in=all_action_ids)
+    if all_obj_ids:
+        objects_by_id = {
+            obj.id: str(obj)
+            for obj in object_model.objects.filter(id__in=all_obj_ids)  # type: ignore[attr-defined]
         }
 
-        # Build result with action names
-        for choice_id, action_ids in choice_to_action_ids.items():
-            published_action_names[choice_id] = [
-                actions_by_id[action_id]
-                for action_id in action_ids
-                if action_id in actions_by_id
+        for choice_id, obj_ids in choice_to_obj_ids.items():
+            published_names[choice_id] = [
+                objects_by_id[oid]
+                for oid in obj_ids
+                if oid in objects_by_id
             ]
 
-    return published_action_names
+    return published_names
 
 
 def _get_choice_option_usage(attribute_type: AttributeType) -> dict[int, ChoiceOptionUsageInfo]:
@@ -199,49 +187,56 @@ def _get_choice_option_usage(attribute_type: AttributeType) -> dict[int, ChoiceO
     Compute usage info for all choice options of an attribute type.
 
     Returns a mapping from choice_option_pk to ChoiceOptionUsageInfo.
-    Only applies to attribute types scoped to actions.
     """
-    if attribute_type.object_content_type.model != 'action':
-        return {}
+    object_model = attribute_type.object_content_type.model_class()
+    assert object_model is not None
+    assert issubclass(object_model, ModelWithAttributes)
 
     option_pks = set(attribute_type.choice_options.values_list('pk', flat=True))
     if not option_pks:
         return {}
 
-    draft_action_names_by_option = _collect_drafts_per_option(attribute_type, option_pks)
-    published_action_names_by_option = _collect_published_per_option(attribute_type, option_pks)
+    published_names_by_option = _collect_published_per_option(attribute_type, option_pks)
 
-    # Find incomplete reports for options that have live attribute references
-    from reports.models import Report
-    action_ct = ContentType.objects.get_for_model(Action)
+    draft_names_by_option: dict[int, list[str]] = {}
+    if issubclass(object_model, DraftStateMixin):
+        draft_names_by_option = _collect_drafts_per_option(attribute_type, option_pks)
 
+    # Reports only track action attributes; for other models, skip report collection.
     used_option_pks: set[int] = set()
-    used_option_pks.update(
-        AttributeChoice.objects.filter(
-            type=attribute_type, content_type=action_ct,
-        ).values_list('choice_id', flat=True),
-    )
-    used_option_pks.update(
-        AttributeChoiceWithText.objects.filter(
-            type=attribute_type, content_type=action_ct, choice_id__isnull=False,
-        ).values_list('choice_id', flat=True),
-    )
-    used_option_pks &= option_pks
-
     report_names: list[str] = []
-    if used_option_pks:
-        report_names = [
-            str(r) for r in Report.objects.filter(
-                is_complete=False, type__plan_id=attribute_type.scope_id,
-            )
-        ]
+    if object_model is Action:
+        obj_ct = attribute_type.object_content_type
+        used_option_pks.update(
+            AttributeChoice.objects.filter(
+                type=attribute_type, content_type=obj_ct,
+            ).values_list('choice_id', flat=True),
+        )
+        used_option_pks.update(
+            AttributeChoiceWithText.objects.filter(
+                type=attribute_type, content_type=obj_ct, choice_id__isnull=False,
+            ).values_list('choice_id', flat=True),
+        )
+        used_option_pks &= option_pks
+
+        if used_option_pks:
+            from reports.models import Report
+            report_names = [
+                str(r) for r in Report.objects.filter(
+                    is_complete=False, type__plan_id=attribute_type.scope_id,
+                )
+            ]
 
     # Build result
     result: dict[int, ChoiceOptionUsageInfo] = {}
     for pk in option_pks:
+        pub_names = published_names_by_option.get(pk, [])
+        draft_names = draft_names_by_option.get(pk, [])
         info = ChoiceOptionUsageInfo(
-            draft_action_names=draft_action_names_by_option.get(pk, []),
-            published_action_names=published_action_names_by_option.get(pk, []),
+            published_object_names=pub_names,
+            published_object_label=_published_label(object_model, len(pub_names)) if pub_names else '',
+            draft_object_names=draft_names,
+            draft_object_label=_draft_label(object_model, len(draft_names)) if draft_names else '',
             report_names=report_names if pk in used_option_pks else [],
         )
         if info.has_usage:
@@ -461,25 +456,25 @@ class ChoiceOptionUsagePanel(Panel):
                 info = None
 
             if info is not None:
-                self.draft_action_count = info.draft_action_count
-                self.published_action_count = info.published_action_count
+                self.published_count = info.published_count
+                self.draft_count = info.draft_count
                 self.report_count = info.report_count
-                self.draft_action_names = info.draft_action_names
-                self.published_action_names = info.published_action_names
+                self.published_object_names = info.published_object_names
+                self.published_object_label = info.published_object_label
+                self.draft_object_names = info.draft_object_names
+                self.draft_object_label = info.draft_object_label
                 self.report_names = info.report_names
-                self.published_action_label = info.published_action_label
-                self.draft_action_label = info.draft_action_label
                 self.report_label = info.report_label
                 self.has_usage = info.has_usage
             else:
-                self.draft_action_count = 0
-                self.published_action_count = 0
+                self.published_count = 0
+                self.draft_count = 0
                 self.report_count = 0
-                self.draft_action_names = []
-                self.published_action_names = []
+                self.published_object_names = []
+                self.published_object_label = ''
+                self.draft_object_names = []
+                self.draft_object_label = ''
                 self.report_names = []
-                self.published_action_label = ''
-                self.draft_action_label = ''
                 self.report_label = ''
                 self.has_usage = False
 

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from django.contrib.admin import SimpleListFilter
@@ -13,8 +15,9 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.admin.panels import FieldPanel, ObjectList
+from wagtail.admin.panels import FieldPanel, ObjectList, Panel
 
+from loguru import logger
 from wagtail_modeladmin.helpers.button import ButtonHelper
 from wagtail_modeladmin.menus import ModelAdminMenuItem
 from wagtail_modeladmin.options import modeladmin_register
@@ -41,9 +44,219 @@ from admin_site.wagtail import (
 
 from .attributes import AttributeType as AttributeTypeWrapper
 from .models import Action, AttributeType, AttributeTypeChoiceOption, Category, Pledge
+from .models.attributes import AttributeChoice, AttributeChoiceWithText
 
 if TYPE_CHECKING:
     from django.http.request import HttpRequest
+
+logger = logger.bind(name='actions.attribute_type_admin')
+
+
+@dataclass
+class ChoiceOptionUsageInfo:
+    draft_action_names: list[str] = field(default_factory=list)
+    published_action_names: list[str] = field(default_factory=list)
+    report_names: list[str] = field(default_factory=list)
+
+    @property
+    def draft_action_count(self) -> int:
+        return len(self.draft_action_names)
+
+    @property
+    def published_action_count(self) -> int:
+        return len(self.published_action_names)
+
+    @property
+    def report_count(self) -> int:
+        return len(self.report_names)
+
+    @property
+    def has_usage(self) -> bool:
+        return self.draft_action_count > 0 or self.published_action_count > 0 or self.report_count > 0
+
+
+def _extract_choice_pk_from_revision_value(format_key: str, value: object) -> int | None:
+    """Extract the choice option PK from a serialized revision attribute value."""
+    if format_key in ('ordered_choice', 'unordered_choice') and isinstance(value, int):
+        return value
+    if format_key == 'optional_choice' and isinstance(value, dict):
+        return value.get('choice')
+    return None
+
+
+def _collect_drafts_per_option(
+    attribute_type: AttributeType, option_pks: set[int],
+) -> dict[int, list[str]]:
+    """Collect action names of unpublished drafts referencing each choice option."""
+    draft_action_names: dict[int, list[str]] = defaultdict(list)
+    actions_with_drafts = Action.objects.filter(
+        plan_id=attribute_type.scope_id,
+        has_unpublished_changes=True,
+    ).select_related('latest_revision')
+
+    format_key = str(attribute_type.format)
+    attr_type_key = str(attribute_type.pk)
+
+    for action in actions_with_drafts:
+        revision = action.latest_revision
+        if not revision:
+            continue
+        attributes = revision.content.get('attributes', {})
+        value = attributes.get(format_key, {}).get(attr_type_key)
+        if value is None:
+            continue
+        choice_pk = _extract_choice_pk_from_revision_value(format_key, value)
+        if choice_pk is not None and choice_pk in option_pks:
+            draft_action_names[choice_pk].append(str(action))
+
+    return draft_action_names
+
+
+def _collect_published_per_option(
+    attribute_type: AttributeType, option_pks: set[int],
+) -> dict[int, list[str]]:
+    """Collect action names of published actions referencing each choice option."""
+    published_action_names: dict[int, list[str]] = defaultdict(list)
+    action_ct = ContentType.objects.get_for_model(Action)
+
+    # Collect choice_id -> action_id mappings
+    choice_to_action_ids: dict[int, list[int]] = defaultdict(list)
+
+    # From AttributeChoice
+    for choice_id, action_id in AttributeChoice.objects.filter(
+        type=attribute_type,
+        content_type=action_ct,
+        choice_id__in=option_pks,
+    ).values_list('choice_id', 'object_id'):
+        choice_to_action_ids[choice_id].append(action_id)
+
+    # From AttributeChoiceWithText
+    for choice_id, action_id in AttributeChoiceWithText.objects.filter(
+        type=attribute_type,
+        content_type=action_ct,
+        choice_id__in=option_pks,
+    ).values_list('choice_id', 'object_id'):
+        choice_to_action_ids[choice_id].append(action_id)
+
+    # Fetch all actions in bulk
+    all_action_ids = []
+    for action_ids in choice_to_action_ids.values():
+        all_action_ids.extend(action_ids)
+
+    if all_action_ids:
+        actions_by_id = {
+            action.id: str(action)
+            for action in Action.objects.filter(id__in=all_action_ids)
+        }
+
+        # Build result with action names
+        for choice_id, action_ids in choice_to_action_ids.items():
+            published_action_names[choice_id] = [
+                actions_by_id[action_id]
+                for action_id in action_ids
+                if action_id in actions_by_id
+            ]
+
+    return published_action_names
+
+
+def _get_choice_option_usage(attribute_type: AttributeType) -> dict[int, ChoiceOptionUsageInfo]:
+    """
+    Compute usage info for all choice options of an attribute type.
+
+    Returns a mapping from choice_option_pk to ChoiceOptionUsageInfo.
+    Only applies to attribute types scoped to actions.
+    """
+    if attribute_type.object_content_type.model != 'action':
+        return {}
+
+    option_pks = set(attribute_type.choice_options.values_list('pk', flat=True))
+    if not option_pks:
+        return {}
+
+    draft_action_names_by_option = _collect_drafts_per_option(attribute_type, option_pks)
+    published_action_names_by_option = _collect_published_per_option(attribute_type, option_pks)
+
+    # Find incomplete reports for options that have live attribute references
+    from reports.models import Report
+    action_ct = ContentType.objects.get_for_model(Action)
+
+    used_option_pks: set[int] = set()
+    used_option_pks.update(
+        AttributeChoice.objects.filter(
+            type=attribute_type, content_type=action_ct,
+        ).values_list('choice_id', flat=True),
+    )
+    used_option_pks.update(
+        AttributeChoiceWithText.objects.filter(
+            type=attribute_type, content_type=action_ct, choice_id__isnull=False,
+        ).values_list('choice_id', flat=True),
+    )
+    used_option_pks &= option_pks
+
+    report_names: list[str] = []
+    if used_option_pks:
+        report_names = [
+            str(r) for r in Report.objects.filter(
+                is_complete=False, type__plan_id=attribute_type.scope_id,
+            )
+        ]
+
+    # Build result
+    result: dict[int, ChoiceOptionUsageInfo] = {}
+    for pk in option_pks:
+        info = ChoiceOptionUsageInfo(
+            draft_action_names=draft_action_names_by_option.get(pk, []),
+            published_action_names=published_action_names_by_option.get(pk, []),
+            report_names=report_names if pk in used_option_pks else [],
+        )
+        if info.has_usage:
+            result[pk] = info
+    return result
+
+
+class ChoiceOptionUsagePanel(Panel):
+    """Panel that warns admins about choice option usage in drafts and reports."""
+
+    def __init__(self, usage_by_option: dict[int, ChoiceOptionUsageInfo], **kwargs):
+        super().__init__(**kwargs)
+        self.usage_by_option = usage_by_option
+
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs['usage_by_option'] = self.usage_by_option
+        return kwargs
+
+    class BoundPanel(Panel.BoundPanel):
+        template_name = 'aplans/panels/choice_option_usage_panel.html'
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            option = self.instance
+            if option and option.pk:
+                info = self.panel.usage_by_option.get(option.pk)
+            else:
+                info = None
+
+            if info is not None:
+                self.draft_action_count = info.draft_action_count
+                self.published_action_count = info.published_action_count
+                self.report_count = info.report_count
+                self.draft_action_names = info.draft_action_names
+                self.published_action_names = info.published_action_names
+                self.report_names = info.report_names
+                self.has_usage = info.has_usage
+            else:
+                self.draft_action_count = 0
+                self.published_action_count = 0
+                self.report_count = 0
+                self.draft_action_names = []
+                self.published_action_names = []
+                self.report_names = []
+                self.has_usage = False
+
+        def is_shown(self):
+            return self.has_usage
 
 
 class AttributeTypeFilter(SimpleListFilter):
@@ -280,7 +493,7 @@ class AttributeTypeAdmin(OrderableMixin, AplansModelAdmin):
     # wagtailorderable hasn't accounted for this.
     @display(ordering='order', description=_('Order'))
     def index_order(self, obj):
-        return mark_safe(  # noqa: S308
+        return mark_safe(
             '<div class="w-orderable__item__handle button button-small button--icon handle text-replace">'
             '<svg class="icon icon-grip default" style="padding: 0px;" aria-hidden="true">'
             '<use href="#icon-grip"></use>'
@@ -297,6 +510,11 @@ class AttributeTypeAdmin(OrderableMixin, AplansModelAdmin):
             request,
             instance,
         )
+
+        if instance.pk is not None:
+            usage_by_option = _get_choice_option_usage(instance)
+            if usage_by_option:
+                choice_option_panels = [*choice_option_panels, ChoiceOptionUsagePanel(usage_by_option)]
 
         creating = instance.pk is None
         if not creating and instance and AttributeTypeWrapper.from_model_instance(instance).attributes.exists():

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -1029,8 +1029,8 @@ class DraftAttributes:
                 f"Could not deserialize attribute for AttributeType {attr_type_id} because "
                 "the AttributeType does not exist. This attribute will be lost."
             )
-            msg = _("An attribute type used in this draft no longer exists. "
-                    "The attribute has been removed from the draft.")
+            msg = _("A field used in this draft no longer exists. The field and its value have been removed from the "
+                    "draft.")
             return (None, DeserializationWarning(
                 attribute_type_id=attr_type_id,
                 attribute_type_name=None,

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -135,6 +135,19 @@ class AttributeValue(ABC):
     def from_serialized_value(cls, value: Any, cache: PlanSpecificCache | None = None) -> AttributeValue:
         pass
 
+    @classmethod
+    def from_serialized_value_with_warning(
+        cls, value: Any, cache: PlanSpecificCache | None = None,
+    ) -> tuple[AttributeValue, str | None]:
+        """
+        Deserialize a value and return any warning message.
+
+        Returns a tuple of (attribute_value, warning_message).
+        The warning_message is None if deserialization was successful without issues.
+        Subclasses that can have missing references should override this method.
+        """
+        return (cls.from_serialized_value(value, cache=cache), None)
+
     @abstractmethod
     def serialize(self) -> Any:
         pass
@@ -171,6 +184,14 @@ class OrderedChoiceAttributeValue(AttributeValue):
 
     @classmethod
     def from_serialized_value(cls, value: Any, cache: PlanSpecificCache | None = None) -> OrderedChoiceAttributeValue:
+        result, _ = cls.from_serialized_value_with_warning(value, cache=cache)
+        return result
+
+    @classmethod
+    def from_serialized_value_with_warning(
+        cls, value: Any, cache: PlanSpecificCache | None = None,
+    ) -> tuple[OrderedChoiceAttributeValue, str | None]:
+        warning: str | None = None
         if value is None:
             option = None
         else:
@@ -186,7 +207,8 @@ class OrderedChoiceAttributeValue(AttributeValue):
                         f"Could not deserialize ordered choice attribute value '{value}' because "
                         "AttributeTypeChoiceOption does not exist. Setting to None."
                     )
-        return OrderedChoiceAttributeValue(option=option)
+                    warning = str(_("A choice option used in this draft no longer exists. The selection has been cleared."))
+        return (OrderedChoiceAttributeValue(option=option), warning)
 
     def serialize(self) -> Any:
         return self.option.pk if self.option else None
@@ -253,6 +275,14 @@ class OptionalChoiceWithTextAttributeValue(AttributeValue):
 
     @classmethod
     def from_serialized_value(cls, value: Any, cache: PlanSpecificCache | None = None) -> OptionalChoiceWithTextAttributeValue:
+        result, _ = cls.from_serialized_value_with_warning(value, cache=cache)
+        return result
+
+    @classmethod
+    def from_serialized_value_with_warning(
+        cls, value: Any, cache: PlanSpecificCache | None = None,
+    ) -> tuple[OptionalChoiceWithTextAttributeValue, str | None]:
+        warning: str | None = None
         if value['choice'] is None:
             option = None
         else:
@@ -268,9 +298,10 @@ class OptionalChoiceWithTextAttributeValue(AttributeValue):
                         f"Could not deserialize optional choice with text attribute value '{value}' because "
                         "AttributeTypeChoiceOption does not exist. Setting choice to None."
                     )
+                    warning = str(_("A choice option used in this draft no longer exists. The selection has been cleared."))
         text_vals = value['text']
         assert isinstance(text_vals, dict)
-        return OptionalChoiceWithTextAttributeValue(option=option, text_vals=text_vals)
+        return (OptionalChoiceWithTextAttributeValue(option=option, text_vals=text_vals), warning)
 
     def serialize(self) -> Any:
         return {
@@ -950,6 +981,15 @@ class Numeric(AttributeType[models.AttributeNumericValue]):
 type DraftAttributesValuesMap = dict[str, dict[int, AttributeValue]]
 
 
+@dataclass
+class DeserializationWarning:
+    """Represents a warning that occurred during draft attribute deserialization."""
+
+    attribute_type_id: int
+    attribute_type_name: str | None
+    message: str
+
+
 class DraftAttributes:
     """
     Contains the values of all draft attributes of a ModelWithAttributes instance.
@@ -959,9 +999,55 @@ class DraftAttributes:
 
     # map attribute type format to a mapping from attribute type ID to attribute value
     _values: DraftAttributesValuesMap
+    # warnings that occurred during deserialization
+    deserialization_warnings: list[DeserializationWarning]
 
     def __init__(self):
         self._values = {}
+        self.deserialization_warnings = []
+
+    @classmethod
+    def _deserialize_single_attribute(
+        cls,
+        attr_type_id: int,
+        serialized_value: Any,
+        value_class: type[AttributeValue],
+        cache: PlanSpecificCache | None,
+    ) -> tuple[AttributeValue | None, DeserializationWarning | None]:
+        """
+        Deserialize a single attribute value and check for missing attribute types.
+
+        Returns a tuple of (attribute_value, warning). If the attribute type doesn't exist,
+        returns (None, warning). If the value had issues (e.g., missing choice option),
+        returns (value, warning).
+        """
+        # Check if the attribute type still exists
+        try:
+            attr_type_instance = models.AttributeType.objects.get(pk=attr_type_id)
+        except models.AttributeType.DoesNotExist:
+            logger.warning(
+                f"Could not deserialize attribute for AttributeType {attr_type_id} because "
+                "the AttributeType does not exist. This attribute will be lost."
+            )
+            msg = _("An attribute type used in this draft no longer exists. "
+                    "The attribute has been removed from the draft.")
+            return (None, DeserializationWarning(
+                attribute_type_id=attr_type_id,
+                attribute_type_name=None,
+                message=str(msg),
+            ))
+        # Deserialize the value, checking for choice option issues
+        attribute_value, choice_warning = value_class.from_serialized_value_with_warning(
+            serialized_value, cache=cache,
+        )
+        warning = None
+        if choice_warning:
+            warning = DeserializationWarning(
+                attribute_type_id=attr_type_id,
+                attribute_type_name=str(attr_type_instance),
+                message=choice_warning,
+            )
+        return (attribute_value, warning)
 
     @classmethod
     def from_revision_content(cls, data: dict[str, dict[str, Any]], cache: PlanSpecificCache | None = None) -> DraftAttributes:
@@ -970,10 +1056,16 @@ class DraftAttributes:
             # No idea anymore why we serialize the IDs as strings
             assert all(isinstance(k, str) for k in id_to_serialized_value)
             at_class = AttributeType.format_to_class(models.AttributeType.AttributeFormat(format))
-            draft_attributes._values[format] = {
-                int(id): at_class.VALUE_CLASS.from_serialized_value(serialized_value, cache=cache)
-                for id, serialized_value in id_to_serialized_value.items()
-            }
+            draft_attributes._values[format] = {}
+            for str_id, serialized_value in id_to_serialized_value.items():
+                attr_type_id = int(str_id)
+                value, warning = cls._deserialize_single_attribute(
+                    attr_type_id, serialized_value, at_class.VALUE_CLASS, cache,
+                )
+                if warning:
+                    draft_attributes.deserialization_warnings.append(warning)
+                if value is not None:
+                    draft_attributes._values[format][attr_type_id] = value
         return draft_attributes
 
     def update(self, attribute_type: AttributeType, value: AttributeValue):

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -17,7 +17,12 @@ from django.contrib.contenttypes.models import ContentType
 
 import pytest
 
-from actions.attributes import DraftAttributes, OptionalChoiceWithTextAttributeValue, OrderedChoiceAttributeValue
+from actions.attributes import (
+    AttributeType as AttributeTypeWrapper,
+    DraftAttributes,
+    OptionalChoiceWithTextAttributeValue,
+    OrderedChoiceAttributeValue,
+)
 from actions.models import (
     Action,
     AttributeChoice,
@@ -36,6 +41,8 @@ from reports.models import ActionSnapshot
 from reports.tests.factories import ReportFactory, ReportTypeFactory
 
 if TYPE_CHECKING:
+    from actions.models.category import Category, CategoryType
+    from actions.models.plan import Plan
     from users.models import User
 
 pytestmark = pytest.mark.django_db
@@ -66,66 +73,38 @@ def count_choice_with_text_attributes_for_action(action: Action) -> int:
 # Fixtures
 # =============================================================================
 
-@pytest.fixture
-def action_attribute_type_ordered_choice(plan):
-    """Create an ordered choice attribute type scoped to the plan."""
-    return AttributeTypeFactory.create(
-        object_content_type=ContentType.objects.get_for_model(Action),
-        scope=plan,
-        format=AttributeType.AttributeFormat.ORDERED_CHOICE,
-        name='Test Ordered Choice',
-    )
-
+# The following registered fixtures from conftest.py are used throughout:
+#   - action_attribute_type__ordered_choice (AttributeType)
+#   - action_attribute_type__optional_choice (AttributeType, format=OPTIONAL_CHOICE_WITH_TEXT)
+#   - attribute_type_choice_option (AttributeTypeChoiceOption for ordered_choice)
+#   - attribute_type_choice_option__optional (AttributeTypeChoiceOption for optional_choice)
 
 @pytest.fixture
-def action_attribute_type_optional_choice_with_text(plan):
-    """Create an optional choice with text attribute type scoped to the plan."""
-    return AttributeTypeFactory.create(
-        object_content_type=ContentType.objects.get_for_model(Action),
-        scope=plan,
-        format=AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT,
-        name='Test Optional Choice With Text',
-    )
-
-
-@pytest.fixture
-def choice_option(action_attribute_type_ordered_choice):
-    """Create a choice option for the ordered choice attribute type."""
-    return AttributeTypeChoiceOptionFactory.create(
-        type=action_attribute_type_ordered_choice,
-        name='Option A',
-    )
-
-
-@pytest.fixture
-def choice_option_with_text(action_attribute_type_optional_choice_with_text):
-    """Create a choice option for the optional choice with text attribute type."""
-    return AttributeTypeChoiceOptionFactory.create(
-        type=action_attribute_type_optional_choice_with_text,
-        name='Option With Text',
-    )
-
-
-@pytest.fixture
-def action_with_choice_attribute(plan, action_attribute_type_ordered_choice, choice_option):
+def action_with_choice_attribute(
+    plan: Plan,
+    attribute_type_choice_option: AttributeTypeChoiceOption,
+) -> Action:
     """Create an action with a choice attribute."""
     action = ActionFactory.create(plan=plan)
     AttributeChoiceFactory.create(
-        type=action_attribute_type_ordered_choice,
+        type=attribute_type_choice_option.type,
         content_object=action,
-        choice=choice_option,
+        choice=attribute_type_choice_option,
     )
     return action
 
 
 @pytest.fixture
-def action_with_choice_with_text_attribute(plan, action_attribute_type_optional_choice_with_text, choice_option_with_text):
+def action_with_choice_with_text_attribute(
+    plan: Plan,
+    attribute_type_choice_option__optional: AttributeTypeChoiceOption,
+) -> Action:
     """Create an action with a choice-with-text attribute."""
     action = ActionFactory.create(plan=plan)
     AttributeChoiceWithTextFactory.create(
-        type=action_attribute_type_optional_choice_with_text,
+        type=attribute_type_choice_option__optional.type,
         content_object=action,
-        choice=choice_option_with_text,
+        choice=attribute_type_choice_option__optional,
         text='Some explanatory text',
     )
     return action
@@ -140,8 +119,8 @@ class TestBasicDeletionCascade:
 
     def test_deleting_choice_option_cascades_to_attribute_choice(
         self,
-        action_with_choice_attribute,
-        choice_option,
+        action_with_choice_attribute: Action,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
     ):
         """Deleting a choice option should cascade-delete related AttributeChoice instances."""
         action = action_with_choice_attribute
@@ -150,15 +129,15 @@ class TestBasicDeletionCascade:
         assert count_choice_attributes_for_action(action) == 1
 
         # Delete the choice option
-        choice_option.delete()
+        attribute_type_choice_option.delete()
 
         # Verify the AttributeChoice was also deleted (CASCADE)
         assert count_choice_attributes_for_action(action) == 0
 
     def test_deleting_choice_option_cascades_to_attribute_choice_with_text(
         self,
-        action_with_choice_with_text_attribute,
-        choice_option_with_text,
+        action_with_choice_with_text_attribute: Action,
+        attribute_type_choice_option__optional: AttributeTypeChoiceOption,
     ):
         """Deleting a choice option should cascade-delete related AttributeChoiceWithText instances."""
         action = action_with_choice_with_text_attribute
@@ -167,7 +146,7 @@ class TestBasicDeletionCascade:
         assert count_choice_with_text_attributes_for_action(action) == 1
 
         # Delete the choice option
-        choice_option_with_text.delete()
+        attribute_type_choice_option__optional.delete()
 
         # Verify the AttributeChoiceWithText was also deleted (CASCADE)
         # Note: The FK is nullable but uses CASCADE, so the whole record is deleted
@@ -175,13 +154,13 @@ class TestBasicDeletionCascade:
 
     def test_deleting_option_used_by_multiple_actions(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Deleting a choice option used by multiple actions should cascade to all."""
         # Create a single choice option
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Shared Option',
         )
 
@@ -190,7 +169,7 @@ class TestBasicDeletionCascade:
         for _ in range(3):
             action = ActionFactory.create(plan=plan)
             AttributeChoiceFactory.create(
-                type=action_attribute_type_ordered_choice,
+                type=action_attribute_type__ordered_choice,
                 content_object=action,
                 choice=option,
             )
@@ -208,14 +187,14 @@ class TestBasicDeletionCascade:
 
     def test_deleting_all_options_from_attribute_type(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Deleting all options from an attribute type should cascade to all related attributes."""
         # Create multiple options
         options = [
             AttributeTypeChoiceOptionFactory.create(
-                type=action_attribute_type_ordered_choice,
+                type=action_attribute_type__ordered_choice,
                 name=f'Option {i}',
             )
             for i in range(3)
@@ -225,20 +204,20 @@ class TestBasicDeletionCascade:
         for option in options:
             action = ActionFactory.create(plan=plan)
             AttributeChoiceFactory.create(
-                type=action_attribute_type_ordered_choice,
+                type=action_attribute_type__ordered_choice,
                 content_object=action,
                 choice=option,
             )
 
         # Verify attributes exist
-        assert AttributeChoice.objects.filter(type=action_attribute_type_ordered_choice).count() == 3
+        assert AttributeChoice.objects.filter(type=action_attribute_type__ordered_choice).count() == 3
 
         # Delete all options
         for option in options:
             option.delete()
 
         # Verify all attributes were deleted
-        assert AttributeChoice.objects.filter(type=action_attribute_type_ordered_choice).count() == 0
+        assert AttributeChoice.objects.filter(type=action_attribute_type__ordered_choice).count() == 0
 
 
 # =============================================================================
@@ -250,12 +229,12 @@ class TestDraftAttributesDeletion:
 
     def test_deserializing_draft_with_deleted_choice_option_sets_value_to_none(
         self,
-        action_attribute_type_ordered_choice,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Deserializing a draft with a deleted choice option should set value to None gracefully."""
         # Create a choice option
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Soon to be deleted',
         )
         option_pk = option.pk
@@ -263,7 +242,7 @@ class TestDraftAttributesDeletion:
         # Simulate serialized draft data with this option
         serialized_data = {
             'ordered_choice': {
-                str(action_attribute_type_ordered_choice.pk): option_pk,
+                str(action_attribute_type__ordered_choice.pk): option_pk,
             }
         }
 
@@ -274,8 +253,7 @@ class TestDraftAttributesDeletion:
         draft_attributes = DraftAttributes.from_revision_content(serialized_data)
 
         # Get the value - should have option=None
-        from actions.attributes import AttributeType as AttributeTypeWrapper
-        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type__ordered_choice)
         value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
 
         assert isinstance(value, OrderedChoiceAttributeValue)
@@ -283,12 +261,12 @@ class TestDraftAttributesDeletion:
 
     def test_deserializing_draft_with_deleted_choice_in_optional_choice_with_text(
         self,
-        action_attribute_type_optional_choice_with_text,
+        action_attribute_type__optional_choice: AttributeType,
     ):
         """Deserializing an optional choice with text draft should preserve text when choice is deleted."""
         # Create a choice option
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_optional_choice_with_text,
+            type=action_attribute_type__optional_choice,
             name='Soon to be deleted',
         )
         option_pk = option.pk
@@ -296,7 +274,7 @@ class TestDraftAttributesDeletion:
         # Simulate serialized draft data with this option and text
         serialized_data = {
             'optional_choice': {
-                str(action_attribute_type_optional_choice_with_text.pk): {
+                str(action_attribute_type__optional_choice.pk): {
                     'choice': option_pk,
                     'text': {'text': 'Important text that should be preserved'},
                 },
@@ -310,9 +288,8 @@ class TestDraftAttributesDeletion:
         draft_attributes = DraftAttributes.from_revision_content(serialized_data)
 
         # Get the value - choice should be None, text should be preserved
-        from actions.attributes import AttributeType as AttributeTypeWrapper
         attr_type_wrapper: AttributeTypeWrapper = (
-            AttributeTypeWrapper.from_model_instance(action_attribute_type_optional_choice_with_text)
+            AttributeTypeWrapper.from_model_instance(action_attribute_type__optional_choice)
         )
         value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
 
@@ -322,15 +299,15 @@ class TestDraftAttributesDeletion:
 
     def test_committing_draft_with_deleted_choice_option(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Committing a draft with a deleted choice option should not create an attribute."""
         action = ActionFactory.create(plan=plan)
 
         # Create a choice option
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Soon to be deleted',
         )
         option_pk = option.pk
@@ -338,7 +315,7 @@ class TestDraftAttributesDeletion:
         # Simulate serialized draft data
         serialized_data = {
             'ordered_choice': {
-                str(action_attribute_type_ordered_choice.pk): option_pk,
+                str(action_attribute_type__ordered_choice.pk): option_pk,
             }
         }
 
@@ -348,8 +325,7 @@ class TestDraftAttributesDeletion:
         # Deserialize and commit the draft
         draft_attributes = DraftAttributes.from_revision_content(serialized_data)
 
-        from actions.attributes import AttributeType as AttributeTypeWrapper
-        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type__ordered_choice)
         value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
 
         # Commit should not create an attribute since option is None
@@ -360,18 +336,17 @@ class TestDraftAttributesDeletion:
 
     def test_draft_attributes_serialization_roundtrip_with_deleted_option(
         self,
-        action_attribute_type_ordered_choice,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Test that draft attributes can be serialized, option deleted, then deserialized."""
         # Create a choice option
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Roundtrip option',
         )
 
         # Create draft attributes with this option
-        from actions.attributes import AttributeType as AttributeTypeWrapper
-        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type__ordered_choice)
 
         draft_attributes = DraftAttributes()
         draft_attributes.update(attr_type_wrapper, OrderedChoiceAttributeValue(option=option))
@@ -395,12 +370,12 @@ class TestDeserializationWarnings:
 
     def test_warning_generated_for_deleted_choice_option(
         self,
-        action_attribute_type_ordered_choice,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Deserializing a draft with a deleted choice option should generate a warning."""
         # Create a choice option
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Warning option',
         )
         option_pk = option.pk
@@ -408,7 +383,7 @@ class TestDeserializationWarnings:
         # Simulate serialized draft data with this option
         serialized_data = {
             'ordered_choice': {
-                str(action_attribute_type_ordered_choice.pk): option_pk,
+                str(action_attribute_type__ordered_choice.pk): option_pk,
             }
         }
 
@@ -421,24 +396,24 @@ class TestDeserializationWarnings:
         # Verify a warning was generated
         assert len(draft_attributes.deserialization_warnings) == 1
         warning = draft_attributes.deserialization_warnings[0]
-        assert warning.attribute_type_id == action_attribute_type_ordered_choice.pk
-        assert warning.attribute_type_name == str(action_attribute_type_ordered_choice)
+        assert warning.attribute_type_id == action_attribute_type__ordered_choice.pk
+        assert warning.attribute_type_name == str(action_attribute_type__ordered_choice)
         assert 'choice option' in warning.message.lower()
 
     def test_warning_generated_for_deleted_optional_choice_with_text(
         self,
-        action_attribute_type_optional_choice_with_text,
+        action_attribute_type__optional_choice: AttributeType,
     ):
         """Deserializing optional choice with text with deleted option should generate a warning."""
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_optional_choice_with_text,
+            type=action_attribute_type__optional_choice,
             name='Warning option with text',
         )
         option_pk = option.pk
 
         serialized_data = {
             'optional_choice': {
-                str(action_attribute_type_optional_choice_with_text.pk): {
+                str(action_attribute_type__optional_choice.pk): {
                     'choice': option_pk,
                     'text': {'text': 'Some text'},
                 },
@@ -451,12 +426,12 @@ class TestDeserializationWarnings:
 
         assert len(draft_attributes.deserialization_warnings) == 1
         warning = draft_attributes.deserialization_warnings[0]
-        assert warning.attribute_type_id == action_attribute_type_optional_choice_with_text.pk
+        assert warning.attribute_type_id == action_attribute_type__optional_choice.pk
         assert 'choice option' in warning.message.lower()
 
     def test_warning_generated_for_deleted_attribute_type(
         self,
-        plan,
+        plan: Plan,
     ):
         """Deserializing a draft with a deleted attribute type should generate a warning."""
         # Create an attribute type
@@ -497,17 +472,17 @@ class TestDeserializationWarnings:
 
     def test_no_warning_when_option_exists(
         self,
-        action_attribute_type_ordered_choice,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """No warning should be generated when choice option exists."""
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Existing option',
         )
 
         serialized_data = {
             'ordered_choice': {
-                str(action_attribute_type_ordered_choice.pk): option.pk,
+                str(action_attribute_type__ordered_choice.pk): option.pk,
             }
         }
 
@@ -520,7 +495,7 @@ class TestDeserializationWarnings:
 
     def test_multiple_warnings_for_multiple_deleted_options(
         self,
-        plan,
+        plan: Plan,
     ):
         """Multiple warnings should be generated when multiple attribute types have missing options."""
         attr_type1 = AttributeTypeFactory.create(
@@ -565,19 +540,19 @@ class TestReportsDeletion:
 
     def test_attribute_choice_str_handles_deleted_choice_option(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """AttributeChoice.__str__ should handle deleted choice option gracefully."""
         action = ActionFactory.create(plan=plan)
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Will be deleted',
         )
 
         # Create attribute
         attr = AttributeChoiceFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             content_object=action,
             choice=option,
         )
@@ -592,20 +567,20 @@ class TestReportsDeletion:
 
     def test_report_snapshot_with_deleted_choice_option(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
         user: User,
     ):
         """Creating a snapshot and then deleting the choice option should be handled gracefully."""
         action = ActionFactory.create(plan=plan)
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Snapshot option',
         )
 
         # Create attribute
         AttributeChoiceFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             content_object=action,
             choice=option,
         )
@@ -623,7 +598,7 @@ class TestReportsDeletion:
         snapshot.save()
 
         # Get the attribute from snapshot before deletion
-        attr_from_snapshot = snapshot.get_attribute_for_type(action_attribute_type_ordered_choice)
+        attr_from_snapshot = snapshot.get_attribute_for_type(action_attribute_type__ordered_choice)
         assert attr_from_snapshot is not None
         # Access the choice_id via field_dict pattern
         assert attr_from_snapshot.choice_id == option.pk  # type: ignore[attr-defined]
@@ -633,7 +608,7 @@ class TestReportsDeletion:
 
         # The snapshot should still have the reference, but accessing .choice will fail
         # This simulates what happens with stale snapshot data
-        attr_from_snapshot_after = snapshot.get_attribute_for_type(action_attribute_type_ordered_choice)
+        attr_from_snapshot_after = snapshot.get_attribute_for_type(action_attribute_type__ordered_choice)
         # The attribute from snapshot still exists with the old choice_id
         assert attr_from_snapshot_after is not None
         # But calling str() should handle the missing choice gracefully
@@ -643,19 +618,19 @@ class TestReportsDeletion:
 
     def test_report_get_live_versions_with_deleted_choice(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """get_live_versions should not crash when choice options have been deleted."""
         action = ActionFactory.create(plan=plan)
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Live version option',
         )
 
         # Create attribute
         AttributeChoiceFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             content_object=action,
             choice=option,
         )
@@ -675,20 +650,20 @@ class TestReportsDeletion:
 
     def test_complete_report_undo_after_choice_deletion(
         self,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
         user: User,
     ):
         """Undoing report completion after choice option deletion should work."""
         action = ActionFactory.create(plan=plan)
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Report option',
         )
 
         # Create attribute
         AttributeChoiceFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             content_object=action,
             choice=option,
         )
@@ -720,19 +695,19 @@ class TestGraphQLDeletion:
     def test_query_action_attributes_after_choice_deletion(
         self,
         graphql_client_query_data,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Querying action attributes after choice option deletion should return empty list."""
         action = ActionFactory.create(plan=plan)
         option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='GraphQL option',
         )
 
         # Create attribute
         AttributeChoiceFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             content_object=action,
             choice=option,
         )
@@ -783,17 +758,17 @@ class TestGraphQLDeletion:
     def test_query_attribute_type_choice_options_after_deletion(
         self,
         graphql_client_query_data,
-        plan,
-        action_attribute_type_ordered_choice,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Querying attribute type choice options after deletion should return remaining options."""
         # Create multiple options
         option1 = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Option 1',
         )
         AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Option 2',
         )
 
@@ -820,7 +795,7 @@ class TestGraphQLDeletion:
         # Find our attribute type
         attr_type_data = next(
             at for at in data['plan']['actionAttributeTypes']
-            if at['name'] == 'Test Ordered Choice'
+            if at['name'] == action_attribute_type__ordered_choice.name
         )
 
         assert len(attr_type_data['choiceOptions']) == 1
@@ -836,12 +811,12 @@ class TestEdgeCases:
 
     def test_recreating_option_with_same_identifier_after_deletion(
         self,
-        action_attribute_type_ordered_choice,
+        action_attribute_type__ordered_choice: AttributeType,
     ):
         """Re-creating an option with the same identifier should not affect old draft references."""
         # Create and delete option
         old_option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Reused Name',
         )
         old_pk = old_option.pk
@@ -849,7 +824,7 @@ class TestEdgeCases:
         # Simulate serialized draft with old option PK
         serialized_data = {
             'ordered_choice': {
-                str(action_attribute_type_ordered_choice.pk): old_pk,
+                str(action_attribute_type__ordered_choice.pk): old_pk,
             }
         }
 
@@ -858,7 +833,7 @@ class TestEdgeCases:
 
         # Create new option with same name (will get different PK)
         new_option = AttributeTypeChoiceOptionFactory.create(
-            type=action_attribute_type_ordered_choice,
+            type=action_attribute_type__ordered_choice,
             name='Reused Name',
         )
 
@@ -868,8 +843,7 @@ class TestEdgeCases:
         # Deserializing old draft should get None, not the new option
         draft_attributes = DraftAttributes.from_revision_content(serialized_data)
 
-        from actions.attributes import AttributeType as AttributeTypeWrapper
-        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type__ordered_choice)
         value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
 
         assert isinstance(value, OrderedChoiceAttributeValue)
@@ -877,7 +851,7 @@ class TestEdgeCases:
 
     def test_deleting_attribute_type_cascades_to_options_and_attributes(
         self,
-        plan,
+        plan: Plan,
     ):
         """Deleting an attribute type should cascade to options and attributes."""
         attr_type = AttributeTypeFactory.create(
@@ -912,7 +886,7 @@ class TestEdgeCases:
 
     def test_draft_with_multiple_deleted_choice_options(
         self,
-        plan,
+        plan: Plan,
     ):
         """Draft with multiple different attribute types having deleted options should deserialize."""
         # Create two attribute types
@@ -947,8 +921,6 @@ class TestEdgeCases:
         # Deserialize should work and both should be None
         draft_attributes = DraftAttributes.from_revision_content(serialized_data)
 
-        from actions.attributes import AttributeType as AttributeTypeWrapper
-
         wrapper1: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(attr_type1)
         value1 = draft_attributes.get_value_for_attribute_type(wrapper1)
         assert isinstance(value1, OrderedChoiceAttributeValue)
@@ -969,8 +941,8 @@ class TestCategoryAttributeDeletion:
 
     def test_deleting_choice_option_cascades_to_category_attribute(
         self,
-        category_type,
-        category,
+        category_type: CategoryType,
+        category: Category,
     ):
         """Deleting a choice option should cascade to CategoryAttributeChoice."""
         from actions.models import Category

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -493,7 +493,7 @@ class TestDeserializationWarnings:
         warning = draft_attributes.deserialization_warnings[0]
         assert warning.attribute_type_id == attr_type_pk
         assert warning.attribute_type_name is None  # Type doesn't exist, so no name
-        assert 'attribute type' in warning.message.lower()
+        assert 'field' in warning.message.lower()
 
     def test_no_warning_when_option_exists(
         self,

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -1,0 +1,1004 @@
+"""
+Tests for AttributeTypeChoiceOption deletion scenarios.
+
+These tests verify that deleting AttributeTypeChoiceOption instances is handled
+gracefully across different contexts:
+- Direct database references (AttributeChoice, AttributeChoiceWithText)
+- Draft attributes in Wagtail revisions (moderation workflow)
+- Report snapshots via django-reversion
+- GraphQL API queries
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import reversion
+from django.contrib.contenttypes.models import ContentType
+
+import pytest
+
+from actions.attributes import DraftAttributes, OptionalChoiceWithTextAttributeValue, OrderedChoiceAttributeValue
+from actions.models import (
+    Action,
+    AttributeChoice,
+    AttributeChoiceWithText,
+    AttributeType,
+    AttributeTypeChoiceOption,
+)
+from actions.tests.factories import (
+    ActionFactory,
+    AttributeChoiceFactory,
+    AttributeChoiceWithTextFactory,
+    AttributeTypeChoiceOptionFactory,
+    AttributeTypeFactory,
+)
+from reports.models import ActionSnapshot
+from reports.tests.factories import ReportFactory, ReportTypeFactory
+
+if TYPE_CHECKING:
+    from users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def get_action_content_type():
+    """Get the ContentType for Action model."""
+    return ContentType.objects.get_for_model(Action)
+
+
+def count_choice_attributes_for_action(action: Action) -> int:
+    """Count AttributeChoice instances for an action using proper filtering."""
+    ct = get_action_content_type()
+    return AttributeChoice.objects.filter(content_type=ct, object_id=action.pk).count()
+
+
+def count_choice_with_text_attributes_for_action(action: Action) -> int:
+    """Count AttributeChoiceWithText instances for an action using proper filtering."""
+    ct = get_action_content_type()
+    return AttributeChoiceWithText.objects.filter(content_type=ct, object_id=action.pk).count()
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def action_attribute_type_ordered_choice(plan):
+    """Create an ordered choice attribute type scoped to the plan."""
+    return AttributeTypeFactory.create(
+        object_content_type=ContentType.objects.get_for_model(Action),
+        scope=plan,
+        format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        name='Test Ordered Choice',
+    )
+
+
+@pytest.fixture
+def action_attribute_type_optional_choice_with_text(plan):
+    """Create an optional choice with text attribute type scoped to the plan."""
+    return AttributeTypeFactory.create(
+        object_content_type=ContentType.objects.get_for_model(Action),
+        scope=plan,
+        format=AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT,
+        name='Test Optional Choice With Text',
+    )
+
+
+@pytest.fixture
+def choice_option(action_attribute_type_ordered_choice):
+    """Create a choice option for the ordered choice attribute type."""
+    return AttributeTypeChoiceOptionFactory.create(
+        type=action_attribute_type_ordered_choice,
+        name='Option A',
+    )
+
+
+@pytest.fixture
+def choice_option_with_text(action_attribute_type_optional_choice_with_text):
+    """Create a choice option for the optional choice with text attribute type."""
+    return AttributeTypeChoiceOptionFactory.create(
+        type=action_attribute_type_optional_choice_with_text,
+        name='Option With Text',
+    )
+
+
+@pytest.fixture
+def action_with_choice_attribute(plan, action_attribute_type_ordered_choice, choice_option):
+    """Create an action with a choice attribute."""
+    action = ActionFactory.create(plan=plan)
+    AttributeChoiceFactory.create(
+        type=action_attribute_type_ordered_choice,
+        content_object=action,
+        choice=choice_option,
+    )
+    return action
+
+
+@pytest.fixture
+def action_with_choice_with_text_attribute(plan, action_attribute_type_optional_choice_with_text, choice_option_with_text):
+    """Create an action with a choice-with-text attribute."""
+    action = ActionFactory.create(plan=plan)
+    AttributeChoiceWithTextFactory.create(
+        type=action_attribute_type_optional_choice_with_text,
+        content_object=action,
+        choice=choice_option_with_text,
+        text='Some explanatory text',
+    )
+    return action
+
+
+# =============================================================================
+# 1. Basic Deletion Cascade Behavior
+# =============================================================================
+
+class TestBasicDeletionCascade:
+    """Tests for basic CASCADE behavior when deleting AttributeTypeChoiceOption."""
+
+    def test_deleting_choice_option_cascades_to_attribute_choice(
+        self,
+        action_with_choice_attribute,
+        choice_option,
+    ):
+        """Deleting a choice option should cascade-delete related AttributeChoice instances."""
+        action = action_with_choice_attribute
+
+        # Verify the attribute exists
+        assert count_choice_attributes_for_action(action) == 1
+
+        # Delete the choice option
+        choice_option.delete()
+
+        # Verify the AttributeChoice was also deleted (CASCADE)
+        assert count_choice_attributes_for_action(action) == 0
+
+    def test_deleting_choice_option_cascades_to_attribute_choice_with_text(
+        self,
+        action_with_choice_with_text_attribute,
+        choice_option_with_text,
+    ):
+        """Deleting a choice option should cascade-delete related AttributeChoiceWithText instances."""
+        action = action_with_choice_with_text_attribute
+
+        # Verify the attribute exists
+        assert count_choice_with_text_attributes_for_action(action) == 1
+
+        # Delete the choice option
+        choice_option_with_text.delete()
+
+        # Verify the AttributeChoiceWithText was also deleted (CASCADE)
+        # Note: The FK is nullable but uses CASCADE, so the whole record is deleted
+        assert count_choice_with_text_attributes_for_action(action) == 0
+
+    def test_deleting_option_used_by_multiple_actions(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """Deleting a choice option used by multiple actions should cascade to all."""
+        # Create a single choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Shared Option',
+        )
+
+        # Create multiple actions using this option
+        actions = []
+        for _ in range(3):
+            action = ActionFactory.create(plan=plan)
+            AttributeChoiceFactory.create(
+                type=action_attribute_type_ordered_choice,
+                content_object=action,
+                choice=option,
+            )
+            actions.append(action)
+
+        # Verify all attributes exist
+        assert AttributeChoice.objects.filter(choice=option).count() == 3
+
+        # Delete the option
+        option.delete()
+
+        # Verify all AttributeChoice instances were deleted
+        for action in actions:
+            assert count_choice_attributes_for_action(action) == 0
+
+    def test_deleting_all_options_from_attribute_type(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """Deleting all options from an attribute type should cascade to all related attributes."""
+        # Create multiple options
+        options = [
+            AttributeTypeChoiceOptionFactory.create(
+                type=action_attribute_type_ordered_choice,
+                name=f'Option {i}',
+            )
+            for i in range(3)
+        ]
+
+        # Create actions with different options
+        for option in options:
+            action = ActionFactory.create(plan=plan)
+            AttributeChoiceFactory.create(
+                type=action_attribute_type_ordered_choice,
+                content_object=action,
+                choice=option,
+            )
+
+        # Verify attributes exist
+        assert AttributeChoice.objects.filter(type=action_attribute_type_ordered_choice).count() == 3
+
+        # Delete all options
+        for option in options:
+            option.delete()
+
+        # Verify all attributes were deleted
+        assert AttributeChoice.objects.filter(type=action_attribute_type_ordered_choice).count() == 0
+
+
+# =============================================================================
+# 2. Draft Attributes (Moderation Workflow)
+# =============================================================================
+
+class TestDraftAttributesDeletion:
+    """Tests for handling deleted choice options in draft attributes."""
+
+    def test_deserializing_draft_with_deleted_choice_option_sets_value_to_none(
+        self,
+        action_attribute_type_ordered_choice,
+    ):
+        """Deserializing a draft with a deleted choice option should set value to None gracefully."""
+        # Create a choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Soon to be deleted',
+        )
+        option_pk = option.pk
+
+        # Simulate serialized draft data with this option
+        serialized_data = {
+            'ordered_choice': {
+                str(action_attribute_type_ordered_choice.pk): option_pk,
+            }
+        }
+
+        # Delete the option
+        option.delete()
+
+        # Deserialize the draft - should not crash, should set option to None
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        # Get the value - should have option=None
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
+
+        assert isinstance(value, OrderedChoiceAttributeValue)
+        assert value.option is None
+
+    def test_deserializing_draft_with_deleted_choice_in_optional_choice_with_text(
+        self,
+        action_attribute_type_optional_choice_with_text,
+    ):
+        """Deserializing an optional choice with text draft should preserve text when choice is deleted."""
+        # Create a choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_optional_choice_with_text,
+            name='Soon to be deleted',
+        )
+        option_pk = option.pk
+
+        # Simulate serialized draft data with this option and text
+        serialized_data = {
+            'optional_choice': {
+                str(action_attribute_type_optional_choice_with_text.pk): {
+                    'choice': option_pk,
+                    'text': {'text': 'Important text that should be preserved'},
+                },
+            }
+        }
+
+        # Delete the option
+        option.delete()
+
+        # Deserialize the draft - should not crash
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        # Get the value - choice should be None, text should be preserved
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+        attr_type_wrapper: AttributeTypeWrapper = (
+            AttributeTypeWrapper.from_model_instance(action_attribute_type_optional_choice_with_text)
+        )
+        value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
+
+        assert isinstance(value, OptionalChoiceWithTextAttributeValue)
+        assert value.option is None
+        assert value.text_vals['text'] == 'Important text that should be preserved'
+
+    def test_committing_draft_with_deleted_choice_option(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """Committing a draft with a deleted choice option should not create an attribute."""
+        action = ActionFactory.create(plan=plan)
+
+        # Create a choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Soon to be deleted',
+        )
+        option_pk = option.pk
+
+        # Simulate serialized draft data
+        serialized_data = {
+            'ordered_choice': {
+                str(action_attribute_type_ordered_choice.pk): option_pk,
+            }
+        }
+
+        # Delete the option
+        option.delete()
+
+        # Deserialize and commit the draft
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
+
+        # Commit should not create an attribute since option is None
+        attr_type_wrapper.commit_attribute(action, value)
+
+        # Verify no attribute was created
+        assert count_choice_attributes_for_action(action) == 0
+
+    def test_draft_attributes_serialization_roundtrip_with_deleted_option(
+        self,
+        action_attribute_type_ordered_choice,
+    ):
+        """Test that draft attributes can be serialized, option deleted, then deserialized."""
+        # Create a choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Roundtrip option',
+        )
+
+        # Create draft attributes with this option
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+
+        draft_attributes = DraftAttributes()
+        draft_attributes.update(attr_type_wrapper, OrderedChoiceAttributeValue(option=option))
+
+        # Serialize
+        serialized = draft_attributes.get_serialized_data()
+
+        # Delete the option
+        option.delete()
+
+        # Deserialize - should handle missing option
+        restored = DraftAttributes.from_revision_content(serialized)
+        value = restored.get_value_for_attribute_type(attr_type_wrapper)
+
+        assert isinstance(value, OrderedChoiceAttributeValue)
+        assert value.option is None
+
+
+class TestDeserializationWarnings:
+    """Tests for deserialization warnings when draft attributes reference deleted objects."""
+
+    def test_warning_generated_for_deleted_choice_option(
+        self,
+        action_attribute_type_ordered_choice,
+    ):
+        """Deserializing a draft with a deleted choice option should generate a warning."""
+        # Create a choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Warning option',
+        )
+        option_pk = option.pk
+
+        # Simulate serialized draft data with this option
+        serialized_data = {
+            'ordered_choice': {
+                str(action_attribute_type_ordered_choice.pk): option_pk,
+            }
+        }
+
+        # Delete the option
+        option.delete()
+
+        # Deserialize the draft
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        # Verify a warning was generated
+        assert len(draft_attributes.deserialization_warnings) == 1
+        warning = draft_attributes.deserialization_warnings[0]
+        assert warning.attribute_type_id == action_attribute_type_ordered_choice.pk
+        assert warning.attribute_type_name == str(action_attribute_type_ordered_choice)
+        assert 'choice option' in warning.message.lower()
+
+    def test_warning_generated_for_deleted_optional_choice_with_text(
+        self,
+        action_attribute_type_optional_choice_with_text,
+    ):
+        """Deserializing optional choice with text with deleted option should generate a warning."""
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_optional_choice_with_text,
+            name='Warning option with text',
+        )
+        option_pk = option.pk
+
+        serialized_data = {
+            'optional_choice': {
+                str(action_attribute_type_optional_choice_with_text.pk): {
+                    'choice': option_pk,
+                    'text': {'text': 'Some text'},
+                },
+            }
+        }
+
+        option.delete()
+
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        assert len(draft_attributes.deserialization_warnings) == 1
+        warning = draft_attributes.deserialization_warnings[0]
+        assert warning.attribute_type_id == action_attribute_type_optional_choice_with_text.pk
+        assert 'choice option' in warning.message.lower()
+
+    def test_warning_generated_for_deleted_attribute_type(
+        self,
+        plan,
+    ):
+        """Deserializing a draft with a deleted attribute type should generate a warning."""
+        # Create an attribute type
+        attr_type = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Temporary Type',
+        )
+        attr_type_pk = attr_type.pk
+
+        # Create a choice option
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=attr_type,
+            name='Option for temp type',
+        )
+        option_pk = option.pk
+
+        # Simulate serialized draft data
+        serialized_data = {
+            'ordered_choice': {
+                str(attr_type_pk): option_pk,
+            }
+        }
+
+        # Delete the attribute type (cascades to option)
+        attr_type.delete()
+
+        # Deserialize the draft
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        # Verify a warning was generated for the deleted attribute type
+        assert len(draft_attributes.deserialization_warnings) == 1
+        warning = draft_attributes.deserialization_warnings[0]
+        assert warning.attribute_type_id == attr_type_pk
+        assert warning.attribute_type_name is None  # Type doesn't exist, so no name
+        assert 'attribute type' in warning.message.lower()
+
+    def test_no_warning_when_option_exists(
+        self,
+        action_attribute_type_ordered_choice,
+    ):
+        """No warning should be generated when choice option exists."""
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Existing option',
+        )
+
+        serialized_data = {
+            'ordered_choice': {
+                str(action_attribute_type_ordered_choice.pk): option.pk,
+            }
+        }
+
+        # Don't delete the option
+
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        # No warnings should be generated
+        assert len(draft_attributes.deserialization_warnings) == 0
+
+    def test_multiple_warnings_for_multiple_deleted_options(
+        self,
+        plan,
+    ):
+        """Multiple warnings should be generated when multiple attribute types have missing options."""
+        attr_type1 = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Type 1',
+        )
+        attr_type2 = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Type 2',
+        )
+
+        option1 = AttributeTypeChoiceOptionFactory.create(type=attr_type1, name='Option 1')
+        option2 = AttributeTypeChoiceOptionFactory.create(type=attr_type2, name='Option 2')
+
+        serialized_data = {
+            'ordered_choice': {
+                str(attr_type1.pk): option1.pk,
+                str(attr_type2.pk): option2.pk,
+            }
+        }
+
+        # Delete both options
+        option1.delete()
+        option2.delete()
+
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        # Two warnings should be generated
+        assert len(draft_attributes.deserialization_warnings) == 2
+
+
+# =============================================================================
+# 3. Reports with Deleted Choice Options
+# =============================================================================
+
+class TestReportsDeletion:
+    """Tests for handling deleted choice options in report snapshots."""
+
+    def test_attribute_choice_str_handles_deleted_choice_option(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """AttributeChoice.__str__ should handle deleted choice option gracefully."""
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Will be deleted',
+        )
+
+        # Create attribute
+        attr = AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        # Verify str works before deletion
+        assert str(attr) == 'Will be deleted'
+
+        # Note: We cannot test this directly after deletion because CASCADE will
+        # delete the AttributeChoice. This test documents the current behavior.
+        # The __str__ method has special handling for ObjectDoesNotExist which
+        # is used when deserializing old snapshots.
+
+    def test_report_snapshot_with_deleted_choice_option(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+        user: User,
+    ):
+        """Creating a snapshot and then deleting the choice option should be handled gracefully."""
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Snapshot option',
+        )
+
+        # Create attribute
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        # Create report type and report
+        report_type = ReportTypeFactory.create(plan=plan)
+        report = ReportFactory.create(type=report_type, is_complete=False)
+
+        # Create a snapshot via marking complete
+        with reversion.create_revision():
+            reversion.set_user(user)
+            reversion.add_to_revision(action)
+
+        snapshot = ActionSnapshot.for_action(report=report, action=action)
+        snapshot.save()
+
+        # Get the attribute from snapshot before deletion
+        attr_from_snapshot = snapshot.get_attribute_for_type(action_attribute_type_ordered_choice)
+        assert attr_from_snapshot is not None
+        # Access the choice_id via field_dict pattern
+        assert attr_from_snapshot.choice_id == option.pk  # type: ignore[attr-defined]
+
+        # Now delete the option (this cascades to the live AttributeChoice)
+        option.delete()
+
+        # The snapshot should still have the reference, but accessing .choice will fail
+        # This simulates what happens with stale snapshot data
+        attr_from_snapshot_after = snapshot.get_attribute_for_type(action_attribute_type_ordered_choice)
+        # The attribute from snapshot still exists with the old choice_id
+        assert attr_from_snapshot_after is not None
+        # But calling str() should handle the missing choice gracefully
+        # (returns "Missing value" and logs to Sentry)
+        result = str(attr_from_snapshot_after)
+        assert result == 'Missing value'
+
+    def test_report_get_live_versions_with_deleted_choice(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """get_live_versions should not crash when choice options have been deleted."""
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Live version option',
+        )
+
+        # Create attribute
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        # Create incomplete report
+        report_type = ReportTypeFactory.create(plan=plan)
+        report = ReportFactory.create(type=report_type, is_complete=False)
+
+        # Delete the option (cascades to AttributeChoice)
+        option.delete()
+
+        # get_live_versions should still work
+        live_versions = report.get_live_versions()
+
+        # Should have one action version
+        assert len(live_versions.actions) == 1
+
+    def test_complete_report_undo_after_choice_deletion(
+        self,
+        plan,
+        action_attribute_type_ordered_choice,
+        user: User,
+    ):
+        """Undoing report completion after choice option deletion should work."""
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Report option',
+        )
+
+        # Create attribute
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        # Create and complete report
+        report_type = ReportTypeFactory.create(plan=plan)
+        report = ReportFactory.create(type=report_type, is_complete=False)
+        report.mark_as_complete(user)
+
+        assert report.is_complete
+        assert report.action_snapshots.count() == 1
+
+        # Delete the option
+        option.delete()
+
+        # Undo completion should still work
+        report.undo_marking_as_complete(user)
+
+        assert not report.is_complete
+
+
+# =============================================================================
+# 4. GraphQL API
+# =============================================================================
+
+class TestGraphQLDeletion:
+    """Tests for GraphQL API behavior after choice option deletion."""
+
+    def test_query_action_attributes_after_choice_deletion(
+        self,
+        graphql_client_query_data,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """Querying action attributes after choice option deletion should return empty list."""
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='GraphQL option',
+        )
+
+        # Create attribute
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        # Verify attribute is returned before deletion
+        data = graphql_client_query_data(
+            """
+            query($action: ID!) {
+                action(id: $action) {
+                    attributes {
+                        ... on AttributeChoice {
+                            id
+                            choice {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+            """,
+            variables={'action': action.pk},
+        )
+
+        assert len(data['action']['attributes']) == 1
+        assert data['action']['attributes'][0]['choice']['name'] == 'GraphQL option'
+
+        # Delete the option (cascades to AttributeChoice)
+        option.delete()
+
+        # Query again - should return empty list
+        data = graphql_client_query_data(
+            """
+            query($action: ID!) {
+                action(id: $action) {
+                    attributes {
+                        ... on AttributeChoice {
+                            id
+                        }
+                    }
+                }
+            }
+            """,
+            variables={'action': action.pk},
+        )
+
+        assert data['action']['attributes'] == []
+
+    def test_query_attribute_type_choice_options_after_deletion(
+        self,
+        graphql_client_query_data,
+        plan,
+        action_attribute_type_ordered_choice,
+    ):
+        """Querying attribute type choice options after deletion should return remaining options."""
+        # Create multiple options
+        option1 = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Option 1',
+        )
+        AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Option 2',
+        )
+
+        # Delete first option
+        option1.delete()
+
+        # Query attribute type - should only show remaining option
+        data = graphql_client_query_data(
+            """
+            query($plan: ID!) {
+                plan(id: $plan) {
+                    actionAttributeTypes {
+                        name
+                        choiceOptions {
+                            name
+                        }
+                    }
+                }
+            }
+            """,
+            variables={'plan': plan.identifier},
+        )
+
+        # Find our attribute type
+        attr_type_data = next(
+            at for at in data['plan']['actionAttributeTypes']
+            if at['name'] == 'Test Ordered Choice'
+        )
+
+        assert len(attr_type_data['choiceOptions']) == 1
+        assert attr_type_data['choiceOptions'][0]['name'] == 'Option 2'
+
+
+# =============================================================================
+# 5. Edge Cases
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for edge cases in choice option deletion."""
+
+    def test_recreating_option_with_same_identifier_after_deletion(
+        self,
+        action_attribute_type_ordered_choice,
+    ):
+        """Re-creating an option with the same identifier should not affect old draft references."""
+        # Create and delete option
+        old_option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Reused Name',
+        )
+        old_pk = old_option.pk
+
+        # Simulate serialized draft with old option PK
+        serialized_data = {
+            'ordered_choice': {
+                str(action_attribute_type_ordered_choice.pk): old_pk,
+            }
+        }
+
+        # Delete the option
+        old_option.delete()
+
+        # Create new option with same name (will get different PK)
+        new_option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type_ordered_choice,
+            name='Reused Name',
+        )
+
+        # New option should have different PK
+        assert new_option.pk != old_pk
+
+        # Deserializing old draft should get None, not the new option
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+        attr_type_wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(action_attribute_type_ordered_choice)
+        value = draft_attributes.get_value_for_attribute_type(attr_type_wrapper)
+
+        assert isinstance(value, OrderedChoiceAttributeValue)
+        assert value.option is None  # Should not resolve to the new option
+
+    def test_deleting_attribute_type_cascades_to_options_and_attributes(
+        self,
+        plan,
+    ):
+        """Deleting an attribute type should cascade to options and attributes."""
+        attr_type = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Deletable Type',
+        )
+
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=attr_type,
+            name='Deletable Option',
+        )
+
+        action = ActionFactory.create(plan=plan)
+        AttributeChoiceFactory.create(
+            type=attr_type,
+            content_object=action,
+            choice=option,
+        )
+
+        # Verify everything exists
+        assert AttributeTypeChoiceOption.objects.filter(type=attr_type).count() == 1
+        assert AttributeChoice.objects.filter(type=attr_type).count() == 1
+
+        # Delete the attribute type
+        attr_type.delete()
+
+        # Everything should be deleted
+        assert AttributeTypeChoiceOption.objects.filter(pk=option.pk).count() == 0
+        assert count_choice_attributes_for_action(action) == 0
+
+    def test_draft_with_multiple_deleted_choice_options(
+        self,
+        plan,
+    ):
+        """Draft with multiple different attribute types having deleted options should deserialize."""
+        # Create two attribute types
+        attr_type1 = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Type 1',
+        )
+        attr_type2 = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Type 2',
+        )
+
+        option1 = AttributeTypeChoiceOptionFactory.create(type=attr_type1, name='Option 1')
+        option2 = AttributeTypeChoiceOptionFactory.create(type=attr_type2, name='Option 2')
+
+        # Simulate draft with both options
+        serialized_data = {
+            'ordered_choice': {
+                str(attr_type1.pk): option1.pk,
+                str(attr_type2.pk): option2.pk,
+            }
+        }
+
+        # Delete both options
+        option1.delete()
+        option2.delete()
+
+        # Deserialize should work and both should be None
+        draft_attributes = DraftAttributes.from_revision_content(serialized_data)
+
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+
+        wrapper1: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(attr_type1)
+        value1 = draft_attributes.get_value_for_attribute_type(wrapper1)
+        assert isinstance(value1, OrderedChoiceAttributeValue)
+        assert value1.option is None
+
+        wrapper2: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(attr_type2)
+        value2 = draft_attributes.get_value_for_attribute_type(wrapper2)
+        assert isinstance(value2, OrderedChoiceAttributeValue)
+        assert value2.option is None
+
+
+# =============================================================================
+# 6. Category Attributes
+# =============================================================================
+
+class TestCategoryAttributeDeletion:
+    """Tests for choice option deletion affecting category attributes."""
+
+    def test_deleting_choice_option_cascades_to_category_attribute(
+        self,
+        category_type,
+        category,
+    ):
+        """Deleting a choice option should cascade to CategoryAttributeChoice."""
+        from actions.models import Category
+
+        attr_type = AttributeTypeFactory.create(
+            scope=category_type,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Category Choice',
+        )
+
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=attr_type,
+            name='Category Option',
+        )
+
+        # Create attribute on category
+        AttributeChoiceFactory.create(
+            type=attr_type,
+            content_object=category,
+            choice=option,
+        )
+
+        # Verify attribute exists
+        ct = ContentType.objects.get_for_model(Category)
+        assert AttributeChoice.objects.filter(content_type=ct, object_id=category.pk).count() == 1
+
+        # Delete option
+        option.delete()
+
+        # Attribute should be deleted
+        assert AttributeChoice.objects.filter(content_type=ct, object_id=category.pk).count() == 0

--- a/actions/tests/test_attribute_type_usage_tracking.py
+++ b/actions/tests/test_attribute_type_usage_tracking.py
@@ -1,0 +1,841 @@
+"""
+Tests for AttributeType and AttributeTypeChoiceOption usage tracking functionality.
+
+These tests verify that the usage tracking system correctly identifies:
+- Published objects using attribute types and choice options
+- Reports that would be affected by attribute deletion
+- Proper label generation for different model types
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.contenttypes.models import ContentType
+
+import pytest
+
+from actions.attribute_type_admin import (
+    ATTRIBUTE_VALUE_MODELS,
+    AttributeTypeUsageInfo,
+    ChoiceOptionUsageInfo,
+    ChoiceOptionUsagePanel,
+    _collect_published_for_attribute_type,
+    _collect_published_per_option,
+    _collect_reports_for_attribute_type,
+    _draft_label,
+    _extract_choice_pk_from_revision_value,
+    _get_attribute_type_usage,
+    _get_choice_option_usage,
+    _published_label,
+    check_attribute_value_models,
+)
+from actions.models import Action, AttributeType, Category, Pledge
+from actions.tests.factories import (
+    ActionFactory,
+    AttributeChoiceFactory,
+    AttributeChoiceWithTextFactory,
+    AttributeTypeChoiceOptionFactory,
+    AttributeTypeFactory,
+    CategoryFactory,
+    CategoryTypeFactory,
+    PledgeFactory,
+)
+from reports.tests.factories import ReportFactory, ReportTypeFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def get_action_content_type():
+    """Get the ContentType for Action model."""
+    return ContentType.objects.get_for_model(Action)
+
+
+def get_category_content_type():
+    """Get the ContentType for Category model."""
+    return ContentType.objects.get_for_model(Category)
+
+
+def get_pledge_content_type():
+    """Get the ContentType for Pledge model."""
+    return ContentType.objects.get_for_model(Pledge)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def action_attribute_type_ordered_choice(plan):
+    """Create an ordered choice attribute type scoped to the plan."""
+    return AttributeTypeFactory.create(
+        object_content_type=get_action_content_type(),
+        scope=plan,
+        format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        name='Test Ordered Choice',
+    )
+
+
+@pytest.fixture
+def action_attribute_type_optional_choice_with_text(plan):
+    """Create an optional choice with text attribute type scoped to the plan."""
+    return AttributeTypeFactory.create(
+        object_content_type=get_action_content_type(),
+        scope=plan,
+        format=AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT,
+        name='Test Optional Choice With Text',
+    )
+
+
+@pytest.fixture
+def category_attribute_type_ordered_choice(plan):
+    """Create an ordered choice attribute type for categories."""
+    return AttributeTypeFactory.create(
+        object_content_type=get_category_content_type(),
+        scope=plan,
+        format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        name='Category Choice Field',
+    )
+
+
+@pytest.fixture
+def pledge_attribute_type_ordered_choice(plan):
+    """Create an ordered choice attribute type for pledges."""
+    return AttributeTypeFactory.create(
+        object_content_type=get_pledge_content_type(),
+        scope=plan,
+        format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        name='Pledge Choice Field',
+    )
+
+
+@pytest.fixture
+def choice_option_a(action_attribute_type_ordered_choice):
+    """Create a choice option A."""
+    return AttributeTypeChoiceOptionFactory.create(
+        type=action_attribute_type_ordered_choice,
+        name='Option A',
+    )
+
+
+@pytest.fixture
+def choice_option_b(action_attribute_type_ordered_choice):
+    """Create a choice option B."""
+    return AttributeTypeChoiceOptionFactory.create(
+        type=action_attribute_type_ordered_choice,
+        name='Option B',
+    )
+
+
+@pytest.fixture
+def choice_option_c(action_attribute_type_optional_choice_with_text):
+    """Create a choice option C for optional choice with text."""
+    return AttributeTypeChoiceOptionFactory.create(
+        type=action_attribute_type_optional_choice_with_text,
+        name='Option C',
+    )
+
+
+# =============================================================================
+# Tests for _extract_choice_pk_from_revision_value
+# =============================================================================
+
+
+class TestExtractChoicePkFromRevisionValue:
+    """Test extraction of choice PKs from serialized revision values."""
+
+    def test_ordered_choice_with_int_value(self):
+        """Test extracting PK from ordered_choice format with int value."""
+        pk = _extract_choice_pk_from_revision_value('ordered_choice', 42)
+        assert pk == 42
+
+    def test_unordered_choice_with_int_value(self):
+        """Test extracting PK from unordered_choice format with int value."""
+        pk = _extract_choice_pk_from_revision_value('unordered_choice', 99)
+        assert pk == 99
+
+    def test_optional_choice_with_dict_value(self):
+        """Test extracting PK from optional_choice format with dict value."""
+        value = {'choice': 123, 'text': {'en': 'Some text'}}
+        pk = _extract_choice_pk_from_revision_value('optional_choice', value)
+        assert pk == 123
+
+    def test_optional_choice_without_choice_key(self):
+        """Test handling optional_choice dict without 'choice' key."""
+        value = {'text': {'en': 'Some text'}}
+        pk = _extract_choice_pk_from_revision_value('optional_choice', value)
+        assert pk is None
+
+    def test_ordered_choice_with_non_int_value(self):
+        """Test handling ordered_choice with non-int value."""
+        pk = _extract_choice_pk_from_revision_value('ordered_choice', 'invalid')
+        assert pk is None
+
+    def test_optional_choice_with_non_dict_value(self):
+        """Test handling optional_choice with non-dict value."""
+        pk = _extract_choice_pk_from_revision_value('optional_choice', 'invalid')
+        assert pk is None
+
+    def test_unknown_format_key(self):
+        """Test handling unknown format key."""
+        pk = _extract_choice_pk_from_revision_value('text', 'some text')
+        assert pk is None
+
+
+# =============================================================================
+# Tests for _collect_published_per_option
+# =============================================================================
+
+
+class TestCollectPublishedPerOption:
+    """Test collecting published objects per choice option."""
+
+    def test_no_published_objects(self, action_attribute_type_ordered_choice, choice_option_a):
+        """Test with no published objects using the choice options."""
+        option_pks = {choice_option_a.pk}
+        result = _collect_published_per_option(action_attribute_type_ordered_choice, option_pks)
+        assert result == {}
+
+    def test_single_published_action_with_attribute_choice(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test collecting a single published action with AttributeChoice."""
+        action = ActionFactory.create(plan=plan, name='Action 1')
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action.pk,
+            choice=choice_option_a,
+        )
+
+        option_pks = {choice_option_a.pk}
+        result = _collect_published_per_option(action_attribute_type_ordered_choice, option_pks)
+
+        assert choice_option_a.pk in result
+        assert len(result[choice_option_a.pk]) == 1
+        assert result[choice_option_a.pk][0] == str(action)
+
+    def test_multiple_actions_same_option(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test collecting multiple actions using the same choice option."""
+        action1 = ActionFactory.create(plan=plan, name='Action 1')
+        action2 = ActionFactory.create(plan=plan, name='Action 2')
+
+        for action in [action1, action2]:
+            AttributeChoiceFactory.create(
+                type=action_attribute_type_ordered_choice,
+                content_type=get_action_content_type(),
+                object_id=action.pk,
+                choice=choice_option_a,
+            )
+
+        option_pks = {choice_option_a.pk}
+        result = _collect_published_per_option(action_attribute_type_ordered_choice, option_pks)
+
+        assert choice_option_a.pk in result
+        assert len(result[choice_option_a.pk]) == 2
+        names = set(result[choice_option_a.pk])
+        assert str(action1) in names
+        assert str(action2) in names
+
+    def test_multiple_options_different_actions(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a, choice_option_b,
+    ):
+        """Test collecting actions distributed across multiple choice options."""
+        action1 = ActionFactory.create(plan=plan, name='Action 1')
+        action2 = ActionFactory.create(plan=plan, name='Action 2')
+
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action1.pk,
+            choice=choice_option_a,
+        )
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action2.pk,
+            choice=choice_option_b,
+        )
+
+        option_pks = {choice_option_a.pk, choice_option_b.pk}
+        result = _collect_published_per_option(action_attribute_type_ordered_choice, option_pks)
+
+        assert choice_option_a.pk in result
+        assert choice_option_b.pk in result
+        assert len(result[choice_option_a.pk]) == 1
+        assert len(result[choice_option_b.pk]) == 1
+        assert result[choice_option_a.pk][0] == str(action1)
+        assert result[choice_option_b.pk][0] == str(action2)
+
+    def test_attribute_choice_with_text(
+        self, plan, action_attribute_type_optional_choice_with_text, choice_option_c,
+    ):
+        """Test collecting objects with AttributeChoiceWithText."""
+        action = ActionFactory.create(plan=plan, name='Action 1')
+        AttributeChoiceWithTextFactory.create(
+            type=action_attribute_type_optional_choice_with_text,
+            content_type=get_action_content_type(),
+            object_id=action.pk,
+            choice=choice_option_c,
+        )
+
+        option_pks = {choice_option_c.pk}
+        result = _collect_published_per_option(
+            action_attribute_type_optional_choice_with_text, option_pks,
+        )
+
+        assert choice_option_c.pk in result
+        assert len(result[choice_option_c.pk]) == 1
+        assert result[choice_option_c.pk][0] == str(action)
+
+    def test_only_requested_options_included(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a, choice_option_b,
+    ):
+        """Test that only requested option PKs are included in results."""
+        action1 = ActionFactory.create(plan=plan, name='Action 1')
+        action2 = ActionFactory.create(plan=plan, name='Action 2')
+
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action1.pk,
+            choice=choice_option_a,
+        )
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action2.pk,
+            choice=choice_option_b,
+        )
+
+        # Only request option A
+        option_pks = {choice_option_a.pk}
+        result = _collect_published_per_option(action_attribute_type_ordered_choice, option_pks)
+
+        assert choice_option_a.pk in result
+        assert choice_option_b.pk not in result
+
+
+# =============================================================================
+# Tests for _collect_published_for_attribute_type
+# =============================================================================
+
+
+class TestCollectPublishedForAttributeType:
+    """Test collecting all published objects using an attribute type."""
+
+    def test_no_published_objects(self, action_attribute_type_ordered_choice):
+        """Test with no objects using the attribute type."""
+        result = _collect_published_for_attribute_type(action_attribute_type_ordered_choice)
+        assert result == []
+
+    def test_different_attribute_value_types(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test that all attribute value model types are checked."""
+        action = ActionFactory.create(plan=plan, name='Action 1')
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action.pk,
+            choice=choice_option_a,
+        )
+
+        result = _collect_published_for_attribute_type(action_attribute_type_ordered_choice)
+
+        assert len(result) == 1
+        assert result[0] == str(action)
+
+
+# =============================================================================
+# Tests for _collect_reports_for_attribute_type
+# =============================================================================
+
+
+class TestCollectReportsForAttributeType:
+    """Test collecting incomplete reports for attribute types."""
+
+    def test_non_action_attribute_returns_empty(self, category_attribute_type_ordered_choice):
+        """Test that non-action attribute types return empty list."""
+        result = _collect_reports_for_attribute_type(category_attribute_type_ordered_choice)
+        assert result == []
+
+    def test_no_reports(self, action_attribute_type_ordered_choice):
+        """Test with no reports in the system."""
+        result = _collect_reports_for_attribute_type(action_attribute_type_ordered_choice)
+        assert result == []
+
+    def test_incomplete_reports(self, plan, action_attribute_type_ordered_choice):
+        """Test collecting incomplete reports."""
+        report_type = ReportTypeFactory.create(plan=plan)
+        report1 = ReportFactory.create(type=report_type, is_complete=False, name='Q1 Report')
+        report2 = ReportFactory.create(type=report_type, is_complete=False, name='Q2 Report')
+
+        result = _collect_reports_for_attribute_type(action_attribute_type_ordered_choice)
+
+        assert len(result) == 2
+        assert str(report1) in result
+        assert str(report2) in result
+
+    def test_ignores_complete_reports(self, plan, action_attribute_type_ordered_choice):
+        """Test that complete reports are not included."""
+        report_type = ReportTypeFactory.create(plan=plan)
+        ReportFactory.create(type=report_type, is_complete=True, name='Complete Report')
+        incomplete_report = ReportFactory.create(
+            type=report_type, is_complete=False, name='Incomplete Report',
+        )
+
+        result = _collect_reports_for_attribute_type(action_attribute_type_ordered_choice)
+
+        assert len(result) == 1
+        assert str(incomplete_report) in result
+
+    def test_only_plan_reports(self, plan, action_attribute_type_ordered_choice):
+        """Test that only reports from the same plan are included."""
+        from actions.tests.factories import PlanFactory
+
+        other_plan = PlanFactory.create()
+
+        # Report from the attribute type's plan
+        report_type1 = ReportTypeFactory.create(plan=plan)
+        report1 = ReportFactory.create(type=report_type1, is_complete=False, name='Same Plan Report')
+
+        # Report from a different plan
+        report_type2 = ReportTypeFactory.create(plan=other_plan)
+        ReportFactory.create(type=report_type2, is_complete=False, name='Other Plan Report')
+
+        result = _collect_reports_for_attribute_type(action_attribute_type_ordered_choice)
+
+        assert len(result) == 1
+        assert str(report1) in result
+
+
+# =============================================================================
+# Tests for label functions
+# =============================================================================
+
+
+class TestPublishedLabel:
+    """Test _published_label function for different models."""
+
+    def test_action_model_singular(self):
+        """Test label for single published action."""
+        label = _published_label(Action, 1)
+        assert '1' in label
+        assert 'action' in label.lower()
+
+    def test_action_model_plural(self):
+        """Test label for multiple published actions."""
+        label = _published_label(Action, 5)
+        assert '5' in label
+        assert 'action' in label.lower()
+
+    def test_category_model_singular(self):
+        """Test label for single category."""
+        label = _published_label(Category, 1)
+        assert '1' in label
+        assert 'categor' in label.lower()  # category/categories
+
+    def test_category_model_plural(self):
+        """Test label for multiple categories."""
+        label = _published_label(Category, 3)
+        assert '3' in label
+        assert 'categor' in label.lower()
+
+    def test_pledge_model_singular(self):
+        """Test label for single pledge."""
+        label = _published_label(Pledge, 1)
+        assert '1' in label
+        assert 'pledge' in label.lower()
+
+    def test_pledge_model_plural(self):
+        """Test label for multiple pledges."""
+        label = _published_label(Pledge, 2)
+        assert '2' in label
+        assert 'pledge' in label.lower()
+
+    def test_unexpected_model_raises_type_error(self):
+        """Test that unexpected model raises TypeError."""
+        # Use a mock class that's not in the expected list
+        class UnexpectedModel:
+            pass
+
+        with pytest.raises(TypeError, match='Unexpected model'):
+            _published_label(UnexpectedModel, 1)  # type: ignore[arg-type]
+
+
+class TestDraftLabel:
+    """Test _draft_label function for different models."""
+
+    def test_action_model_singular(self):
+        """Test label for single draft action."""
+        label = _draft_label(Action, 1)
+        assert '1' in label
+        assert 'action' in label.lower()
+        assert 'draft' in label.lower()
+
+    def test_action_model_plural(self):
+        """Test label for multiple draft actions."""
+        label = _draft_label(Action, 4)
+        assert '4' in label
+        assert 'action' in label.lower()
+        assert 'draft' in label.lower()
+
+    def test_unexpected_model_raises_type_error(self):
+        """Test that unexpected model raises TypeError."""
+        with pytest.raises(TypeError, match='Unexpected model'):
+            _draft_label(Category, 1)  # type: ignore[arg-type]
+
+
+# =============================================================================
+# Tests for _get_choice_option_usage
+# =============================================================================
+
+
+class TestGetChoiceOptionUsage:
+    """Test the main function for getting choice option usage info."""
+
+    def test_no_options_returns_empty(self, action_attribute_type_ordered_choice):
+        """Test attribute type with no choice options."""
+        result = _get_choice_option_usage(action_attribute_type_ordered_choice)
+        assert result == {}
+
+    def test_unused_options_return_empty(
+        self, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test that unused choice options are not included in results."""
+        result = _get_choice_option_usage(action_attribute_type_ordered_choice)
+        assert result == {}
+
+    def test_option_with_published_usage(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test option used in published action."""
+        action = ActionFactory.create(plan=plan, name='Action 1')
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action.pk,
+            choice=choice_option_a,
+        )
+
+        result = _get_choice_option_usage(action_attribute_type_ordered_choice)
+
+        assert choice_option_a.pk in result
+        info = result[choice_option_a.pk]
+        assert info.published_count == 1
+        assert info.draft_count == 0
+        assert str(action) in info.published_object_names
+        assert info.published_object_label != ''
+
+    def test_option_with_report_usage(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test option used in action that's included in incomplete reports."""
+        action = ActionFactory.create(plan=plan, name='Action 1')
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action.pk,
+            choice=choice_option_a,
+        )
+
+        # Create incomplete report
+        report_type = ReportTypeFactory.create(plan=plan)
+        report = ReportFactory.create(type=report_type, is_complete=False, name='Q1 Report')
+
+        result = _get_choice_option_usage(action_attribute_type_ordered_choice)
+
+        assert choice_option_a.pk in result
+        info = result[choice_option_a.pk]
+        assert info.report_count == 1
+        assert str(report) in info.report_names
+
+    def test_option_ignores_complete_reports(
+        self, plan, action_attribute_type_ordered_choice, choice_option_a,
+    ):
+        """Test that complete reports are not included in usage."""
+        action = ActionFactory.create(plan=plan, name='Action 1')
+        AttributeChoiceFactory.create(
+            type=action_attribute_type_ordered_choice,
+            content_type=get_action_content_type(),
+            object_id=action.pk,
+            choice=choice_option_a,
+        )
+
+        # Create complete report
+        report_type = ReportTypeFactory.create(plan=plan)
+        ReportFactory.create(type=report_type, is_complete=True, name='Q1 Report')
+
+        result = _get_choice_option_usage(action_attribute_type_ordered_choice)
+
+        assert choice_option_a.pk in result
+        info = result[choice_option_a.pk]
+        assert info.report_count == 0
+
+
+# =============================================================================
+# Tests for _get_attribute_type_usage
+# =============================================================================
+
+
+class TestGetAttributeTypeUsage:
+    """Test the main function for getting attribute type usage info."""
+
+    def test_unused_attribute_type(self, action_attribute_type_ordered_choice):
+        """Test attribute type with no usage."""
+        result = _get_attribute_type_usage(action_attribute_type_ordered_choice)
+
+        assert isinstance(result, AttributeTypeUsageInfo)
+        assert result.published_count == 0
+        assert result.draft_count == 0
+        assert result.report_count == 0
+        assert not result.has_usage
+
+    def test_category_attribute_type(self, plan, category_attribute_type_ordered_choice):
+        """Test usage tracking for category attribute types."""
+        category_type = CategoryTypeFactory.create(plan=plan)
+        category = CategoryFactory.create(type=category_type, name='Category 1')
+
+        choice_option = AttributeTypeChoiceOptionFactory.create(
+            type=category_attribute_type_ordered_choice,
+        )
+        AttributeChoiceFactory.create(
+            type=category_attribute_type_ordered_choice,
+            content_type=get_category_content_type(),
+            object_id=category.pk,
+            choice=choice_option,
+        )
+
+        result = _get_attribute_type_usage(category_attribute_type_ordered_choice)
+
+        assert result.published_count == 1
+        assert result.draft_count == 0  # Categories don't have drafts
+        assert result.report_count == 0  # Reports only track actions
+        assert str(category) in result.published_object_names
+        # Should not have draft_label for non-draft models
+        assert result.draft_label == ''
+
+    def test_pledge_attribute_type(self, plan, pledge_attribute_type_ordered_choice):
+        """Test usage tracking for pledge attribute types."""
+        pledge = PledgeFactory.create(plan=plan, name='Pledge 1')
+
+        choice_option = AttributeTypeChoiceOptionFactory.create(
+            type=pledge_attribute_type_ordered_choice,
+        )
+        AttributeChoiceFactory.create(
+            type=pledge_attribute_type_ordered_choice,
+            content_type=get_pledge_content_type(),
+            object_id=pledge.pk,
+            choice=choice_option,
+        )
+
+        result = _get_attribute_type_usage(pledge_attribute_type_ordered_choice)
+
+        assert result.published_count == 1
+        assert result.draft_count == 0  # Pledges don't have drafts
+        assert result.report_count == 0  # Reports only track actions
+        assert str(pledge) in result.published_object_names
+
+
+# =============================================================================
+# Tests for ChoiceOptionUsageInfo dataclass
+# =============================================================================
+
+
+class TestChoiceOptionUsageInfo:
+    """Test ChoiceOptionUsageInfo dataclass properties."""
+
+    def test_defaults(self):
+        """Test default values."""
+        info = ChoiceOptionUsageInfo()
+        assert info.published_count == 0
+        assert info.draft_count == 0
+        assert info.report_count == 0
+        assert not info.has_usage
+
+    def test_published_count(self):
+        """Test published_count property."""
+        info = ChoiceOptionUsageInfo(published_object_names=['A', 'B', 'C'])
+        assert info.published_count == 3
+
+    def test_draft_count(self):
+        """Test draft_count property."""
+        info = ChoiceOptionUsageInfo(draft_object_names=['X', 'Y'])
+        assert info.draft_count == 2
+
+    def test_report_count(self):
+        """Test report_count property."""
+        info = ChoiceOptionUsageInfo(report_names=['R1', 'R2', 'R3', 'R4'])
+        assert info.report_count == 4
+
+    def test_has_usage_with_published(self):
+        """Test has_usage is True when there are published objects."""
+        info = ChoiceOptionUsageInfo(published_object_names=['A'])
+        assert info.has_usage
+
+    def test_has_usage_with_drafts(self):
+        """Test has_usage is True when there are drafts."""
+        info = ChoiceOptionUsageInfo(draft_object_names=['X'])
+        assert info.has_usage
+
+    def test_has_usage_with_reports(self):
+        """Test has_usage is True when there are reports."""
+        info = ChoiceOptionUsageInfo(report_names=['R1'])
+        assert info.has_usage
+
+    def test_has_usage_false(self):
+        """Test has_usage is False when all counts are zero."""
+        info = ChoiceOptionUsageInfo()
+        assert not info.has_usage
+
+    def test_report_label_singular(self):
+        """Test report_label for single report."""
+        info = ChoiceOptionUsageInfo(report_names=['R1'])
+        label = info.report_label
+        assert '1' in label
+        assert 'report' in label.lower()
+
+    def test_report_label_plural(self):
+        """Test report_label for multiple reports."""
+        info = ChoiceOptionUsageInfo(report_names=['R1', 'R2', 'R3'])
+        label = info.report_label
+        assert '3' in label
+        assert 'report' in label.lower()
+
+
+# =============================================================================
+# Tests for AttributeTypeUsageInfo dataclass
+# =============================================================================
+
+
+class TestAttributeTypeUsageInfo:
+    """Test AttributeTypeUsageInfo dataclass properties."""
+
+    def test_defaults(self):
+        """Test default values."""
+        info = AttributeTypeUsageInfo()
+        assert info.published_count == 0
+        assert info.draft_count == 0
+        assert info.report_count == 0
+        assert not info.has_usage
+
+    def test_counts(self):
+        """Test count properties."""
+        info = AttributeTypeUsageInfo(
+            published_object_names=['A', 'B'],
+            draft_object_names=['X'],
+            report_names=['R1', 'R2', 'R3'],
+        )
+        assert info.published_count == 2
+        assert info.draft_count == 1
+        assert info.report_count == 3
+
+    def test_has_usage(self):
+        """Test has_usage property."""
+        # No usage
+        info1 = AttributeTypeUsageInfo()
+        assert not info1.has_usage
+
+        # Published usage
+        info2 = AttributeTypeUsageInfo(published_object_names=['A'])
+        assert info2.has_usage
+
+        # Draft usage
+        info3 = AttributeTypeUsageInfo(draft_object_names=['X'])
+        assert info3.has_usage
+
+        # Report usage
+        info4 = AttributeTypeUsageInfo(report_names=['R'])
+        assert info4.has_usage
+
+
+# =============================================================================
+# Tests for ChoiceOptionUsagePanel
+# =============================================================================
+
+
+class TestChoiceOptionUsagePanel:
+    """Test ChoiceOptionUsagePanel custom panel."""
+
+    def test_panel_initialization(self):
+        """Test panel can be initialized with usage data."""
+        usage_by_option = {
+            1: ChoiceOptionUsageInfo(published_object_names=['Action 1']),
+        }
+        panel = ChoiceOptionUsagePanel(usage_by_option=usage_by_option)
+        assert panel.usage_by_option == usage_by_option
+
+    def test_clone_kwargs(self):
+        """Test clone_kwargs includes usage_by_option."""
+        usage_by_option = {
+            1: ChoiceOptionUsageInfo(published_object_names=['Action 1']),
+        }
+        panel = ChoiceOptionUsagePanel(usage_by_option=usage_by_option)
+        kwargs = panel.clone_kwargs()
+        assert 'usage_by_option' in kwargs
+        assert kwargs['usage_by_option'] == usage_by_option
+
+
+# =============================================================================
+# Tests for check_attribute_value_models
+# =============================================================================
+
+
+class TestCheckAttributeValueModels:
+    """Test check_attribute_value_models validation function."""
+
+    def test_all_models_present(self):
+        """Test that all expected attribute value models are in ATTRIBUTE_VALUE_MODELS."""
+        from actions.models.attributes import (
+            AttributeCategoryChoice,
+            AttributeChoice,
+            AttributeChoiceWithText,
+            AttributeNumericValue,
+            AttributeRichText,
+            AttributeText,
+        )
+
+        # This should not raise any warnings
+        check_attribute_value_models()
+
+        # Verify ATTRIBUTE_VALUE_MODELS contains expected models
+        assert AttributeChoice in ATTRIBUTE_VALUE_MODELS
+        assert AttributeChoiceWithText in ATTRIBUTE_VALUE_MODELS
+        assert AttributeText in ATTRIBUTE_VALUE_MODELS
+        assert AttributeRichText in ATTRIBUTE_VALUE_MODELS
+        assert AttributeNumericValue in ATTRIBUTE_VALUE_MODELS
+        assert AttributeCategoryChoice in ATTRIBUTE_VALUE_MODELS
+
+    def test_logs_warning_for_missing_models(self):
+        """Test that missing models are logged as warnings."""
+        # We can't easily modify ATTRIBUTE_VALUE_MODELS, so we'll patch it
+        with (
+            patch('actions.attribute_type_admin.ATTRIBUTE_VALUE_MODELS', []),
+            patch('actions.attribute_type_admin.logger.warning') as mock_logger,
+        ):
+            check_attribute_value_models()
+            # Should log a warning about missing models
+            assert mock_logger.called
+
+    def test_logs_warning_for_extra_models(self):
+        """Test that extra models are logged as warnings."""
+        # Add a fake class that's not a real Attribute subclass
+        class FakeAttribute:
+            pass
+
+        fake_list = ATTRIBUTE_VALUE_MODELS + [FakeAttribute]  # type: ignore[list-item]
+        with (
+            patch('actions.attribute_type_admin.ATTRIBUTE_VALUE_MODELS', fake_list),
+            patch('actions.attribute_type_admin.logger.warning') as mock_logger,
+        ):
+            check_attribute_value_models()
+            # Should log a warning about extra models
+            assert mock_logger.called

--- a/reports/models.py
+++ b/reports/models.py
@@ -453,7 +453,7 @@ class ActionSnapshot(models.Model):
                 return instance
         return None
 
-    def get_attribute_for_type(self, attribute_type):
+    def get_attribute_for_type(self, attribute_type: AttributeType):
         """
         Get the first action attribute of the given type in this snapshot.
 

--- a/reports/report_formatters.py
+++ b/reports/report_formatters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, override
 
 from django.apps import apps
 from django.db.models.fields import Field
@@ -70,7 +70,7 @@ class ReportFieldFormatter(ABC):
 
     def value_for_action_snapshot(
         self,
-        block_value: dict[str, ReportCellValue],
+        block_value: dict[str, Any],
         snapshot: ActionSnapshot,
     ) -> ValueType:
         raise NotImplementedError
@@ -398,8 +398,13 @@ class ActionAttributeTypeReportFieldFormatter(ReportFieldFormatter):
         GraphQLForeignKey('attribute_type', AttributeTypeModel, required=True),
     ]
 
+    @override
     def value_for_action_snapshot(self, block_value, snapshot) -> Model | None:
-        return snapshot.get_attribute_for_type(block_value['attribute_type'])
+        attribute_type = block_value['attribute_type']
+        if attribute_type is None:
+            return None
+        assert isinstance(attribute_type, AttributeTypeModel)
+        return snapshot.get_attribute_for_type(attribute_type)
 
     def graphql_value_for_action_snapshot(self, field, snapshot):
         attribute = self.value_for_action_snapshot(field.value, snapshot)
@@ -508,6 +513,7 @@ class ActionCategoryReportFieldFormatter(ReportFieldFormatter):
 
     def value_for_action_snapshot(self, block_value, snapshot) -> ValueType:
         category_type = block_value['category_type']
+        assert isinstance(category_type, CategoryType)
         related_objects = snapshot.get_related_versions()
         category_ids = self._get_category_ids(
             snapshot.action_version.field_dict.get('id'),

--- a/review.md
+++ b/review.md
@@ -1,0 +1,78 @@
+# Review: `test_attribute_type_choice_option_deletion.py`
+
+## Evaluation Against Project Test Conventions
+
+Conventions are defined in `docs/unit-tests.md` and `CLAUDE.md`.
+
+### Key Convention Summary
+
+1. **Use registered singleton fixtures** (`action`, `plan`, `action_attribute_type__ordered_choice`) when
+   you need exactly one instance with default values.
+2. **Use `Factory.create()`** when you need to customize the instance or create multiple instances.
+3. **Avoid `_factory()` call style** — the docs say: *"Avoid using factory-as-function (`action_factory()`)
+   unless the factory has customizations in the registration. Since type hints require importing the Factory
+   class anyway, prefer `ActionFactory.create()` for clarity and type safety."*
+
+### Issues Found
+
+#### 1. Custom fixtures duplicate registered ones (high severity)
+
+The test file defines four fixtures (lines 69–106) that duplicate fixtures already registered
+via `pytest-factoryboy` in the root `conftest.py`:
+
+| Test file fixture                              | Registered equivalent                    |
+|------------------------------------------------|------------------------------------------|
+| `action_attribute_type_ordered_choice`         | `action_attribute_type__ordered_choice`   |
+| `action_attribute_type_optional_choice_with_text` | `action_attribute_type__optional_choice` |
+| `choice_option`                                | `attribute_type_choice_option`            |
+| `choice_option_with_text`                      | `attribute_type_choice_option__optional`  |
+
+**Note:** `OPTIONAL_CHOICE_WITH_TEXT` has DB value `'optional_choice'`, so the registered fixture
+name is `action_attribute_type__optional_choice`.
+
+The registered fixtures are created in `conftest.py` lines 306–328 (attribute types for every
+`AttributeFormat` value) and lines 321–328 (choice option convenience fixtures).
+
+#### 2. Missing type annotations on fixture and test parameters (medium severity)
+
+Per the testing guide, all fixture and test function parameters should have type annotations:
+
+```python
+# Current (missing annotations):
+def test_deleting_choice_option_cascades_to_attribute_choice(
+    self,
+    action_with_choice_attribute,
+    choice_option,
+):
+
+# Should be:
+def test_deleting_choice_option_cascades_to_attribute_choice(
+    self,
+    action_with_choice_attribute: Action,
+    attribute_type_choice_option: AttributeTypeChoiceOption,
+):
+```
+
+This applies to essentially all fixture parameters throughout the file.
+
+#### 3. Repeated inline import of `AttributeTypeWrapper` (low severity)
+
+The import `from actions.attributes import AttributeType as AttributeTypeWrapper` appears
+inline in 6 different test methods. This should be a module-level import.
+
+#### 4. `ActionFactory.create(plan=plan)` where `action` fixture would suffice (low severity)
+
+A few single-action fixture cases create actions explicitly when the registered `action`
+fixture could be used instead. However, in many tests multiple or customized actions are
+needed, so direct `Factory.create()` calls are appropriate per the guidelines.
+
+#### 5. `ReportFactory` / `ReportTypeFactory` used via direct `.create()` — correct
+
+These factories are **not registered** as pytest-factoryboy fixtures. Using them via
+direct `Factory.create()` calls is the correct approach.
+
+#### 6. Direct `AttributeTypeFactory.create()` for customized instances — correct
+
+Tests in `TestDeserializationWarnings` and `TestEdgeCases` that need attribute types with
+specific properties use `AttributeTypeFactory.create(...)` directly. This follows the
+"use Factory.create() when you need to customize" guideline.

--- a/templates/aplans/_usage_tooltip_item.html
+++ b/templates/aplans/_usage_tooltip_item.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+<li>
+    <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
+        {{ label }}
+        <div data-w-tooltip-target="content" hidden>
+            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
+                {% with remaining=names|length|add:"-8" %}
+                {% if remaining > 1 %}
+                    {% for name in names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
+                    <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
+                {% else %}
+                    {% for name in names %}<li>{{ name }}</li>{% endfor %}
+                {% endif %}
+                {% endwith %}
+            </ul>
+            {% if tooltip_text %}<div>{{ tooltip_text }}</div>{% endif %}
+            {% if tooltip_text_extra %}<div>{{ tooltip_text_extra }}</div>{% endif %}
+        </div>
+    </span>
+</li>

--- a/templates/aplans/attribute_type_delete.html
+++ b/templates/aplans/attribute_type_delete.html
@@ -1,0 +1,77 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n modeladmin_tags %}
+
+{% block titletag %}{{ view.get_meta_title }}{% endblock %}
+
+{% block content %}
+
+    {% block header %}
+        {% include "wagtailadmin/shared/header.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
+    {% endblock %}
+
+    {% block content_main %}
+        <div class="nice-padding">
+            {% if protected_error %}
+                <h2>{% blocktrans trimmed with view.verbose_name|capfirst as model_name %}{{ model_name }} could not be deleted{% endblocktrans %}</h2>
+                <p>{% blocktrans trimmed with instance as instance_name %}'{{ instance_name }}' is currently referenced by other objects, and cannot be deleted without jeopardising data integrity. To delete it successfully, first remove references from the following objects, then try again:{% endblocktrans %}</p>
+                <ul>
+                    {% for obj in linked_objects %}<li><b>{{ obj|get_content_type_for_obj|title }}:</b> {{ obj }}</li>{% endfor %}
+                </ul>
+                <p><a href="{{ view.index_url }}" class="button">{% trans 'Go back to listing' %}</a></p>
+            {% else %}
+                {% if usage_info.has_usage %}
+                <div class="help-block help-warning">
+                    {% trans "This field is currently in use. Deleting it will remove attribute values from the following objects:" %}
+                    <ul>
+                        {% if usage_info.published_count > 0 %}
+                        <li>
+                            <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
+                                {{ usage_info.published_label }}
+                                <div data-w-tooltip-target="content" hidden>
+                                    <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
+                                        {% with remaining=usage_info.published_object_names|length|add:"-8" %}
+                                        {% if remaining > 1 %}
+                                            {% for name in usage_info.published_object_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
+                                            <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
+                                        {% else %}
+                                            {% for name in usage_info.published_object_names %}<li>{{ name }}</li>{% endfor %}
+                                        {% endif %}
+                                        {% endwith %}
+                                    </ul>
+                                </div>
+                            </span>
+                        </li>
+                        {% endif %}
+                        {% if usage_info.draft_count > 0 %}
+                        <li>
+                            <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
+                                {{ usage_info.draft_label }}
+                                <div data-w-tooltip-target="content" hidden>
+                                    <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
+                                        {% with remaining=usage_info.draft_object_names|length|add:"-8" %}
+                                        {% if remaining > 1 %}
+                                            {% for name in usage_info.draft_object_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
+                                            <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
+                                        {% else %}
+                                            {% for name in usage_info.draft_object_names %}<li>{{ name }}</li>{% endfor %}
+                                        {% endif %}
+                                        {% endwith %}
+                                    </ul>
+                                </div>
+                            </span>
+                        </li>
+                        {% endif %}
+                    </ul>
+                </div>
+                {% endif %}
+
+                <p>{{ view.confirmation_message }}</p>
+                <form action="{{ view.delete_url }}" method="POST">
+                    {% csrf_token %}
+                    <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
+                    <a href="{{ view.index_url }}" class="button button-secondary">{% trans "No, don't delete" %}</a>
+                </form>
+            {% endif %}
+        </div>
+    {% endblock %}
+{% endblock %}

--- a/templates/aplans/attribute_type_delete.html
+++ b/templates/aplans/attribute_type_delete.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n modeladmin_tags %}
+{% load i18n %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
@@ -11,39 +11,30 @@
 
     {% block content_main %}
         <div class="nice-padding">
-            {% if protected_error %}
-                <h2>{% blocktrans trimmed with view.verbose_name|capfirst as model_name %}{{ model_name }} could not be deleted{% endblocktrans %}</h2>
-                <p>{% blocktrans trimmed with instance as instance_name %}'{{ instance_name }}' is currently referenced by other objects, and cannot be deleted without jeopardising data integrity. To delete it successfully, first remove references from the following objects, then try again:{% endblocktrans %}</p>
+            {% if usage_info.has_usage %}
+            <div class="help-block help-warning">
+                {% trans "This field is currently in use. Deleting it will remove attribute values from the following objects:" %}
                 <ul>
-                    {% for obj in linked_objects %}<li><b>{{ obj|get_content_type_for_obj|title }}:</b> {{ obj }}</li>{% endfor %}
+                    {% if usage_info.published_count > 0 %}
+                        {% include "aplans/_usage_tooltip_item.html" with label=usage_info.published_label names=usage_info.published_object_names %}
+                    {% endif %}
+                    {% if usage_info.draft_count > 0 %}
+                        {% include "aplans/_usage_tooltip_item.html" with label=usage_info.draft_label names=usage_info.draft_object_names %}
+                    {% endif %}
+                    {% if usage_info.report_count > 0 %}
+                        {% trans "If you would like to keep the current value in reports even after deleting this field, please mark the reports as complete." as report_tooltip %}
+                        {% include "aplans/_usage_tooltip_item.html" with label=usage_info.report_label names=usage_info.report_names tooltip_text=report_tooltip %}
+                    {% endif %}
                 </ul>
-                <p><a href="{{ view.index_url }}" class="button">{% trans 'Go back to listing' %}</a></p>
-            {% else %}
-                {% if usage_info.has_usage %}
-                <div class="help-block help-warning">
-                    {% trans "This field is currently in use. Deleting it will remove attribute values from the following objects:" %}
-                    <ul>
-                        {% if usage_info.published_count > 0 %}
-                            {% include "aplans/_usage_tooltip_item.html" with label=usage_info.published_label names=usage_info.published_object_names %}
-                        {% endif %}
-                        {% if usage_info.draft_count > 0 %}
-                            {% include "aplans/_usage_tooltip_item.html" with label=usage_info.draft_label names=usage_info.draft_object_names %}
-                        {% endif %}
-                        {% if usage_info.report_count > 0 %}
-                            {% trans "If you would like to keep the current value in reports even after deleting this field, please mark the reports as complete." as report_tooltip %}
-                            {% include "aplans/_usage_tooltip_item.html" with label=usage_info.report_label names=usage_info.report_names tooltip_text=report_tooltip %}
-                        {% endif %}
-                    </ul>
-                </div>
-                {% endif %}
-
-                <p>{{ view.confirmation_message }}</p>
-                <form action="{{ view.delete_url }}" method="POST">
-                    {% csrf_token %}
-                    <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
-                    <a href="{{ view.index_url }}" class="button button-secondary">{% trans "No, don't delete" %}</a>
-                </form>
+            </div>
             {% endif %}
+
+            <p>{{ view.confirmation_message }}</p>
+            <form action="{{ view.delete_url }}" method="POST">
+                {% csrf_token %}
+                <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
+                <a href="{{ view.index_url }}" class="button button-secondary">{% trans "No, don't delete" %}</a>
+            </form>
         </div>
     {% endblock %}
 {% endblock %}

--- a/templates/aplans/attribute_type_delete.html
+++ b/templates/aplans/attribute_type_delete.html
@@ -24,42 +24,14 @@
                     {% trans "This field is currently in use. Deleting it will remove attribute values from the following objects:" %}
                     <ul>
                         {% if usage_info.published_count > 0 %}
-                        <li>
-                            <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
-                                {{ usage_info.published_label }}
-                                <div data-w-tooltip-target="content" hidden>
-                                    <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
-                                        {% with remaining=usage_info.published_object_names|length|add:"-8" %}
-                                        {% if remaining > 1 %}
-                                            {% for name in usage_info.published_object_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                                            <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
-                                        {% else %}
-                                            {% for name in usage_info.published_object_names %}<li>{{ name }}</li>{% endfor %}
-                                        {% endif %}
-                                        {% endwith %}
-                                    </ul>
-                                </div>
-                            </span>
-                        </li>
+                            {% include "aplans/_usage_tooltip_item.html" with label=usage_info.published_label names=usage_info.published_object_names %}
                         {% endif %}
                         {% if usage_info.draft_count > 0 %}
-                        <li>
-                            <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
-                                {{ usage_info.draft_label }}
-                                <div data-w-tooltip-target="content" hidden>
-                                    <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
-                                        {% with remaining=usage_info.draft_object_names|length|add:"-8" %}
-                                        {% if remaining > 1 %}
-                                            {% for name in usage_info.draft_object_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                                            <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
-                                        {% else %}
-                                            {% for name in usage_info.draft_object_names %}<li>{{ name }}</li>{% endfor %}
-                                        {% endif %}
-                                        {% endwith %}
-                                    </ul>
-                                </div>
-                            </span>
-                        </li>
+                            {% include "aplans/_usage_tooltip_item.html" with label=usage_info.draft_label names=usage_info.draft_object_names %}
+                        {% endif %}
+                        {% if usage_info.report_count > 0 %}
+                            {% trans "If you would like to keep the current value in reports even after deleting this field, please mark the reports as complete." as report_tooltip %}
+                            {% include "aplans/_usage_tooltip_item.html" with label=usage_info.report_label names=usage_info.report_names tooltip_text=report_tooltip %}
                         {% endif %}
                     </ul>
                 </div>

--- a/templates/aplans/panels/choice_option_usage_panel.html
+++ b/templates/aplans/panels/choice_option_usage_panel.html
@@ -2,68 +2,18 @@
 <div class="help-block help-warning">
     {% if self.has_usage %}
     {% trans "This choice option is currently in use. Changing or deleting it will affect the following objects:" %}
+    {% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." as change_tooltip %}
     <ul>
       {% if self.published_action_count > 0 %}
-      <li>
-        <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
-          {% blocktrans count published_action_count=self.published_action_count %}{{ published_action_count }} published action{% plural %}{{ published_action_count }} published actions{% endblocktrans %}
-          <div data-w-tooltip-target="content" hidden>
-            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
-              {% with remaining=self.published_action_names|length|add:"-8" %}
-              {% if remaining > 1 %}
-                {% for name in self.published_action_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
-              {% else %}
-                {% for name in self.published_action_names %}<li>{{ name }}</li>{% endfor %}
-              {% endif %}
-              {% endwith %}
-            </ul>
-            <div>{% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." %}</div>
-          </div>
-        </span>
-      </li>
+        {% include "aplans/_usage_tooltip_item.html" with label=self.published_action_label names=self.published_action_names tooltip_text=change_tooltip %}
       {% endif %}
       {% if self.draft_action_count > 0 %}
-      <li>
-        <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
-          {% blocktrans count draft_action_count=self.draft_action_count %}{{ draft_action_count }} action draft{% plural %}{{ draft_action_count }} action drafts{% endblocktrans %}
-          <div data-w-tooltip-target="content" hidden>
-            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
-              {% with remaining=self.draft_action_names|length|add:"-8" %}
-              {% if remaining > 1 %}
-                {% for name in self.draft_action_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
-              {% else %}
-                {% for name in self.draft_action_names %}<li>{{ name }}</li>{% endfor %}
-              {% endif %}
-              {% endwith %}
-            </ul>
-            <div>{% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." %}</div>
-          </div>
-        </span>
-      </li>
+        {% include "aplans/_usage_tooltip_item.html" with label=self.draft_action_label names=self.draft_action_names tooltip_text=change_tooltip %}
       {% endif %}
       {% if self.report_count > 0 %}
-      <li>
-        <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
-          {% blocktrans count report_count=self.report_count %}{{ report_count }} report{% plural %}{{ report_count }} reports{% endblocktrans %}
-          <div data-w-tooltip-target="content" hidden>
-            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
-              {% with remaining=self.report_names|length|add:"-8" %}
-              {% if remaining > 1 %}
-                {% for name in self.report_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
-              {% else %}
-                {% for name in self.report_names %}<li>{{ name }}</li>{% endfor %}
-              {% endif %}
-              {% endwith %}
-            </ul>
-            <div>{% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." %}</div>
-            <div>{% trans "If you would like to keep the current value in reports even after changing or deleting this choice option, please mark the reports using this choice option as complete." %}</div>
-            {# Technically it would be enough to mark the actions as complete for those reports, but the text is technical enough as it is. #}
-          </div>
-        </span>
-      </li>
+        {% trans "If you would like to keep the current value in reports even after changing or deleting this choice option, please mark the reports using this choice option as complete." as report_extra_tooltip %}
+        {# Technically it would be enough to mark the actions as complete for those reports, but the text is technical enough as it is. #}
+        {% include "aplans/_usage_tooltip_item.html" with label=self.report_label names=self.report_names tooltip_text=change_tooltip tooltip_text_extra=report_extra_tooltip %}
       {% endif %}
     </ul>
     {% endif %}

--- a/templates/aplans/panels/choice_option_usage_panel.html
+++ b/templates/aplans/panels/choice_option_usage_panel.html
@@ -4,11 +4,11 @@
     {% trans "This choice option is currently in use. Changing or deleting it will affect the following objects:" %}
     {% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." as change_tooltip %}
     <ul>
-      {% if self.published_action_count > 0 %}
-        {% include "aplans/_usage_tooltip_item.html" with label=self.published_action_label names=self.published_action_names tooltip_text=change_tooltip %}
+      {% if self.published_count > 0 %}
+        {% include "aplans/_usage_tooltip_item.html" with label=self.published_object_label names=self.published_object_names tooltip_text=change_tooltip %}
       {% endif %}
-      {% if self.draft_action_count > 0 %}
-        {% include "aplans/_usage_tooltip_item.html" with label=self.draft_action_label names=self.draft_action_names tooltip_text=change_tooltip %}
+      {% if self.draft_count > 0 %}
+        {% include "aplans/_usage_tooltip_item.html" with label=self.draft_object_label names=self.draft_object_names tooltip_text=change_tooltip %}
       {% endif %}
       {% if self.report_count > 0 %}
         {% trans "If you would like to keep the current value in reports even after changing or deleting this choice option, please mark the reports using this choice option as complete." as report_extra_tooltip %}

--- a/templates/aplans/panels/choice_option_usage_panel.html
+++ b/templates/aplans/panels/choice_option_usage_panel.html
@@ -1,0 +1,70 @@
+{% load i18n %}
+<div class="help-block help-warning">
+    {% if self.has_usage %}
+    {% trans "This choice option is currently in use. Changing or deleting it will affect the following objects:" %}
+    <ul>
+      {% if self.published_action_count > 0 %}
+      <li>
+        <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
+          {% blocktrans count published_action_count=self.published_action_count %}{{ published_action_count }} published action{% plural %}{{ published_action_count }} published actions{% endblocktrans %}
+          <div data-w-tooltip-target="content" hidden>
+            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
+              {% with remaining=self.published_action_names|length|add:"-8" %}
+              {% if remaining > 1 %}
+                {% for name in self.published_action_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
+                <li>{% blocktrans %}... {{ remaining }} more published actions{% endblocktrans %}</li>
+              {% else %}
+                {% for name in self.published_action_names %}<li>{{ name }}</li>{% endfor %}
+              {% endif %}
+              {% endwith %}
+            </ul>
+            <div>{% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." %}</div>
+          </div>
+        </span>
+      </li>
+      {% endif %}
+      {% if self.draft_action_count > 0 %}
+      <li>
+        <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
+          {% blocktrans count draft_action_count=self.draft_action_count %}{{ draft_action_count }} unpublished action draft{% plural %}{{ draft_action_count }} unpublished action drafts{% endblocktrans %}
+          <div data-w-tooltip-target="content" hidden>
+            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
+              {% with remaining=self.draft_action_names|length|add:"-8" %}
+              {% if remaining > 1 %}
+                {% for name in self.draft_action_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
+                <li>{% blocktrans %}... {{ remaining }} more unpublished action drafts{% endblocktrans %}</li>
+              {% else %}
+                {% for name in self.draft_action_names %}<li>{{ name }}</li>{% endfor %}
+              {% endif %}
+              {% endwith %}
+            </ul>
+            <div>{% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." %}</div>
+          </div>
+        </span>
+      </li>
+      {% endif %}
+      {% if self.report_count > 0 %}
+      <li>
+        <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
+          {% blocktrans count report_count=self.report_count %}{{ report_count }} report{% plural %}{{ report_count }} reports{% endblocktrans %}
+          <div data-w-tooltip-target="content" hidden>
+            <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
+              {% with remaining=self.report_names|length|add:"-8" %}
+              {% if remaining > 1 %}
+                {% for name in self.report_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
+                <li>{% blocktrans %}... {{ remaining }} more reports{% endblocktrans %}</li>
+              {% else %}
+                {% for name in self.report_names %}<li>{{ name }}</li>{% endfor %}
+              {% endif %}
+              {% endwith %}
+            </ul>
+            <div>{% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." %}</div>
+            <div>{% trans "If you would like to keep the current value in reports even after changing or deleting this choice option, please mark the reports using this choice option as complete." %}</div>
+            {# Technically it would be enough to mark the actions as complete for those reports, but the text is technical enough as it is. #}
+          </div>
+        </span>
+      </li>
+      {% endif %}
+    </ul>
+    {% endif %}
+</div>

--- a/templates/aplans/panels/choice_option_usage_panel.html
+++ b/templates/aplans/panels/choice_option_usage_panel.html
@@ -12,7 +12,7 @@
               {% with remaining=self.published_action_names|length|add:"-8" %}
               {% if remaining > 1 %}
                 {% for name in self.published_action_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                <li>{% blocktrans %}... {{ remaining }} more published actions{% endblocktrans %}</li>
+                <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
               {% else %}
                 {% for name in self.published_action_names %}<li>{{ name }}</li>{% endfor %}
               {% endif %}
@@ -26,13 +26,13 @@
       {% if self.draft_action_count > 0 %}
       <li>
         <span data-controller="w-tooltip" style="text-decoration: underline dotted; cursor: help;">
-          {% blocktrans count draft_action_count=self.draft_action_count %}{{ draft_action_count }} unpublished action draft{% plural %}{{ draft_action_count }} unpublished action drafts{% endblocktrans %}
+          {% blocktrans count draft_action_count=self.draft_action_count %}{{ draft_action_count }} action draft{% plural %}{{ draft_action_count }} action drafts{% endblocktrans %}
           <div data-w-tooltip-target="content" hidden>
             <ul style="margin: 0; padding-left: 1.2em; text-align: left;">
               {% with remaining=self.draft_action_names|length|add:"-8" %}
               {% if remaining > 1 %}
                 {% for name in self.draft_action_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                <li>{% blocktrans %}... {{ remaining }} more unpublished action drafts{% endblocktrans %}</li>
+                <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
               {% else %}
                 {% for name in self.draft_action_names %}<li>{{ name }}</li>{% endfor %}
               {% endif %}
@@ -52,7 +52,7 @@
               {% with remaining=self.report_names|length|add:"-8" %}
               {% if remaining > 1 %}
                 {% for name in self.report_names|slice:":8" %}<li>{{ name }}</li>{% endfor %}
-                <li>{% blocktrans %}... {{ remaining }} more reports{% endblocktrans %}</li>
+                <li>{% blocktrans context "X more objects" %}... {{ remaining }} more{% endblocktrans %}</li>
               {% else %}
                 {% for name in self.report_names %}<li>{{ name }}</li>{% endfor %}
               {% endif %}


### PR DESCRIPTION
## Description

Improves data integrity and user experience when deleting attribute types and choice options by implementing comprehensive usage tracking and warnings throughout the admin interface.

### Changes

- **Usage tracking system** - Added generic infrastructure to track where AttributeTypes and AttributeTypeChoiceOptions are used across published objects, drafts, and reports
- **Delete confirmation warnings** - Custom deletion page displays detailed usage information showing which actions/categories/reports/pledges will be affected before deletion
- **Admin panel warnings** - Choice option edit panels now show real-time warnings when options are in use, preventing accidental data loss
- **Graceful draft handling** - When choice options or attribute types used by an action draft are deleted, the draft edit view displays a warning on the top of the page, which alerts the user to the fact that some data has disappeared due to having a stale reference
- **Report compatibility** - Usage tracking includes incomplete reports with guidance to mark them as complete to preserve historical values

### Technical Details

- Introduced `AttributeTypeUsageInfo` and `ChoiceOptionUsageInfo` dataclasses for structured usage tracking
- Added `ChoiceOptionUsagePanel` as a custom Wagtail panel with real-time usage display
- Extended `ActionEditView` to display deserialization warnings for lost draft attributes
- Implemented `_get_attribute_type_usage()` and `_get_choice_option_usage()` functions for comprehensive usage tracking
- Custom delete view template (`attribute_type_delete.html`) with usage breakdown by published/draft/report objects
- Application startup check validates that all attribute value models are properly registered

### Test Coverage

- `test_attribute_type_usage_tracking.py` - 841 lines of comprehensive unit tests for AttributeType usage tracking
- `test_attribute_type_choice_option_deletion.py` - 1,004 lines covering choice option deletion scenarios, draft handling, and usage warnings

## Screenshots/Videos (if applicable)
[Video demonstrating the changes](https://github.com/user-attachments/assets/691219ed-6f78-4734-9559-0064642368cc)

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/task/1212937973495947)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
