### PR TITLE
Fix action task translated fields lost on revision publish

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1721,17 +1721,14 @@ else:
 class ActionRelatedModelTransModelMixin:
     @classmethod
     def from_serializable_data(cls, data: SerializableData, check_fks: bool = True, strict_fks: bool = False) -> Self | None:
-        data.pop('i18n', None)
-        kwargs = {}
         to_delete = set()
         assert hasattr(cls, '_meta')
         meta = cast('Options[Any]', cast('models.Model', cls)._meta)  # pyright: ignore[reportInvalidCast]
-        for field_name, value in data.items():
-            field = None
+        for field_name in list(data.keys()):
             try:
                 field = meta.get_field(field_name)
             except FieldDoesNotExist:
-                kwargs[field_name] = value
+                continue
             if isinstance(field, TranslatedVirtualField):
                 to_delete.add(field_name)
         for f in to_delete:


### PR DESCRIPTION
## Description
The from_serializable_data method on ActionRelatedModelTransModelMixin was stripping the i18n JSONField during deserialization.
Since Action uses DraftStateMixin + RevisionMixin, every save triggers a revision publish which round-trips through serialization, losing all translation data for ActionTask and ActionLink inline models.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://kausaltech.slack.com/archives/C05PQP9BL1F/p1771336068884939?thread_ts=1771335715.796939&cid=C05PQP9BL1F

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
