### PR TITLE
Fix pledge index view crashing on search

### DIFF
--- a/actions/models/pledge.py
+++ b/actions/models/pledge.py
@@ -178,9 +178,10 @@ class Pledge(
     # Search configuration
     search_fields = [
         index.SearchField('name', boost=10),
+        index.AutocompleteField('name'),
         index.SearchField('description'),
         index.SearchField('body'),
-        index.FilterField('plan_id')
+        index.FilterField('plan_id'),
     ]
 
     class Meta:

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -234,7 +234,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
         qs = self.get_queryset()
         # Wagtail search returns PostgresSearchResults which doesn't support values_list
         if hasattr(qs, 'values_list'):
-            pledge_ids = qs.values_list('pk', flat=True)
+            pledge_ids = list(qs.values_list('pk', flat=True))
         else:
             pledge_ids = [item.pk for item in qs]
         user_data_values = (

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -202,6 +202,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
     export_headings = {
         'commitment_count': _('Number of commitments'),
     }
+    show_export_buttons = True
 
     @property
     def list_export(self) -> list[str]:
@@ -230,7 +231,12 @@ class PledgeIndexView(WatchIndexView[Pledge]):
     @cached_property
     def _user_data_keys(self) -> list[str]:
         """Discover all unique keys from user_data across commitments for the current queryset."""
-        pledge_ids = self.get_queryset().values_list('pk', flat=True)
+        qs = self.get_queryset()
+        # Wagtail search returns PostgresSearchResults which doesn't support values_list
+        if hasattr(qs, 'values_list'):
+            pledge_ids = qs.values_list('pk', flat=True)
+        else:
+            pledge_ids = [item.pk for item in qs]
         user_data_values = (
             PledgeCommitment.objects
             .filter(pledge_id__in=pledge_ids)


### PR DESCRIPTION
## Description
Fix pledge index view crashing when search is active. 
Wagtail's show_export_buttons evaluates bool(list_export) on every page render. Our dynamic list_export property queries the DB via get_queryset(), which returns PostgresSearchResults during search, crashing on values_list().
Fix by setting show_export_buttons = True to skip the evaluation on normal page render.

Also handle PostgresSearchResults in _user_data_keys as a safeguard
for the case where an export is triggered while a search is active.

Also enable partial search hits

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
