### PR TITLE
Normalize many-to-many model pks to avoid uniqueness failures

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -45,6 +45,7 @@ from aplans.utils import naturaltime
 from aplans.wagtail_utils import _get_category_fields
 
 from actions.chooser import ActionChooser
+from actions.models.action import _renormalize_pks_for_unique_constraint
 from actions.models.plan import Plan
 from admin_site.models import BuiltInFieldCustomization
 from admin_site.utils import FieldLabelRenderer
@@ -248,8 +249,8 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
         if hasattr(self.instance, 'updated_at'):
             self.instance.updated_at = timezone.now()
 
-        obj: Action = super().save(commit)
-
+        # Extract role-based formsets BEFORE calling super().save() to prevent double processing
+        role_based_formsets_by_relation = {}
         for _cls, relation_name, __, ___ in MODELS_WITH_ROLES:
             formsets = {}
             # There is a corresponding formset for a role if and only if we can edit objects of that role.
@@ -257,6 +258,13 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
                 formset = cast('dict', self.formsets).pop(f'{relation_name}_{role}', None)
                 if formset:
                     formsets[role] = formset
+            if formsets:
+                role_based_formsets_by_relation[relation_name] = (_cls, formsets)
+
+        obj: Action = super().save(commit)
+
+        # Now handle the role-based formsets with renormalization logic
+        for relation_name, (_cls, formsets) in role_based_formsets_by_relation.items():
             manager = getattr(obj, relation_name)
             original_objects = manager.get_object_list().copy()
             self.save_related_objects_with_role(manager, formsets, original_objects, commit)
@@ -285,6 +293,47 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
         for attribute_type in attribute_types:
             attribute_type.on_form_save(obj, self.cleaned_data, commit=commit)
         return obj
+
+    def _renormalize_pks_for_swaps(
+        self,
+        db_objects: list[ModelWithRole],
+        saved_objects: list[ModelWithRole],
+        wrapped_attr: str
+    ) -> None:
+        """
+        Renormalize PKs in formset objects to avoid swap conflicts.
+
+        When organizations/persons are swapped between roles, reassign PKs to ensure
+        each wrapped object (org/person) is assigned to the DB record that currently
+        has that wrapped object. This prevents IntegrityError from unique_together.
+
+        Args:
+            db_objects: List of original objects from the database
+            saved_objects: List of instances from formsets (may have swapped wrapped objects)
+            wrapped_attr: Name of the FK field ('organization' or 'person')
+
+        """
+        # Define accessors for model instances
+        def get_pk_model(item) -> int | None:
+            return item.pk
+
+        def set_pk_model(item, pk: int | None) -> None:
+            item.pk = pk
+            item.id = pk
+
+        def get_wrapped_id_model(item) -> int | None:
+            return getattr(item, f'{wrapped_attr}_id')
+
+        # Call generic renormalization (both db and target items are model instances)
+        _renormalize_pks_for_unique_constraint(
+            db_items=db_objects,
+            target_items=saved_objects,
+            get_pk_db=get_pk_model,
+            get_wrapped_id_db=get_wrapped_id_model,
+            get_pk_target=get_pk_model,
+            set_pk_target=set_pk_model,
+            get_wrapped_id_target=get_wrapped_id_model,
+        )
 
     def save_related_objects_with_role(self, manager, formsets, original_objects, commit=True):
         """
@@ -336,6 +385,19 @@ class ActionAdminForm(WagtailAdminModelForm[Action]):
         # The formsets have only been called with commit=False so far, so if we really should commit, we need to save
         # the instances with commit=True.
         if commit:
+            # Check if we need special handling for organization/person swaps
+            # wrapped_object_attr is the 4th element in MODELS_WITH_ROLES tuple
+            wrapped_attr = None
+            for _cls, _relation_name, _wrapped_model, _wrapped_attr in MODELS_WITH_ROLES:
+                if manager.model == _cls:
+                    wrapped_attr = _wrapped_attr
+                    break
+
+            # Renormalize PKs to avoid swap conflicts
+            if wrapped_attr:
+                self._renormalize_pks_for_swaps(original_objects, saved_objects, wrapped_attr)
+
+            # Now commit with renormalized PKs
             manager.commit()
 
 

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -618,8 +618,8 @@ class Action(
     def _renormalize_revision_items(
         self,
         revision: Revision[Self],
-        content_key: str,
-        wrapped_attr: str,
+        content_key: Literal['responsible_parties', 'contact_persons'],
+        wrapped_attr: Literal['organization', 'person'],
     ) -> None:
         """
         Renormalize PKs in revision content to avoid unique constraint violations.
