### PR TITLE
Add templates to watched files in Django reloader

### DIFF
--- a/aplans/watchfiles_reloader.py
+++ b/aplans/watchfiles_reloader.py
@@ -37,7 +37,11 @@ class WatchfilesReloader(autoreload.BaseReloader):
         watched_files = list(self.watched_files(include_globs=False))
         watched_roots = self.watched_roots(watched_files)
         roots = autoreload.common_roots(watched_roots)
-        watcher = watchfiles.watch(*roots, watch_filter=DjangoPythonFilter())
+        # Watch Python files plus template files (HTML, Jinja2, text templates for emails)
+        watcher = watchfiles.watch(
+            *roots,
+            watch_filter=DjangoPythonFilter(extra_extensions=('html', 'jinja2', 'txt'))
+        )
         for file_changes in watcher:
             for _, path in file_changes:
                 self.notify_file_changed(Path(path))


### PR DESCRIPTION
The reloader would not detect when a template changed, causing Django to serve the old cached version of the template. This enables watching template files.