### PR TITLE
Fix IndicatorValueSummaryContentBlock returning null for fieldLabel and fieldHelpText

### DIFF
--- a/indicators/blocks/layout.py
+++ b/indicators/blocks/layout.py
@@ -287,6 +287,7 @@ class IndicatorValueSummaryContentBlock(IndicatorContentBlock):
         label = _('Value summary')
 
     graphql_fields = [
+        *IndicatorContentBlock.graphql_fields,
         GraphQLBoolean('show_reference_value'),
         GraphQLInt('reference_year', required=False),
         GraphQLBoolean('show_current_value'),

--- a/indicators/tests/test_schema.py
+++ b/indicators/tests/test_schema.py
@@ -923,6 +923,39 @@ def test_indicator_query_visibility(graphql_client_query_data):
     assert data == expected
 
 
+def test_indicator_value_summary_block_field_label(plan_with_pages, graphql_client_query_data):
+    from pages.models import IndicatorListPage
+
+    page = plan_with_pages.root_page.get_children().type(IndicatorListPage).get().specific
+    page.details_main_top = [('value_summary', {
+        'field_label': 'My custom label',
+        'field_help_text': 'My custom help text',
+    })]
+    page.save()
+
+    data = graphql_client_query_data(
+        """
+        query($plan: ID!) {
+          plan(id: $plan) {
+            indicatorListPage {
+              detailsMainTop {
+                ... on IndicatorValueSummaryContentBlock {
+                  fieldLabel
+                  fieldHelpText
+                }
+              }
+            }
+          }
+        }
+        """,
+        variables=dict(plan=plan_with_pages.identifier),
+    )
+    blocks = data['plan']['indicatorListPage']['detailsMainTop']
+    assert len(blocks) == 1
+    assert blocks[0]['fieldLabel'] == 'My custom label'
+    assert blocks[0]['fieldHelpText'] == 'My custom help text'
+
+
 def test_related_indicators_visibility(graphql_client_query_data):
     plan = PlanFactory.create()
     public_indicator = IndicatorFactory.create(visibility=RestrictedVisibilityModel.VisibilityState.PUBLIC)


### PR DESCRIPTION
## Description
Fix IndicatorValueSummaryContentBlock returning null for fieldLabel and fieldHelpText
The graphql_fields list was replacing the parent class's fields instead of extending them, so the inherited field_label and field_help_text had no Grapple resolvers registered.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213188183808657

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
