### PR TITLE
Bring back 'name' to indicator list columns

### DIFF
--- a/indicators/blocks/layout.py
+++ b/indicators/blocks/layout.py
@@ -106,6 +106,7 @@ Field = ModelFieldProperties
 
 def initialize():
     register(
+        Field(field_name='name'),
         Field(field_name='description'),
         Field(field_name='organization'),
         Field(field_name='updated_at'),
@@ -205,6 +206,7 @@ class IndicatorValueColumn(IndicatorListColumn):
 IndicatorListColumnsStream = generate_stream_block(
     name='IndicatorListColumnsStream',
     fields=(
+        'name',
         'organization',
         'level',
         ('category', IndicatorCategoryColumn()),


### PR DESCRIPTION
## Description
Commit 2ad25503252cbca85f7451abc890942c563e2ff3 inadvertently removed `name` from indicator list columns streamfield blocks, in addition to indicator details streamfield blocks. This PR brings it back from the dead.

## Screenshots/Videos (if applicable)
Situation after PR:

- When editing indicators page, `name` is available for `Indicator list columns`
<img width="529" height="336" alt="image" src="https://github.com/user-attachments/assets/be6e6e4a-d677-4de4-9ef9-158f3233e298" />

- but not for `Indicator details view`
<img width="523" height="449" alt="image" src="https://github.com/user-attachments/assets/e8054321-298d-428b-b291-43e7a31f8f72" />


## Related issue
[Asana](https://app.asana.com/1/1201243246741462/project/1206977717484257/task/1213180816046418?focus=true)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist
### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
#### Manual testing instructions
Edit indicators page of a plan, see that name block is available for stream fields when it makes sense.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [x] **Moderation** integration implemented
- [x] **Reporting** integration implemented
- [x] **Copy plan feature** integration implemented

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to StreamField configuration/field registration with minimal runtime impact beyond making `name` selectable again.
> 
> **Overview**
> Restores the Indicator `name` field as an available StreamField option by registering it in `initialize()` and adding it back into `IndicatorListColumnsStream`.
> 
> This re-enables selecting/displaying indicator names in the indicator list column configuration (and ensures the field is present in the registry for relevant contexts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77259d56aa5b86c974ab9c736dce8cc7059035c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->