### PR TITLE
Wip/adding french locale

### DIFF
--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -552,6 +552,7 @@ LANGUAGES = (
     ('es', _('Spanish')),
     ('es-US', _('Spanish (United States)')),
     ('fi', _('Finnish')),
+    ('fr', _('French')),
     ('lv', _('Latvian')),
     ('pt', _('Portuguese')),  # Use Brazilian Portuguese only for now
     ('pt-BR', _('Portuguese (Brazil)')),
@@ -589,9 +590,10 @@ PARLER_LANGUAGES = {
         {'code': 'sv'},
         {'code': 'de'},
         {'code': 'da'},
+        {'code': 'fr'},
     ),
     'default': {
-        'fallbacks': ['en', 'fi', 'sv', 'de', 'da'],
+        'fallbacks': ['en', 'fi', 'sv', 'de', 'da','fr'],
         'hide_untranslated': False,   # the default; let .active_translations() return fallbacks too.
     },
 }
@@ -802,6 +804,13 @@ if ELASTICSEARCH_URL:
             'analyzer': {
                 'default': {
                     'type': 'spanish',
+                },
+            },
+        },
+         'fr': {
+            'analyzer': {
+                'default': {
+                    'type': 'french',
                 },
             },
         },

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -701,6 +701,7 @@ LANGUAGE_COLLATORS = {
     'es': 'es-x-icu',
     'es-US': 'es-US-x-icu',
     'fi': 'fi-FI-x-icu',
+    'fr': 'fr-x-icu',
     'lv': 'lv-LV-x-icu',
     'sv': 'sv-SE-x-icu',
     'sv-FI': 'sv-FI-x-icu',


### PR DESCRIPTION
## Description
Brief description of the changes made in this PR.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core i18n and search configuration, which can affect translation fallback behavior and Elasticsearch index/analyzer settings (may require reindexing when enabled). Change scope is small and additive but touches global settings.
> 
> **Overview**
> Adds **French (`fr`)** as a supported language across backend configuration.
> 
> Updates i18n settings (`LANGUAGES`, `PARLER_LANGUAGES` and fallbacks), adds a French Elasticsearch analyzer config for Wagtail search (`ANALYSIS_CONFIG`), and registers an ICU collator mapping for `fr` in `LANGUAGE_COLLATORS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b81e7fd561ebfc43dcc939d901d6defdf4f5a553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->