@@ -639,7 +639,8 @@ class Action(
         db_items: Iterable[ActionResponsibleParty | ActionContactPerson]
         if content_key == 'responsible_parties':
             db_items = list(ActionResponsibleParty.objects.filter(action=self))
-        else:  # contact_persons
+        else:
+            assert content_key == 'contact_persons'
             db_items = list(ActionContactPerson.objects.filter(action=self))
 
         # Define accessors for model instances (used for db_items)

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -72,7 +72,7 @@ from .attributes import AttributeType as AttributeTypeModel, ModelWithAttributes
 from .features import PlanFeatures
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Mapping, Sequence
 
     from django.db.models.expressions import Combinable
     from django.db.models.options import Options
@@ -226,6 +226,78 @@ ACTION_FIELDS_TO_ADD_TO_REVERSION = ModelWithAttributes.REVERSION_FOLLOW + [
     'related_indicators',
     'action_category_through',
 ]
+
+
+def _renormalize_pks_for_unique_constraint(
+    db_items: list,
+    target_items: list,
+    get_pk_db: Callable[[Any], int | None],
+    get_wrapped_id_db: Callable[[Any], int | None],
+    get_pk_target: Callable[[Any], int | None],
+    set_pk_target: Callable[[Any, int | None], None],
+    get_wrapped_id_target: Callable[[Any], int | None],
+) -> None:
+    """
+    Renormalize PKs to prevent unique constraint violations during swaps.
+
+    When items with a unique constraint on (parent, wrapped_foreign_key) are being
+    swapped, this function renormalizes PKs so each item updates the DB record that
+    currently has the same wrapped_foreign_key value.
+
+    This is used for ActionContactPerson and ActionResponsibleParty objects (wrappers)
+    that wrap inside them Persons and Organizations.
+
+    Args:
+        db_items: Current database state (models or dicts)
+        target_items: Desired state to save (models or dicts) - MODIFIED IN PLACE
+        get_pk_db: Function to extract PK from a db_item
+        get_wrapped_id_db: Function to extract wrapped FK ID from a db_item
+        get_pk_target: Function to extract PK from a target_item
+        set_pk_target: Function to set PK on a target_item
+        get_wrapped_id_target: Function to extract wrapped FK ID from a target_item
+
+    Example:
+        DB:     pk=1: org_a, PRIMARY    pk=2: org_b, COLLABORATOR
+        Target: pk=1: org_b, PRIMARY    pk=2: org_a, COLLABORATOR
+        After:  pk=2: org_b, PRIMARY    pk=1: org_a, COLLABORATOR  (PKs swapped)
+
+    """
+    if not target_items:
+        return
+
+    # Build mapping: wrapped_id -> current DB pk
+    wrapped_to_pk_db = {
+        get_wrapped_id_db(item): get_pk_db(item)
+        for item in db_items
+        if get_pk_db(item) is not None
+    }
+
+    # Detect if any wrapped ID is moving to a different PK
+    needs_renormalization = False
+    for item in target_items:
+        pk = get_pk_target(item)
+        if pk is None:
+            continue
+        wrapped_id = get_wrapped_id_target(item)
+        current_pk_for_wrapped = wrapped_to_pk_db.get(wrapped_id)
+        if current_pk_for_wrapped is not None and current_pk_for_wrapped != pk:
+            needs_renormalization = True
+            break
+
+    if not needs_renormalization:
+        return
+
+    # Renormalize: assign each wrapped ID to its current DB pk
+    for item in target_items:
+        wrapped_id = get_wrapped_id_target(item)
+        if wrapped_id is None:
+            continue
+        current_pk = wrapped_to_pk_db.get(wrapped_id)
+        if current_pk is not None:
+            set_pk_target(item, current_pk)
+        else:
+            # New item being added, set pk=None for INSERT
+            set_pk_target(item, None)
 
 
 @reversion.register(follow=ACTION_FIELDS_TO_ADD_TO_REVERSION)
@@ -543,8 +615,65 @@ class Action(
             else:
                 attribute_type.commit_attribute(self, attribute_value)
 
+    def _renormalize_revision_items(
+        self,
+        revision: Revision[Self],
+        content_key: str,
+        wrapped_attr: str,
+    ) -> None:
+        """
+        Renormalize PKs in revision content to avoid unique constraint violations.
+
+        Args:
+            revision: The revision being published
+            content_key: Key in revision.content ('responsible_parties' or 'contact_persons')
+            wrapped_attr: FK field name ('organization' or 'person')
+
+        """
+        # Get items from revision content
+        revision_items = revision.content.get(content_key, [])
+        if not revision_items:
+            return
+
+        # Get current DB state
+        db_items: Iterable[ActionResponsibleParty | ActionContactPerson]
+        if content_key == 'responsible_parties':
+            db_items = list(ActionResponsibleParty.objects.filter(action=self))
+        else:  # contact_persons
+            db_items = list(ActionContactPerson.objects.filter(action=self))
+
+        # Define accessors for model instances (used for db_items)
+        def get_pk_model(item) -> int | None:
+            return item.pk
+
+        def get_wrapped_id_model(item) -> int | None:
+            return getattr(item, f'{wrapped_attr}_id')
+
+        # Define accessors for dicts (used for target_items)
+        def get_pk_dict(item: dict) -> int | None:
+            return item.get('pk')
+
+        def set_pk_dict(item: dict, pk: int | None) -> None:
+            item['pk'] = pk
+
+        def get_wrapped_id_dict(item: dict) -> int | None:
+            return item.get(wrapped_attr)
+
+        # Call generic renormalization
+        _renormalize_pks_for_unique_constraint(
+            db_items=db_items,
+            target_items=revision_items,
+            get_pk_db=get_pk_model,
+            get_wrapped_id_db=get_wrapped_id_model,
+            get_pk_target=get_pk_dict,
+            set_pk_target=set_pk_dict,
+            get_wrapped_id_target=get_wrapped_id_dict,
+        )
+
     def publish(self, revision: Revision[Self], user: User | None = None, **kwargs) -> None:  # type: ignore[override]
         attributes = revision.content.pop('attributes')
+        self._renormalize_revision_items(revision, 'responsible_parties', 'organization')
+        self._renormalize_revision_items(revision, 'contact_persons', 'person')
         super().publish(revision, user=user, **kwargs)
         self.commit_attributes(attributes, user)
 

--- a/actions/tests/test_admin.py
+++ b/actions/tests/test_admin.py
@@ -388,9 +388,6 @@ def test_action_responsible_party_swap_should_succeed(plan_admin_user, action, c
     to collaborator, org B moves from collaborator to primary), the final state has
     each organization appearing only once, so this should be a valid operation.
 
-    This test currently FAILS due to a bug where Django's ORM saves formsets sequentially,
-    causing a temporary duplicate violation of the unique_together constraint.
-    After the fix, the swap should succeed without errors.
     """
     from actions.action_admin import ActionAdmin
     from actions.models import ActionResponsibleParty
@@ -484,23 +481,25 @@ def test_action_responsible_party_swap_should_succeed(plan_admin_user, action, c
         f"org_a should now be COLLABORATOR, but has role {party_with_org_a.role}"
 
 
-def test_action_responsible_party_swap_on_publish_draft(plan, organization_factory, action_factory):
+def test_action_responsible_party_swap_on_publish_draft(plan):
     """
     Test that publishing a Wagtail draft revision with swapped responsible parties succeeds.
 
     This tests the code path where Wagtail deserializes a revision (via revision.as_object())
-    and then saves it (via Action.save()). The deserialized action will have child objects
+    and then saves it (via Action.publish()). The deserialized action will have child objects
     with existing PKs but swapped organizations, which would cause an IntegrityError without
-    the fix in Action.save().
+    the fix in Action._renormalize_revision_items().
     """
     from actions.models import ActionResponsibleParty
+    from actions.tests.factories import ActionFactory
+    from orgs.tests.factories import OrganizationFactory
 
     # Create two organizations
-    org_a = organization_factory()
-    org_b = organization_factory()
+    org_a = OrganizationFactory.create()
+    org_b = OrganizationFactory.create()
 
     # Create an action with two responsible parties in initial state
-    action = action_factory(plan=plan)
+    action = ActionFactory.create(plan=plan)
     ActionResponsibleParty.objects.create(
         action=action,
         organization=org_a,
@@ -675,7 +674,7 @@ def test_action_contact_person_swap_should_succeed(plan_admin_user, action, clie
         f"person_a should now be MODERATOR, but has role {contact_with_person_a.role}"
 
 
-def test_action_contact_person_swap_on_publish_draft(plan, person_factory, action_factory):
+def test_action_contact_person_swap_on_publish_draft(plan):
     """
     Test that publishing a Wagtail draft revision with swapped contact persons succeeds.
 
@@ -685,13 +684,15 @@ def test_action_contact_person_swap_on_publish_draft(plan, person_factory, actio
     the fix in Action._renormalize_revision_items().
     """
     from actions.models import ActionContactPerson
+    from actions.tests.factories import ActionFactory
+    from people.tests.factories import PersonFactory
 
     # Create two persons
-    person_a = person_factory()
-    person_b = person_factory()
+    person_a = PersonFactory.create()
+    person_b = PersonFactory.create()
 
     # Create an action with two contact persons in initial state
-    action = action_factory(plan=plan)
+    action = ActionFactory.create(plan=plan)
     ActionContactPerson.objects.create(
         action=action,
         person=person_a,

--- a/actions/tests/test_admin.py
+++ b/actions/tests/test_admin.py
@@ -378,3 +378,387 @@ class TestCategoryAdminButtonHelper:
 
         assert result is not None
         assert f'category_type={category_type.id}' in result['url']
+
+
+def test_action_responsible_party_swap_should_succeed(plan_admin_user, action, client):
+    """
+    Test that swapping organizations between ActionResponsibleParty instances works correctly.
+
+    When swapping organizations between different roles (e.g., org A moves from primary
+    to collaborator, org B moves from collaborator to primary), the final state has
+    each organization appearing only once, so this should be a valid operation.
+
+    This test currently FAILS due to a bug where Django's ORM saves formsets sequentially,
+    causing a temporary duplicate violation of the unique_together constraint.
+    After the fix, the swap should succeed without errors.
+    """
+    from actions.action_admin import ActionAdmin
+    from actions.models import ActionResponsibleParty
+    from actions.tests.factories import ActionResponsiblePartyFactory
+    from admin_site.tests.factories import ClientPlanFactory
+    from orgs.tests.factories import OrganizationFactory
+
+    # Setup: Create the plan's client association
+    ClientPlanFactory.create(plan=action.plan)
+
+    # Create two organizations
+    org_a = OrganizationFactory.create()
+    org_b = OrganizationFactory.create()
+
+    # Create two ActionResponsibleParty records with different organizations and roles
+    # Initial state: org_a is PRIMARY, org_b is COLLABORATOR
+    arp_primary = ActionResponsiblePartyFactory.create(
+        action=action,
+        organization=org_a,
+        role=ActionResponsibleParty.Role.PRIMARY,
+    )
+    arp_collaborator = ActionResponsiblePartyFactory.create(
+        action=action,
+        organization=org_b,
+        role=ActionResponsibleParty.Role.COLLABORATOR,
+    )
+
+    # Get the edit URL for the action
+    admin = ActionAdmin()
+    edit_url_name = admin.url_helper.get_action_url_name('edit')
+    edit_url = reverse(edit_url_name, kwargs={'instance_pk': action.pk})
+
+    # Login as plan admin
+    client.force_login(plan_admin_user)
+
+    # Construct POST data that swaps the organizations between the two roles
+    # Desired state: org_b is PRIMARY, org_a is COLLABORATOR
+    post_data = {
+        # Required action fields
+        'identifier': action.identifier,
+        'name': action.name,
+        'visibility': 'public',  # Required field
+        # Primary responsible parties formset - swap to org B
+        'responsible_parties_primary-TOTAL_FORMS': '1',
+        'responsible_parties_primary-INITIAL_FORMS': '1',
+        'responsible_parties_primary-MIN_NUM_FORMS': '0',
+        'responsible_parties_primary-MAX_NUM_FORMS': '1000',
+        'responsible_parties_primary-0-id': arp_primary.pk,
+        'responsible_parties_primary-0-organization': org_b.pk,  # Swapped from org_a
+        'responsible_parties_primary-0-ORDER': '1',
+        # Collaborator responsible parties formset - swap to org A
+        'responsible_parties_collaborator-TOTAL_FORMS': '1',
+        'responsible_parties_collaborator-INITIAL_FORMS': '1',
+        'responsible_parties_collaborator-MIN_NUM_FORMS': '0',
+        'responsible_parties_collaborator-MAX_NUM_FORMS': '1000',
+        'responsible_parties_collaborator-0-id': arp_collaborator.pk,
+        'responsible_parties_collaborator-0-organization': org_a.pk,  # Swapped from org_b
+        'responsible_parties_collaborator-0-ORDER': '1',
+        # Empty formsets for other relations (required for form validation)
+        'tasks-TOTAL_FORMS': '0',
+        'tasks-INITIAL_FORMS': '0',
+        'links-TOTAL_FORMS': '0',
+        'links-INITIAL_FORMS': '0',
+        'contact_persons_editor-TOTAL_FORMS': '0',
+        'contact_persons_editor-INITIAL_FORMS': '0',
+        'contact_persons_moderator-TOTAL_FORMS': '0',
+        'contact_persons_moderator-INITIAL_FORMS': '0',
+    }
+
+    # Execute the POST request - this should succeed with a redirect
+    response = client.post(edit_url, data=post_data)
+
+    # Verify successful save (redirect to the action list or detail page)
+    assert response.status_code == 302, f"Expected redirect, got {response.status_code}"
+
+    # Query for the responsible parties after the swap
+    # Note: The delete-recreate approach means the old PKs no longer exist,
+    # so we need to query by organization
+    responsible_parties = ActionResponsibleParty.objects.filter(action=action)
+    assert responsible_parties.count() == 2, "Should have exactly 2 responsible parties"
+
+    # Find the parties by organization
+    party_with_org_a = responsible_parties.get(organization=org_a)
+    party_with_org_b = responsible_parties.get(organization=org_b)
+
+    # Verify the organizations have been swapped to the correct roles
+    assert party_with_org_b.role == ActionResponsibleParty.Role.PRIMARY, \
+        f"org_b should now be PRIMARY, but has role {party_with_org_b.role}"
+
+    assert party_with_org_a.role == ActionResponsibleParty.Role.COLLABORATOR, \
+        f"org_a should now be COLLABORATOR, but has role {party_with_org_a.role}"
+
+
+def test_action_responsible_party_swap_on_publish_draft(plan, organization_factory, action_factory):
+    """
+    Test that publishing a Wagtail draft revision with swapped responsible parties succeeds.
+
+    This tests the code path where Wagtail deserializes a revision (via revision.as_object())
+    and then saves it (via Action.save()). The deserialized action will have child objects
+    with existing PKs but swapped organizations, which would cause an IntegrityError without
+    the fix in Action.save().
+    """
+    from actions.models import ActionResponsibleParty
+
+    # Create two organizations
+    org_a = organization_factory()
+    org_b = organization_factory()
+
+    # Create an action with two responsible parties in initial state
+    action = action_factory(plan=plan)
+    ActionResponsibleParty.objects.create(
+        action=action,
+        organization=org_a,
+        role=ActionResponsibleParty.Role.PRIMARY,
+        order=0,
+    )
+    ActionResponsibleParty.objects.create(
+        action=action,
+        organization=org_b,
+        role=ActionResponsibleParty.Role.COLLABORATOR,
+        order=1,
+    )
+
+    # Create an initial revision (don't publish yet - we'll test publishing the swapped one)
+    initial_revision = action.save_revision()
+
+    # Now manually create a revision with swapped responsible parties
+    # Get the revision content and modify it to have the swap
+    # Note: Use initial_revision.content (dict) not content_json (string)
+    revision_content = initial_revision.content.copy()
+
+    # Ensure attributes key exists (required by Action.publish())
+    # This is needed because Action.publish() expects it
+    if 'attributes' not in revision_content:
+        revision_content['attributes'] = {}
+
+    # Find the responsible_parties in the revision content
+    # The structure is: revision_content['responsible_parties'] = [list of dicts]
+    # Each dict has keys: 'pk', 'order', 'action', 'organization', 'role', 'specifier'
+    responsible_parties = revision_content.get('responsible_parties', [])
+
+    # Swap the organizations while keeping the PKs
+    for rp in responsible_parties:
+        if rp.get('organization') == org_a.pk:
+            # This was org_a (PRIMARY), swap to org_b
+            rp['organization'] = org_b.pk
+        elif rp.get('organization') == org_b.pk:
+            # This was org_b (COLLABORATOR), swap to org_a
+            rp['organization'] = org_a.pk
+
+    # Create a new revision with the swapped content
+    from wagtail.models import Revision
+    swapped_revision: Revision = Revision(
+        content_type=initial_revision.content_type,
+        base_content_type=initial_revision.base_content_type,
+        object_id=action.pk,
+    )
+    swapped_revision.content = revision_content
+    swapped_revision.save()
+
+    # Verify current published state is still the original (before swap)
+    action.refresh_from_db()
+    parties_before = ActionResponsibleParty.objects.filter(action=action)
+    assert parties_before.count() == 2
+    assert parties_before.get(organization=org_a).role == ActionResponsibleParty.Role.PRIMARY
+    assert parties_before.get(organization=org_b).role == ActionResponsibleParty.Role.COLLABORATOR
+
+    # Now publish the revision with swapped responsible parties
+    # This should NOT raise IntegrityError
+    swapped_revision.publish()
+
+    # Verify the swap was applied successfully
+    action.refresh_from_db()
+    parties_after = ActionResponsibleParty.objects.filter(action=action)
+    assert parties_after.count() == 2
+
+    party_a_after = parties_after.get(organization=org_a)
+    party_b_after = parties_after.get(organization=org_b)
+
+    # Verify the organizations have been swapped to the correct roles
+    assert party_b_after.role == ActionResponsibleParty.Role.PRIMARY
+    assert party_a_after.role == ActionResponsibleParty.Role.COLLABORATOR
+
+
+def test_action_contact_person_swap_should_succeed(plan_admin_user, action, client):
+    """
+    Test that swapping persons between ActionContactPerson instances works correctly.
+
+    When swapping persons between different roles (e.g., person A moves from editor
+    to moderator, person B moves from moderator to editor), the final state has
+    each person appearing only once, so this should be a valid operation.
+
+    This tests the renormalization logic in ActionAdminForm._renormalize_pks_for_swaps().
+    """
+    from actions.action_admin import ActionAdmin
+    from actions.models import ActionContactPerson
+    from actions.tests.factories import ActionContactFactory
+    from admin_site.tests.factories import ClientPlanFactory
+    from people.tests.factories import PersonFactory
+
+    # Setup: Create the plan's client association
+    ClientPlanFactory.create(plan=action.plan)
+
+    # Create two persons
+    person_a = PersonFactory.create()
+    person_b = PersonFactory.create()
+
+    # Create two ActionContactPerson records with different persons and roles
+    # Initial state: person_a is EDITOR, person_b is MODERATOR
+    acp_editor = ActionContactFactory.create(
+        action=action,
+        person=person_a,
+        role=ActionContactPerson.Role.EDITOR,
+    )
+    acp_moderator = ActionContactFactory.create(
+        action=action,
+        person=person_b,
+        role=ActionContactPerson.Role.MODERATOR,
+    )
+
+    # Get the edit URL for the action
+    admin = ActionAdmin()
+    edit_url_name = admin.url_helper.get_action_url_name('edit')
+    edit_url = reverse(edit_url_name, kwargs={'instance_pk': action.pk})
+
+    # Login as plan admin
+    client.force_login(plan_admin_user)
+
+    # Construct POST data that swaps the persons between the two roles
+    # Desired state: person_b is EDITOR, person_a is MODERATOR
+    post_data = {
+        # Required action fields
+        'identifier': action.identifier,
+        'name': action.name,
+        'visibility': 'public',  # Required field
+        # Editor contact persons formset - swap to person B
+        'contact_persons_editor-TOTAL_FORMS': '1',
+        'contact_persons_editor-INITIAL_FORMS': '1',
+        'contact_persons_editor-MIN_NUM_FORMS': '0',
+        'contact_persons_editor-MAX_NUM_FORMS': '1000',
+        'contact_persons_editor-0-id': acp_editor.pk,
+        'contact_persons_editor-0-person': person_b.pk,  # Swapped from person_a
+        'contact_persons_editor-0-ORDER': '1',
+        # Moderator contact persons formset - swap to person A
+        'contact_persons_moderator-TOTAL_FORMS': '1',
+        'contact_persons_moderator-INITIAL_FORMS': '1',
+        'contact_persons_moderator-MIN_NUM_FORMS': '0',
+        'contact_persons_moderator-MAX_NUM_FORMS': '1000',
+        'contact_persons_moderator-0-id': acp_moderator.pk,
+        'contact_persons_moderator-0-person': person_a.pk,  # Swapped from person_b
+        'contact_persons_moderator-0-ORDER': '1',
+        # Empty formsets for other relations (required for form validation)
+        'tasks-TOTAL_FORMS': '0',
+        'tasks-INITIAL_FORMS': '0',
+        'links-TOTAL_FORMS': '0',
+        'links-INITIAL_FORMS': '0',
+        'responsible_parties_primary-TOTAL_FORMS': '0',
+        'responsible_parties_primary-INITIAL_FORMS': '0',
+        'responsible_parties_collaborator-TOTAL_FORMS': '0',
+        'responsible_parties_collaborator-INITIAL_FORMS': '0',
+    }
+
+    # Execute the POST request - this should succeed with a redirect
+    response = client.post(edit_url, data=post_data)
+
+    # Verify successful save (redirect to the action list or detail page)
+    assert response.status_code == 302, f"Expected redirect, got {response.status_code}"
+
+    # Query for the contact persons after the swap
+    contact_persons = ActionContactPerson.objects.filter(action=action)
+    assert contact_persons.count() == 2, "Should have exactly 2 contact persons"
+
+    # Find the contacts by person
+    contact_with_person_a = contact_persons.get(person=person_a)
+    contact_with_person_b = contact_persons.get(person=person_b)
+
+    # Verify the persons have been swapped to the correct roles
+    assert contact_with_person_b.role == ActionContactPerson.Role.EDITOR, \
+        f"person_b should now be EDITOR, but has role {contact_with_person_b.role}"
+
+    assert contact_with_person_a.role == ActionContactPerson.Role.MODERATOR, \
+        f"person_a should now be MODERATOR, but has role {contact_with_person_a.role}"
+
+
+def test_action_contact_person_swap_on_publish_draft(plan, person_factory, action_factory):
+    """
+    Test that publishing a Wagtail draft revision with swapped contact persons succeeds.
+
+    This tests the code path where Wagtail deserializes a revision (via revision.as_object())
+    and then publishes it (via Action.publish()). The deserialized action will have child objects
+    with existing PKs but swapped persons, which would cause an IntegrityError without
+    the fix in Action._renormalize_revision_items().
+    """
+    from actions.models import ActionContactPerson
+
+    # Create two persons
+    person_a = person_factory()
+    person_b = person_factory()
+
+    # Create an action with two contact persons in initial state
+    action = action_factory(plan=plan)
+    ActionContactPerson.objects.create(
+        action=action,
+        person=person_a,
+        role=ActionContactPerson.Role.EDITOR,
+        order=0,
+    )
+    ActionContactPerson.objects.create(
+        action=action,
+        person=person_b,
+        role=ActionContactPerson.Role.MODERATOR,
+        order=1,
+    )
+
+    # Create an initial revision (don't publish yet - we'll test publishing the swapped one)
+    initial_revision = action.save_revision()
+
+    # Now manually create a revision with swapped contact persons
+    # Get the revision content and modify it to have the swap
+    revision_content = initial_revision.content.copy()
+
+    # Ensure attributes key exists (required by Action.publish())
+    if 'attributes' not in revision_content:
+        revision_content['attributes'] = {}
+
+    # Find the contact_persons in the revision content
+    # The structure is: revision_content['contact_persons'] = [list of dicts]
+    # Each dict has keys: 'pk', 'order', 'action', 'person', 'role', 'primary_contact'
+    contact_persons = revision_content.get('contact_persons', [])
+
+    # Swap the persons while keeping the PKs
+    for cp in contact_persons:
+        if cp.get('person') == person_a.pk:
+            # This was person_a (EDITOR), swap to person_b
+            cp['person'] = person_b.pk
+        elif cp.get('person') == person_b.pk:
+            # This was person_b (MODERATOR), swap to person_a
+            cp['person'] = person_a.pk
+
+    # Create a new revision with the swapped content
+    from wagtail.models import Revision
+    swapped_revision: Revision = Revision(
+        content_type=initial_revision.content_type,
+        base_content_type=initial_revision.base_content_type,
+        object_id=action.pk,
+    )
+    swapped_revision.content = revision_content
+    swapped_revision.save()
+
+    # Verify current published state is still the original (before swap)
+    action.refresh_from_db()
+    contacts_before = ActionContactPerson.objects.filter(action=action)
+    assert contacts_before.count() == 2
+    assert contacts_before.get(person=person_a).role == ActionContactPerson.Role.EDITOR
+    assert contacts_before.get(person=person_b).role == ActionContactPerson.Role.MODERATOR
+
+    # Now publish the revision with swapped contact persons
+    # This should NOT raise IntegrityError
+    swapped_revision.publish()
+
+    # Verify the swap was applied successfully
+    action.refresh_from_db()
+    contacts_after = ActionContactPerson.objects.filter(action=action)
+    assert contacts_after.count() == 2
+
+    contact_a_after = contacts_after.get(person=person_a)
+    contact_b_after = contacts_after.get(person=person_b)
+
+    # Verify the persons have been swapped to the correct roles
+    assert contact_b_after.role == ActionContactPerson.Role.EDITOR
+    assert contact_a_after.role == ActionContactPerson.Role.MODERATOR


### PR DESCRIPTION
ActionContactPersons and ActionResponsibleParties sometimes get edited so that their contents get swapped and therefore their pks get swapped. This results in uniqueness failures in the clusterablemodel code since it results in a situation where the same wrapped object (person or organization) suddenly gets a new wrapper pk while the old wrapper instance is still in the db. This is due to how clusterablemodel handles changes in steps.

In practice this mostly occurs when a user changes the contents of the inline fieldpanels in the Action edit form so that the contents of the panels get swapped (the organization from the second item is moved to the first item and vice versa). This still keeps the old pks of the wrapping objects (the ManyToMany relations such as ActionResponsibleParty) intact. But if an ActionResponsibleParty pk wrapping an Organization changes, due to the fact that clusterablemodel changes these one-by-one in a loop, there comes a point where the organization, action combination exists already in the db when trying to insert it into the new place.

## Description
Before publishing an action revision, or saving an action from the form, this code makes sure the pks already existing in the db, corresponding to the organizations / people, are reused even though the role might change.

## Screenshots/Videos (if applicable)
N/A

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/14046/events/6a37717366c34c9896ffe93bddbd850a/?project=3&referrer=event-or-group-header

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A
------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If you want, you can try to manually go to an action with two different orgs in primary responsible party and collaborator  and swap the organizations around. No crash anymore.
### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
