### PR TITLE
Invalidate plan cache when a pledge commitment changes

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -2245,6 +2245,7 @@ class CommitToPledgeMutation(graphene.Mutation):
                 pledge_user=pledge_user,
             ).delete()
 
+        pledge.plan.invalidate_cache()
         return CommitToPledgePayload(committed=committed)
 
 

--- a/actions/tests/test_graphql_pledge.py
+++ b/actions/tests/test_graphql_pledge.py
@@ -751,6 +751,55 @@ class TestCommitToPledgeMutation:
         assert 'errors' in response
         assert 'Pledge not found' in response['errors'][0]['message']
 
+    def test_commit_invalidates_plan_cache(self, graphql_client_query_data):
+        """Test that committing to a pledge invalidates the plan's GraphQL cache."""
+        old_cache_invalidated_at = self.plan.cache_invalidated_at
+
+        graphql_client_query_data(
+            """
+            mutation($userUuid: UUID!, $pledgeId: ID!, $committed: Boolean!) {
+              pledge {
+                commitToPledge(userUuid: $userUuid, pledgeId: $pledgeId, committed: $committed) {
+                  committed
+                }
+              }
+            }
+            """,
+            variables={
+                'userUuid': str(self.pledge_user.uuid),
+                'pledgeId': str(self.pledge.id),
+                'committed': True,
+            },
+        )
+
+        self.plan.refresh_from_db()
+        assert self.plan.cache_invalidated_at > old_cache_invalidated_at
+
+    def test_uncommit_invalidates_plan_cache(self, graphql_client_query_data):
+        """Test that uncommitting from a pledge invalidates the plan's GraphQL cache."""
+        PledgeCommitment.objects.create(pledge=self.pledge, pledge_user=self.pledge_user)
+        old_cache_invalidated_at = self.plan.cache_invalidated_at
+
+        graphql_client_query_data(
+            """
+            mutation($userUuid: UUID!, $pledgeId: ID!, $committed: Boolean!) {
+              pledge {
+                commitToPledge(userUuid: $userUuid, pledgeId: $pledgeId, committed: $committed) {
+                  committed
+                }
+              }
+            }
+            """,
+            variables={
+                'userUuid': str(self.pledge_user.uuid),
+                'pledgeId': str(self.pledge.id),
+                'committed': False,
+            },
+        )
+
+        self.plan.refresh_from_db()
+        assert self.plan.cache_invalidated_at > old_cache_invalidated_at
+
     def test_commit_when_community_engagement_disabled_returns_error(self, graphql_client_query):
         """Test that committing fails when community engagement is disabled for the plan."""
         self.plan.features.enable_community_engagement = False


### PR DESCRIPTION
## Description
The GraphQL cache was not invalidated when residents committed to or uncommitted from pledges, causing stale commitmentCount values.


## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
