### PR TITLE
Plan copying improvements

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -5,7 +5,7 @@ import re
 import zoneinfo
 from datetime import UTC, datetime, timedelta
 from functools import cache
-from typing import TYPE_CHECKING, ClassVar, Self, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 from urllib.parse import urlparse
 
 import reversion
@@ -18,7 +18,7 @@ from django.core import management
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator, URLValidator
 from django.db import models, transaction
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.db.models.aggregates import Max
 from django.db.models.functions import Cast, Length, Substr
 from django.utils import timezone, translation
@@ -1071,6 +1071,13 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel):  # ty
         visible_indicators = Indicator.objects.qs.filter(levels__in=visible_levels)
         return RelatedIndicator.objects.filter(Q(causal_indicator__in=visible_indicators) &
                                                Q(effect_indicator__in=visible_indicators)).exists()
+
+    def shared_indicators(self) -> models.QuerySet[IndicatorLevel, dict[str, Any]]:
+        """Return the indicators of this plan that are also linked to some other plan."""
+        return (
+            IndicatorLevel.objects.filter(indicator__in=self.indicators.all())
+            .values('indicator').annotate(num_plans=Count('plan')).filter(num_plans__gt=1)
+        )
 
     def default_identifier_for_copying(self) -> str:
         """Get an identifier a copy of this plan should have by default."""

--- a/copying/main.py
+++ b/copying/main.py
@@ -25,7 +25,7 @@ from wagtail.models.media import Collection
 from wagtail.models.reference_index import ReferenceIndex
 
 from loguru import logger
-from relations_iterator import AbstractVisitor, ConfigurableRelationTree, RelationTreeIterator, TreeNode, clone  # type: ignore
+from relations_iterator import AbstractVisitor, ConfigurableRelationTree, RelationTreeIterator, TreeNode  # type: ignore
 
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
@@ -833,9 +833,9 @@ def copy_collection_with_contents(collection: Collection, clone_visitor: CloneVi
         AplansImage.objects.filter(collection_id=collection.pk),
         AplansDocument.objects.filter(collection_id=collection.pk),
     )
-    clone(collection, {}, clone_visitor)
+    visit_tree(collection, {}, clone_visitor)
     for image_or_document in images_or_documents:
-        clone(image_or_document, {}, clone_visitor)
+        visit_tree(image_or_document, {}, clone_visitor)
         image_or_document.collection = collection
         file = image_or_document.file
         try:
@@ -952,12 +952,12 @@ def _clone_plan_objects(
 
     Returns the copy of the plan.
     """
-    # Work on fresh `Plan` objects because `clone` changes its first argument. We just want to get stuff into the
-    # visitor's copy cache (and the DB of course).
+    # Work on fresh `Plan` objects because `visit_tree` changes its first argument. We just want to get stuff into
+    # the visitor's copy cache (and the DB of course).
     root_collection = Plan.objects.get(pk=plan.pk).root_collection
     if root_collection:
         copy_collection_with_contents(root_collection, clone_visitor)
-    clone(Plan.objects.get(pk=plan.pk).site, {}, clone_visitor)
+    visit_tree(Plan.objects.get(pk=plan.pk).site, {}, clone_visitor)
     assert plan.site
     assert isinstance(plan.site.root_page.specific, PlanRootPage)
     root_page_copies = copy_root_pages(
@@ -980,7 +980,7 @@ def _clone_plan_objects(
             signals.post_save, create_site_general_content, Plan, 'create_site_general_content'
         ))
         # We leave the signal update_plan_domain_deploy_info enabled
-        clone(plan_copy, PLAN_CLONE_STRUCTURE, clone_visitor)
+        visit_tree(plan_copy, PLAN_CLONE_STRUCTURE, clone_visitor)
 
     # Copy documentation page hierarchy
     for documentation_root_page in plan.documentation_root_pages.all():
@@ -1004,7 +1004,7 @@ def _clone_plan_objects(
         | (Q(scope_content_type=category_type_ct) & Q(scope_id__in=plan.category_types.all()))
     ))
     for at in attribute_types:
-        clone(at, ATTRIBUTE_TYPE_CLONE_STRUCTURE, clone_visitor)
+        visit_tree(at, ATTRIBUTE_TYPE_CLONE_STRUCTURE, clone_visitor)
 
     # Update root page (`plan_copy.site` should now be the site copy)
     assert plan_copy.site
@@ -1020,9 +1020,9 @@ def _clone_plan_objects(
     if copy_indicators:
         indicators = list(plan.indicators.all())
         for indicator in indicators:
-            clone(indicator, INDICATOR_CLONE_STRUCTURE, clone_visitor)
+            visit_tree(indicator, INDICATOR_CLONE_STRUCTURE, clone_visitor)
         for dimension in Dimension.objects.filter(id__in=plan.dimensions.values_list('dimension_id')):
-            clone(dimension, DIMENSION_CLONE_STRUCTURE, clone_visitor)
+            visit_tree(dimension, DIMENSION_CLONE_STRUCTURE, clone_visitor)
     else:
         indicators = []
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -765,7 +765,7 @@ def copy_root_pages(
     assert root_page_copy.translation_key != root_page.translation_key
     # When copying the translations of `root_page`, reuse this translation key
     for page in root_page.get_translations():
-        assert isinstance(page, PlanRootPage)
+        assert isinstance(page, (PlanRootPage, DocumentationRootPage))
         update_attrs = {
             'translation_key': new_translation_key,
             'title': page.title + title_suffix,

--- a/copying/main.py
+++ b/copying/main.py
@@ -466,6 +466,12 @@ class UpdateReferencesVisitor(AbstractVisitor):
     def _(self, instance: Plan) -> Generator[Field | GenericForeignKey]:
         return self._get_references(instance, exclude_fields=['copy_of'])
 
+    @get_references.register
+    def _(self, instance: Page) -> Generator[Field | GenericForeignKey]:
+        # Pages are copied via Wagtail's Page.copy(), which handles page_ptr, latest_revision, and live_revision
+        # internally. These objects are not registered in the clone visitor, so skip them to avoid spurious warnings.
+        return self._get_references(instance, exclude_fields=['page_ptr', 'latest_revision', 'live_revision'])
+
     def update_extractable_references(self, instance: Model) -> bool:
         updated = False
         for field in instance._meta.get_fields():

--- a/copying/main.py
+++ b/copying/main.py
@@ -604,6 +604,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
             # propagate changes to its value to the StreamField's value.
             field_name, *content_path_rest = content_path.split('.')
             assert field_name == source_field.name
+            # Make sure we only update copies
+            assert self.clone_visitor.is_copy(from_object)
             update_streamfield_block(from_object, field_name, content_path_rest, to_object, copy)
             return True
 
@@ -630,6 +632,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
             # Create `from_object._cluster_related_objects`
             manager.get_object_list()  # type: ignore[attr-defined]
             referencing_object = manager.get(id=id)
+            # Make sure we only update copies
+            assert self.clone_visitor.is_copy(referencing_object)
             child_field_name, *child_content_path = content_path_rest
             child_field = referencing_object._meta.get_field(child_field_name)
             if isinstance(child_field, StreamField):
@@ -659,6 +663,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
             field_name, *content_path_rest = content_path.split('.')
             assert field_name == source_field.name
             assert content_path_rest == ['']
+            # Make sure we only update copies
+            assert self.clone_visitor.is_copy(from_object)
             update_rich_text_reference_in_field(
                 instance=from_object,
                 field_name=field_name,

--- a/copying/main.py
+++ b/copying/main.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Callable, Generator, Iterable
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from copy import copy as shallow_copy
 from functools import singledispatchmethod, wraps
 from itertools import chain
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import wagtail.signal_handlers
@@ -56,9 +56,6 @@ from users.models import User
 if TYPE_CHECKING:
     from wagtail.documents.models import AbstractDocument
     from wagtail.images.models import AbstractImage
-
-P = ParamSpec('P')
-R = TypeVar('R')
 
 type CloneStructure = dict[str, CloneStructure]
 
@@ -855,27 +852,33 @@ def _new_site_hostname(old_plan: Plan, new_plan_identifier: str) -> str:
     return new_site_hostname
 
 
-def update_reference_index_immediately(f: Callable[P, R]) -> Callable[P, R]:
+@contextmanager
+def _update_reference_index_immediately_ctx() -> Generator[None]:
     """
-    Force immediate update of Wagtail's reference index when saving model instances within a call to `f`.
+    Force immediate update of Wagtail's reference index for the duration of this context.
 
     When a model instance is saved, Wagtail enqueues a task to update the reference index. By default, this task is
     executed when the current transaction is committed. This may cause problems if the code within the transaction not
     only saves some model instances but also relies on the reference index being kept up to date before the transaction
     ends.
 
-    When this decorator is used on a function `f`, this behavior is changed during the call to `f` in such a way that
-    the reference index is updated immediately when a model instance is saved.
+    Within this context, the reference index is updated immediately when a model instance is saved.
     """
+    original_task = wagtail.signal_handlers.update_reference_index_task  # type: ignore[attr-defined]
+    tmp_task = dataclasses.replace(original_task, enqueue_on_commit=False)
+    wagtail.signal_handlers.update_reference_index_task = tmp_task  # type: ignore[attr-defined]
+    try:
+        yield
+    finally:
+        wagtail.signal_handlers.update_reference_index_task = original_task  # type: ignore[attr-defined]
+
+
+def update_reference_index_immediately[**P, R](f: Callable[P, R]) -> Callable[P, R]:
+    """Force immediate reference index updates within a call to `f`."""
     @wraps(f)
-    def wrapped(*args, **kwargs) -> R:
-        original_task = wagtail.signal_handlers.update_reference_index_task  # type: ignore[attr-defined]
-        tmp_task = dataclasses.replace(original_task, enqueue_on_commit=False)
-        try:
-            wagtail.signal_handlers.update_reference_index_task = tmp_task  # type: ignore[attr-defined]
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        with _update_reference_index_immediately_ctx():
             return f(*args, **kwargs)
-        finally:
-            wagtail.signal_handlers.update_reference_index_task = original_task  # type: ignore[attr-defined]
 
     return wrapped
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -169,6 +169,11 @@ MODELS_NOT_COPIED = [
 ]
 
 
+def _is_excluded_model(model: type[Model]) -> bool:
+    """Return True if the model is deliberately excluded from plan copying."""
+    return model in MODELS_NOT_COPIED
+
+
 class CloneVisitor(AbstractVisitor):
     """Visit a tree node and create a copy of its instance, keeping track of which copy belongs to which instance."""
 
@@ -448,7 +453,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
         if exclude_fields is None:
             exclude_fields = []
         for fk in get_foreign_keys(instance):
-            if fk.name not in exclude_fields and fk.related_model not in MODELS_NOT_COPIED:
+            if fk.name not in exclude_fields and not _is_excluded_model(fk.related_model):
                 yield fk
         for gfk in get_generic_foreign_keys(instance):
             if gfk.name not in exclude_fields:
@@ -552,7 +557,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
             assert hasattr(fk, 'name')
             related_object = getattr(instance, fk.name)
             if related_object:
-                if related_object._meta.model in MODELS_NOT_COPIED:
+                if _is_excluded_model(related_object._meta.model):
                     continue
                 try:
                     copy = self.clone_visitor.get_copy(related_object)
@@ -584,7 +589,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
         Returns true if and only if the instance was updated.
         """
 
-        if to_object._meta.model in MODELS_NOT_COPIED:
+        if _is_excluded_model(to_object._meta.model):
             return False
 
         try:

--- a/copying/main.py
+++ b/copying/main.py
@@ -102,10 +102,7 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     'plan_common_category_types_through': {},
     'plan_related_organizations_through': {},
     'public_site_viewers': {},
-    # Do not copy report types because they contain attribute type
-    # references in the streamfield json which are not handled properly
-    # at the moment
-    #'report_types': {
+    'report_types': {
         # Deliberately don't copy reports because (a) the contained action snapshots refer to instances from the
         # original plan within the serialized data, and (b) it might be justifiable for many use cases to skip copying
         # reports. We could do something about (a) by meddling with the serialized data, but it's going to be an
@@ -113,7 +110,7 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
         # 'reports': {
         #     'action_snapshots': {},  # As we don't copy `action_version`, original action will be linked to snapshot
         # },
-    #},
+    },
     'scenarios': {},
     # Note that `Dimension` instances are copied separately when `copy_indicators` is true.
     'dimensions': {},  # copies through model (`PlanDimension`) instances, not `Dimension` instances

--- a/copying/main.py
+++ b/copying/main.py
@@ -15,7 +15,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db import transaction
-from django.db.models import Count, Field, ForeignKey, Manager, ManyToOneRel, Model, Q, signals
+from django.db.models import Field, ForeignKey, Manager, ManyToOneRel, Model, Q, signals
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
 from wagtail.fields import RichTextField, StreamField
@@ -46,7 +46,7 @@ from documents.models import AplansDocument
 from images.models import AplansImage
 from indicators.models.common_indicator import CommonIndicator
 from indicators.models.dimensions import Dimension
-from indicators.models.indicator import Indicator, IndicatorLevel
+from indicators.models.indicator import Indicator
 from indicators.models.metadata import Quantity, Unit
 from orgs.models import Organization
 from pages.models import PlanRootPage
@@ -450,7 +450,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
         if exclude_fields is None:
             exclude_fields = []
         for fk in get_foreign_keys(instance):
-            if fk.name not in exclude_fields and not _is_excluded_model(fk.related_model):
+            if fk.name not in exclude_fields and isinstance(fk.related_model, type) and not _is_excluded_model(fk.related_model):
                 yield fk
         for gfk in get_generic_foreign_keys(instance):
             if gfk.name not in exclude_fields:
@@ -811,6 +811,8 @@ def _copy_instance_revision(
     instance: RevisionMixin, clone_visitor: CloneVisitor, update_references_visitor: UpdateReferencesVisitor,
 ) -> None:
     try:
+        if instance.latest_revision is None:
+            return
         rev_obj = instance.latest_revision.as_object()
     except Exception as exc:
         # Some non-ClusterableModel models with i18n fields that reference FKs
@@ -828,9 +830,9 @@ def _copy_instance_revision(
     # as_object() sets pk from the revision's content_object (the original), so fix it to the copy's pk
     rev_obj.pk = instance.pk
     if hasattr(rev_obj, 'uuid'):
-        rev_obj.uuid = instance.uuid
+        rev_obj.uuid = instance.uuid  # type: ignore[attr-defined]
     if hasattr(rev_obj, 'copy_of'):
-        rev_obj.copy_of = instance.copy_of
+        rev_obj.copy_of = instance.copy_of  # type: ignore[attr-defined]
     # Update but don't save `rev_obj`. (Otherwise we'd overwrite published instances with drafts. We just want to
     # create a revision out of `rev_obj` and save that.)
     update_references_visitor.update_instance(rev_obj, save=False)
@@ -996,11 +998,12 @@ def _copy_collection_site_and_pages(
     root_collection = Plan.objects.get(pk=plan.pk).root_collection
     if root_collection:
         copy_collection_with_contents(root_collection, clone_visitor)
-    visit_tree(Plan.objects.get(pk=plan.pk).site, {}, clone_visitor)
-    assert plan.site
-    assert isinstance(plan.site.root_page.specific, PlanRootPage)
+    site = Plan.objects.get(pk=plan.pk).site
+    assert site
+    visit_tree(site, {}, clone_visitor)
+    assert isinstance(site.root_page.specific, PlanRootPage)
     root_page_copies = copy_root_pages(
-        root_page=plan.site.root_page.specific,
+        root_page=site.root_page.specific,
         title_suffix=root_page_title_suffix,
     )
     for original_root, root_copy in root_page_copies:

--- a/copying/main.py
+++ b/copying/main.py
@@ -944,16 +944,16 @@ def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, new_site_host
         raise ValueError("Cannot copy indicators as some are instances of a common indicator")
 
 
-def _clone_plan_objects(
+def _copy_collection_site_and_pages(
     plan: Plan,
     clone_visitor: CloneVisitor,
     root_page_title_suffix: str | None,
-    copy_indicators: bool,
-) -> Plan:
+) -> tuple[Plan, Page]:
     """
-    Perform the actual cloning of all plan objects within a transaction.
+    Copy the collection, site, and plan root pages.
 
-    Returns the copy of the plan.
+    Returns a (plan_copy, root_page_copy) tuple where plan_copy is a fresh Plan instance
+    with the original plan's PK (not yet cloned itself) and root_page_copy is the copied root page.
     """
     # Work on fresh `Plan` objects because `visit_tree` changes its first argument. We just want to get stuff into
     # the visitor's copy cache (and the DB of course).
@@ -973,8 +973,11 @@ def _clone_plan_objects(
     plan_copy = Plan.objects.get(pk=plan.pk)
     # Hack to avoid site (and root page) initialization in Plan.save()  # noqa: FIX004
     plan_copy._site_created = True
+    return plan_copy, root_page_copy
 
-    # Copy plan
+
+def _copy_plan_with_structure(plan_copy: Plan, clone_visitor: CloneVisitor) -> None:
+    """Copy the plan and all related objects defined in PLAN_CLONE_STRUCTURE, with signals temporarily disabled."""
     with ExitStack() as stack:
         # Disconnect signals to prevent creating related model instances when saving the plan
         stack.enter_context(temp_disconnect_signal(signals.post_save, create_notification_settings, Plan))
@@ -985,7 +988,14 @@ def _clone_plan_objects(
         # We leave the signal update_plan_domain_deploy_info enabled
         visit_tree(plan_copy, PLAN_CLONE_STRUCTURE, clone_visitor)
 
-    # Copy documentation page hierarchy
+
+def _copy_documentation_pages(
+    plan: Plan,
+    plan_copy: Plan,
+    root_page_title_suffix: str | None,
+    clone_visitor: CloneVisitor,
+) -> None:
+    """Copy all documentation page hierarchies and link them to the plan copy."""
     for documentation_root_page in plan.documentation_root_pages.all():
         doc_page_copies = copy_root_pages(
             root_page=documentation_root_page,
@@ -998,16 +1008,51 @@ def _clone_plan_objects(
         doc_root_page_copy.plan = plan_copy
         doc_root_page_copy.save(update_fields=['plan'])
 
-    # Attribute types use generic foreign keys, so we need to copy them ourselves
+
+def _copy_attribute_types(plan: Plan, clone_visitor: CloneVisitor) -> list[AttributeType]:
+    """
+    Copy all attribute types scoped to the plan or its category types.
+
+    Attribute types use generic foreign keys, so we need to copy them separately rather than through the
+    relation tree. Returns the list of original attribute type instances (not the copies).
+    """
     plan_ct = ContentType.objects.get_for_model(Plan)
     category_type_ct = ContentType.objects.get_for_model(CategoryType)
-    # Materialize attribute types in list because we'll update them in place
+    # Materialize in a list because we'll update them in place
     attribute_types = list(AttributeType.objects.filter(
         (Q(scope_content_type=plan_ct) & Q(scope_id=plan.id))
         | (Q(scope_content_type=category_type_ct) & Q(scope_id__in=plan.category_types.all()))
     ))
     for at in attribute_types:
         visit_tree(at, ATTRIBUTE_TYPE_CLONE_STRUCTURE, clone_visitor)
+    return attribute_types
+
+
+def _copy_indicators(plan: Plan, clone_visitor: CloneVisitor) -> list[Indicator]:
+    """Copy all indicators and dimensions of the plan. Returns the list of copied indicator instances."""
+    indicators = list(plan.indicators.all())
+    for indicator in indicators:
+        visit_tree(indicator, INDICATOR_CLONE_STRUCTURE, clone_visitor)
+    for dimension in Dimension.objects.filter(id__in=plan.dimensions.values_list('dimension_id')):
+        visit_tree(dimension, DIMENSION_CLONE_STRUCTURE, clone_visitor)
+    return indicators
+
+
+def _clone_plan_objects(
+    plan: Plan,
+    clone_visitor: CloneVisitor,
+    root_page_title_suffix: str | None,
+    copy_indicators: bool,
+) -> Plan:
+    """
+    Perform the actual cloning of all plan objects within a transaction.
+
+    Returns the copy of the plan.
+    """
+    plan_copy, root_page_copy = _copy_collection_site_and_pages(plan, clone_visitor, root_page_title_suffix)
+    _copy_plan_with_structure(plan_copy, clone_visitor)
+    _copy_documentation_pages(plan, plan_copy, root_page_title_suffix, clone_visitor)
+    attribute_types = _copy_attribute_types(plan, clone_visitor)
 
     # Update root page (`plan_copy.site` should now be the site copy)
     assert plan_copy.site
@@ -1020,14 +1065,7 @@ def _clone_plan_objects(
     # may be the current, yet unpublished, draft.
     copy_revisions(clone_visitor)
 
-    if copy_indicators:
-        indicators = list(plan.indicators.all())
-        for indicator in indicators:
-            visit_tree(indicator, INDICATOR_CLONE_STRUCTURE, clone_visitor)
-        for dimension in Dimension.objects.filter(id__in=plan.dimensions.values_list('dimension_id')):
-            visit_tree(dimension, DIMENSION_CLONE_STRUCTURE, clone_visitor)
-    else:
-        indicators = []
+    indicators = _copy_indicators(plan, clone_visitor) if copy_indicators else []
 
     # Restore temporarily removed links
     clone_visitor.restore_removed_links()

--- a/copying/main.py
+++ b/copying/main.py
@@ -782,22 +782,21 @@ def copy_root_pages(
 def copy_action_drafts(plan_copy: Plan, clone_visitor: CloneVisitor):
     update_references_visitor = UpdateReferencesVisitor(clone_visitor)
     for action in Action.objects.filter(plan=plan_copy, latest_revision__isnull=False).select_related('latest_revision'):
-        if action.latest_revision:
-            assert isinstance(action.latest_revision, Revision)
-            rev_obj = action.latest_revision.as_object()
-            # The PK of `rev_obj` is that of the original from which `action` was copied
-            rev_obj.pk = action.pk
-            rev_obj.uuid = action.uuid
-            assert action.copy_of
-            rev_obj.copy_of = action.copy_of
-            # Update but don't save `rev_obj`. (Otherwise we'd overwrite published actions with drafts. We just want to
-            # create a revision out of `rev_obj` and save that.
-            update_references_visitor.update_instance(rev_obj, save=False)
-            if rev_obj.draft_attributes:
-                rev_obj.draft_attributes.replace_references(clone_visitor)
-            new_rev = rev_obj.save_revision(changed=False)
-            action.latest_revision = new_rev
-            action.save(update_fields=['latest_revision'])
+        assert isinstance(action.latest_revision, Revision)
+        rev_obj = action.latest_revision.as_object()
+        # The PK of `rev_obj` is that of the original from which `action` was copied
+        rev_obj.pk = action.pk
+        rev_obj.uuid = action.uuid
+        assert action.copy_of
+        rev_obj.copy_of = action.copy_of
+        # Update but don't save `rev_obj`. (Otherwise we'd overwrite published actions with drafts. We just want to
+        # create a revision out of `rev_obj` and save that.
+        update_references_visitor.update_instance(rev_obj, save=False)
+        if rev_obj.draft_attributes:
+            rev_obj.draft_attributes.replace_references(clone_visitor)
+        new_rev = rev_obj.save_revision(changed=False)
+        action.latest_revision = new_rev
+        action.save(update_fields=['latest_revision'])
 
 
 def copy_collection_with_contents(collection: Collection, clone_visitor: CloneVisitor):

--- a/copying/main.py
+++ b/copying/main.py
@@ -862,8 +862,8 @@ def register_page_copies(clone_visitor: CloneVisitor, original_root: Page, root_
 
     The two page trees must be isomorphic.
     """
-    original_pages = original_root.get_descendants().specific()
-    page_copies = root_copy.get_descendants().specific()
+    original_pages = original_root.get_descendants(inclusive=True).specific()
+    page_copies = root_copy.get_descendants(inclusive=True).specific()
     for original_page, page_copy in zip(original_pages, page_copies, strict=True):
         assert type(original_page) is type(page_copy)
         clone_visitor.register_copy(original_page, page_copy)

--- a/copying/main.py
+++ b/copying/main.py
@@ -954,6 +954,10 @@ def register_page_copies(clone_visitor: CloneVisitor, original_root: Page, root_
             clone_visitor.register_copy(original_child, child_copy)
 
 
+def may_copy_indicators(plan: Plan) -> bool:
+    return not plan.shared_indicators().exists()
+
+
 def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, new_site_hostname: str, copy_indicators: bool) -> None:
     """
     Validate arguments for copy_plan before any mutations.
@@ -968,11 +972,7 @@ def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, new_site_host
     if not copy_indicators:
         return
 
-    plan_has_shared_indicator = (
-        IndicatorLevel.objects.filter(indicator__in=plan.indicators.all())
-        .values('indicator').annotate(num_plans=Count('plan')).filter(num_plans__gt=1)
-    )
-    if plan_has_shared_indicator:
+    if not may_copy_indicators(plan):
         raise ValueError("Cannot copy indicators as the plan shares indicators with another plan")
     # We decided not to copy organizations and common indicators. So the unique constraint on `(common_id,
     # organization_id)` in `Indicator` prevents us from copying indicators that are instances of a common indicator.

--- a/copying/main.py
+++ b/copying/main.py
@@ -586,13 +586,106 @@ class UpdateReferencesVisitor(AbstractVisitor):
                     update_fields.append(fk.name)
         return update_fields
 
+    def _update_stream_field_reference(
+        self, from_object: Model, to_object: Model, copy: Model, source_field: Field, content_path: str,
+    ) -> bool:
+        """Update a reference that lives inside a StreamField block."""
+        # We can't use apply_changes_to_raw_data from wagtail.blocks.migrations.utils because the block paths it
+        # uses target blocks by their type names, so if there are two sibling blocks of the same type, there is no
+        # way to target just one of them. In contrast to `ref.model_path`, this is taken into account by
+        # `content_path`, which identifies StreamBlock children by UUID instead of their type, so we should use
+        # this one instead. Unfortunately there is no easy way to quickly change a value with a given content path.
+        # There is `StreamField.get_blockby_content_path()`, but this returns a `BoundBlock`, which does not
+        # propagate changes to its value to the StreamField's value.
+        field_name, *content_path_rest = content_path.split('.')
+        assert field_name == source_field.name
+        # Make sure we only update copies (pk is None for draft-only objects deserialized from revisions)
+        assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
+        update_streamfield_block(from_object, field_name, content_path_rest, to_object, copy)
+        return True
+
+    def _update_many_to_one_rel_reference(
+        self, from_object: Model, to_object: Model, copy: Model, source_field: ManyToOneRel, content_path: str,
+    ) -> bool:
+        """
+        Update a reference held by a cluster-related child object of a ClusterableModel parent.
+
+        For ClusterableModels (Pages, Organizations, etc.) owning cluster-related objects, we can't rely
+        on the clone structure to update references because copying these models uses special logic
+        (Wagtail's Page.copy() for pages, or cluster-related object handling for other ClusterableModels).
+        Additionally, Wagtail's reference index stores references from cluster-related child objects
+        at the parent level. For example, if an Indicator (child) has a reference in its description field,
+        Wagtail stores this in the reference index at the Organization (parent) level with a content path
+        like "indicators.123.description.". So we need to handle these references here by traversing into
+        the child objects.
+        """
+        if not isinstance(from_object, ClusterableModel):
+            # In this case, we will update the reference elsewhere using the clone structure. (I hope!)
+            return False
+        # `from_object` is the parent of an object that references
+        # `ref.to_content_type.get_object_for_this_type(id=ref.to_object_id)`.
+        # The referencing object is of type `source_field.related_model`.
+        field_name, id, *content_path_rest = content_path.split('.')
+        assert field_name == source_field.name
+        assert field_name == source_field.related_name
+        manager = getattr(from_object, field_name)
+        assert isinstance(manager, Manager)
+        # Create `from_object._cluster_related_objects`
+        manager.get_object_list()  # type: ignore[attr-defined]
+        referencing_object = manager.get(id=id)
+        # Make sure we only update copies
+        assert self.clone_visitor.is_copy(referencing_object)
+        child_field_name, *child_content_path = content_path_rest
+        child_field = referencing_object._meta.get_field(child_field_name)
+        if isinstance(child_field, StreamField):
+            update_streamfield_block(referencing_object, child_field_name, child_content_path, to_object, copy)
+            assert field_name in from_object._cluster_related_objects  # type: ignore[attr-defined]
+        elif isinstance(child_field, RichTextField):
+            assert child_content_path == ['']
+            update_rich_text_reference_in_field(
+                instance=referencing_object,
+                field_name=child_field_name,
+                old_referenced_object=to_object,
+                new_referenced_object=copy,
+            )
+        else:
+            # Not sure if there are other cases, but I haven't accounted for any others...
+            assert isinstance(child_field, (ForeignKey, GenericForeignKey))
+            setattr(referencing_object, child_field_name, copy)
+        return True
+
+    def _update_foreign_key_reference(
+        self, from_object: Model, to_object: Model, copy: Model, source_field: ForeignKey, content_path: str,
+    ) -> bool:
+        """Verify that a ForeignKey reference has already been updated by update_foreign_keys()."""
+        assert source_field.name == content_path
+        # Foreign keys should have been already taken care of in a previous call to `self.update_foreign_keys()`
+        assert getattr(from_object, source_field.name) is copy
+        return False
+
+    def _update_rich_text_reference(
+        self, from_object: Model, to_object: Model, copy: Model, source_field: RichTextField, content_path: str,
+    ) -> bool:
+        """Update a reference embedded in a RichTextField."""
+        field_name, *content_path_rest = content_path.split('.')
+        assert field_name == source_field.name
+        assert content_path_rest == ['']
+        # Make sure we only update copies (pk is None for draft-only objects deserialized from revisions)
+        assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
+        update_rich_text_reference_in_field(
+            instance=from_object,
+            field_name=field_name,
+            old_referenced_object=to_object,
+            new_referenced_object=copy,
+        )
+        return True
+
     def update_reference(self, from_object: Model, to_object: Model, source_field: Field, content_path: str) -> bool:
         """
         Update the reference to `to_object` in the field `source_field` of `from_object` at `content_path`.
 
         Returns true if and only if the instance was updated.
         """
-
         if _is_excluded_model(to_object._meta.model):
             return False
 
@@ -612,84 +705,13 @@ class UpdateReferencesVisitor(AbstractVisitor):
             return False
 
         if isinstance(source_field, StreamField):
-            # We can't use apply_changes_to_raw_data from wagtail.blocks.migrations.utils because the block paths it
-            # uses target blocks by their type names, so if there are two sibling blocks of the same type, there is no
-            # way to target just one of them. In contrast to `ref.model_path`, this is taken into account by
-            # `content_path`, which identifies StreamBlock children by UUID instead of their type, so we should use
-            # this one instead. Unfortunately there is no easy way to quickly change a value with a given content path.
-            # There is `StreamField.get_blockby_content_path()`, but this returns a `BoundBlock`, which does not
-            # propagate changes to its value to the StreamField's value.
-            field_name, *content_path_rest = content_path.split('.')
-            assert field_name == source_field.name
-            # Make sure we only update copies (pk is None for draft-only objects deserialized from revisions)
-            assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
-            update_streamfield_block(from_object, field_name, content_path_rest, to_object, copy)
-            return True
-
+            return self._update_stream_field_reference(from_object, to_object, copy, source_field, content_path)
         if isinstance(source_field, ManyToOneRel):
-            if not isinstance(from_object, ClusterableModel):
-                # In this case, we will update the reference elsewhere using the clone structure. (I hope!)
-                return False
-            # For ClusterableModels (Pages, Organizations, etc.) owning cluster-related objects, we can't rely
-            # on the clone structure to update references because copying these models uses special logic
-            # (Wagtail's Page.copy() for pages, or cluster-related object handling for other ClusterableModels).
-            # Additionally, Wagtail's reference index stores references from cluster-related child objects
-            # at the parent level. For example, if an Indicator (child) has a reference in its description field,
-            # Wagtail stores this in the reference index at the Organization (parent) level with a content path
-            # like "indicators.123.description.". So we need to handle these references here by traversing into
-            # the child objects.
-            # `from_object` is the parent of an object that references
-            # `ref.to_content_type.get_object_for_this_type(id=ref.to_object_id)`.
-            # The referencing object is of type `source_field.related_model`.
-            field_name, id, *content_path_rest = content_path.split('.')
-            assert field_name == source_field.name
-            assert field_name == source_field.related_name
-            manager = getattr(from_object, field_name)
-            assert isinstance(manager, Manager)
-            # Create `from_object._cluster_related_objects`
-            manager.get_object_list()  # type: ignore[attr-defined]
-            referencing_object = manager.get(id=id)
-            # Make sure we only update copies
-            assert self.clone_visitor.is_copy(referencing_object)
-            child_field_name, *child_content_path = content_path_rest
-            child_field = referencing_object._meta.get_field(child_field_name)
-            if isinstance(child_field, StreamField):
-                update_streamfield_block(referencing_object, child_field_name, child_content_path, to_object, copy)
-                assert field_name in from_object._cluster_related_objects
-            elif isinstance(child_field, RichTextField):
-                assert child_content_path == ['']
-                update_rich_text_reference_in_field(
-                    instance=referencing_object,
-                    field_name=child_field_name,
-                    old_referenced_object=to_object,
-                    new_referenced_object=copy,
-                )
-            else:
-                # Not sure if there are other cases, but I haven't accounted for any others...
-                assert isinstance(child_field, (ForeignKey, GenericForeignKey))
-                setattr(referencing_object, child_field_name, copy)
-            return True
-
+            return self._update_many_to_one_rel_reference(from_object, to_object, copy, source_field, content_path)
         if isinstance(source_field, ForeignKey):
-            assert source_field.name == content_path
-            # Foreign keys should have been already taken care of in a previous call to `self.update_foreign_keys()`
-            assert getattr(from_object, source_field.name) is copy
-            return False
-
+            return self._update_foreign_key_reference(from_object, to_object, copy, source_field, content_path)
         if isinstance(source_field, RichTextField):
-            field_name, *content_path_rest = content_path.split('.')
-            assert field_name == source_field.name
-            assert content_path_rest == ['']
-            # Make sure we only update copies (pk is None for draft-only objects deserialized from revisions)
-            assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
-            update_rich_text_reference_in_field(
-                instance=from_object,
-                field_name=field_name,
-                old_referenced_object=to_object,
-                new_referenced_object=self.clone_visitor.get_copy(to_object),
-            )
-            return True
-
+            return self._update_rich_text_reference(from_object, to_object, copy, source_field, content_path)
         raise TypeError("Unexpected source field type")
 
     def update_indexed_references(

--- a/copying/main.py
+++ b/copying/main.py
@@ -423,9 +423,11 @@ class UpdateReferencesVisitor(AbstractVisitor):
         logger.trace(f"Update references of {type(instance).__name__} {instance.pk}: {instance}")
         update_fields = []
         update_fields += self.update_cluster_related_objects(instance)
+        logger.info(f"Updating foreign keys of {type(instance).__name__} {instance.pk}: {instance}")
         update_fields += self.update_foreign_keys(instance)
         update_fields += self.update_indexed_references(instance)
         if isinstance(instance, Page) and not skip_page_draft:
+            logger.info(f"Updating page draft of {type(instance).__name__} {instance.pk}: {instance}")
             update_fields += self.update_page_draft(instance)
         # Save changes
         if update_fields and save:
@@ -489,12 +491,12 @@ class UpdateReferencesVisitor(AbstractVisitor):
             if cro.pk is not None and not self.clone_visitor.is_copy(cro):
                 # Probably there is no copy because the model instance that `cro` originally corresponded to no
                 # longer exists in the database.
-                cro.pk = None
-                updated = True
                 logger.warning(
                     f"In cluster related objects of {type(parent).__name__} {parent.pk}: Could not find "
                     f"copy for {type(cro).__name__} {cro.pk}: {cro}"
                 )
+                cro.pk = None
+                updated = True
         else:
             assert cro.pk != cro_copy.pk
             cro.pk = cro_copy.pk
@@ -547,10 +549,16 @@ class UpdateReferencesVisitor(AbstractVisitor):
                 try:
                     copy = self.clone_visitor.get_copy(related_object)
                 except KeyError:
-                    logger.trace(
-                        f"Could not find copy for {type(related_object).__name__} {related_object.pk}: "
-                        f"{related_object}"
-                    )
+                    if self.clone_visitor.is_copy(related_object):
+                        logger.trace(
+                            f"Trying to update foreign key '{fk.name}' of {type(instance).__name__} {instance.pk} "
+                            f"that is already a copy: {type(related_object).__name__} {related_object.pk}"
+                        )
+                    else:
+                        logger.warning(
+                            f"Could not find copy for {type(related_object).__name__} {related_object.pk} "
+                            f"when trying to update foreign key '{fk.name}' of {type(instance).__name__} {instance.pk}"
+                        )
                     continue
                 logger.trace(f"Set foreign key '{fk.name}' of {type(instance).__name__} {instance.pk} to: {copy.pk}")
                 setattr(instance, fk.name, copy)
@@ -574,7 +582,17 @@ class UpdateReferencesVisitor(AbstractVisitor):
         try:
             copy = self.clone_visitor.get_copy(to_object)
         except KeyError:
-           return False
+            if self.clone_visitor.is_copy(to_object):
+                logger.trace(
+                    f"Trying to update reference in {type(from_object).__name__} {from_object.pk} at path "
+                    f"'{content_path}' that is already a copy: {type(to_object).__name__} {to_object.pk}"
+                )
+            else:
+                logger.warning(
+                    f"Cannot update reference in {type(from_object).__name__} {from_object.pk} at path '{content_path}': "
+                    f"Could not find copy for {type(to_object).__name__} {to_object.pk}"
+                )
+            return False
 
         if isinstance(source_field, StreamField):
             # We can't use apply_changes_to_raw_data from wagtail.blocks.migrations.utils because the block paths it

--- a/copying/main.py
+++ b/copying/main.py
@@ -834,6 +834,13 @@ def _copy_instance_revision(
     # Update but don't save `rev_obj`. (Otherwise we'd overwrite published instances with drafts. We just want to
     # create a revision out of `rev_obj` and save that.)
     update_references_visitor.update_instance(rev_obj, save=False)
+    # `update_instance` handles fields with extract_references (e.g., RichTextField) via `update_indexed_references`,
+    # but only for models registered in Wagtail's ReferenceIndex. Models with a ParentalKey (like Action) are not
+    # directly indexed because Wagtail expects references to be tracked at the parent level. However, since Plan has
+    # `wagtail_reference_index_ignore=True`, Action's references are never tracked. We therefore call
+    # `update_extractable_references` directly on rev_obj to update any embedded references (e.g., indicator
+    # references in action description drafts).
+    update_references_visitor.update_extractable_references(rev_obj)
     draft_attributes = getattr(rev_obj, 'draft_attributes', None)
     if draft_attributes:
         draft_attributes.replace_references(clone_visitor)
@@ -1088,13 +1095,15 @@ def _clone_plan_objects(
     plan_copy.site.root_page = root_page_copy
     plan_copy.site.save(update_fields=['root_page'])
 
+    indicators = _copy_indicators(plan, clone_visitor) if copy_indicators else []
+
     # Revisions have not been copied yet. (`Action.revisions` is not a reverse accessor, so we can't include action
     # revisions in the clone hierarchy.)
     # We decided that, when copying, we start with a clean slate revision-wise, except for the latest revision, which
     # may be the current, yet unpublished, draft.
+    # Note: copy_revisions runs after _copy_indicators so that indicator copies exist in clone_visitor when
+    # updating references in action drafts.
     copy_revisions(clone_visitor)
-
-    indicators = _copy_indicators(plan, clone_visitor) if copy_indicators else []
 
     # Restore temporarily removed links
     clone_visitor.restore_removed_links()

--- a/copying/main.py
+++ b/copying/main.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
+from django.db import transaction
 from django.db.models import Count, Field, ForeignKey, Manager, ManyToOneRel, Model, Q, signals
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
@@ -879,65 +880,46 @@ def register_page_copies(clone_visitor: CloneVisitor, original_root: Page, root_
             clone_visitor.register_copy(original_child, child_copy)
 
 
-@update_reference_index_immediately
-def copy_plan(
+def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, copy_indicators: bool) -> str:
+    """
+    Validate arguments for copy_plan before any mutations.
+
+    Returns the new site hostname. Raises ValueError if validation fails.
+    """
+    if Plan.objects.filter(identifier=new_plan_identifier).exists():
+        raise ValueError(f"A plan with identifier '{new_plan_identifier}' already exists")
+    new_site_hostname = _new_site_hostname(plan, new_plan_identifier)
+    if Site.objects.filter(hostname=new_site_hostname).exists():
+        raise ValueError(f"A site with hostname '{new_site_hostname}' already exists")
+
+    if not copy_indicators:
+        return new_site_hostname
+
+    plan_has_shared_indicator = (
+        IndicatorLevel.objects.filter(indicator__in=plan.indicators.all())
+        .values('indicator').annotate(num_plans=Count('plan')).filter(num_plans__gt=1)
+    )
+    if plan_has_shared_indicator:
+        raise ValueError("Cannot copy indicators as the plan shares indicators with another plan")
+    # We decided not to copy organizations and common indicators. So the unique constraint on `(common_id,
+    # organization_id)` in `Indicator` prevents us from copying indicators that are instances of a common indicator.
+    if plan.indicators.filter(common__isnull=False).exists():
+        raise ValueError("Cannot copy indicators as some are instances of a common indicator")
+
+    return new_site_hostname
+
+
+def _clone_plan_objects(
     plan: Plan,
-    new_plan_identifier: str | None = None,
-    new_plan_name: str | None = None,
-    general_name_suffix: str | None = None,
-    root_page_title_suffix: str | None = None,
-    version_name: str | None = None,
-    supersede_original_plan: bool = False,
-    supersede_original_actions: bool = False,
-    copy_indicators: bool = False,
+    clone_visitor: CloneVisitor,
+    root_page_title_suffix: str | None,
+    copy_indicators: bool,
 ) -> Plan:
     """
-    Copy the given plan.
+    Perform the actual cloning of all plan objects within a transaction.
 
-    Sets identifier and name of the copy of the plan to the given values, defaults to the result of calling
-    `default_identifier_for_copying()` and `default_name_for_copying()` on the original.
-
-    Adds the suffix given in `general_name_suffix` to the names of other models. (Defaults to no suffix.)
-
-    Does what you expect for `root_page_title_suffix`.
-
-    The plan version name of the copy can be specified with `version_name`.
-
-    If `supersede_original_plan` is true, the copy will supersede the original plan; if
-    `supersede_original_actions` is true, each action copy will supersede its original.
-
-    If `copy_indicators` is true, all indicators and dimensions of `plan` will be copied. However, this requires the
-    plan to have only indicators that are not shared with another plan, otherwise we abort.
-
-    Returns the copy.
+    Returns the copy of the plan.
     """
-    if new_plan_identifier is None:
-        new_plan_identifier = plan.default_identifier_for_copying()
-    if new_plan_name is None:
-        new_plan_name = plan.default_name_for_copying()
-
-    if copy_indicators:
-        plan_has_shared_indicator = (
-            IndicatorLevel.objects.filter(indicator__in=plan.indicators.all())
-            .values('indicator').annotate(num_plans=Count('plan')).filter(num_plans__gt=1)
-        )
-        if plan_has_shared_indicator:
-            raise ValueError("Cannot copy indicators as the plan shares indicators with another plan")
-        # We decided not to copy organizations and common indicators. So the unique constraint on `(common_id,
-        # organization_id)` in `Indicator` prevents us from copying indicators that are instances of a common indicator.
-        if plan.indicators.filter(common__isnull=False).exists():
-            raise ValueError("Cannot copy indicators as some are instances of a common indicator")
-
-    clone_visitor = CloneVisitor(
-        site_hostname=_new_site_hostname(plan, new_plan_identifier),
-        plan_identifier=new_plan_identifier,
-        plan_name=new_plan_name,
-        copy_name_suffix=general_name_suffix,
-        version_name=version_name,
-        supersede_original_plan=supersede_original_plan,
-        supersede_original_actions=supersede_original_actions,
-    )
-    # A couple of hacks to avoid things breaking when creating a copy of the plan.
     # Work on fresh `Plan` objects because `clone` changes its first argument. We just want to get stuff into the
     # visitor's copy cache (and the DB of course).
     root_collection = Plan.objects.get(pk=plan.pk).root_collection
@@ -1013,6 +995,59 @@ def copy_plan(
     update_references(plan_copy, attribute_types, indicators, clone_visitor)
 
     return plan_copy
+
+
+@update_reference_index_immediately
+def copy_plan(
+    plan: Plan,
+    new_plan_identifier: str | None = None,
+    new_plan_name: str | None = None,
+    general_name_suffix: str | None = None,
+    root_page_title_suffix: str | None = None,
+    version_name: str | None = None,
+    supersede_original_plan: bool = False,
+    supersede_original_actions: bool = False,
+    copy_indicators: bool = False,
+) -> Plan:
+    """
+    Copy the given plan.
+
+    Sets identifier and name of the copy of the plan to the given values, defaults to the result of calling
+    `default_identifier_for_copying()` and `default_name_for_copying()` on the original.
+
+    Adds the suffix given in `general_name_suffix` to the names of other models. (Defaults to no suffix.)
+
+    Does what you expect for `root_page_title_suffix`.
+
+    The plan version name of the copy can be specified with `version_name`.
+
+    If `supersede_original_plan` is true, the copy will supersede the original plan; if
+    `supersede_original_actions` is true, each action copy will supersede its original.
+
+    If `copy_indicators` is true, all indicators and dimensions of `plan` will be copied. However, this requires the
+    plan to have only indicators that are not shared with another plan, otherwise we abort.
+
+    Returns the copy.
+    """
+    if new_plan_identifier is None:
+        new_plan_identifier = plan.default_identifier_for_copying()
+    if new_plan_name is None:
+        new_plan_name = plan.default_name_for_copying()
+
+    new_site_hostname = _validate_copy_plan_args(plan, new_plan_identifier, copy_indicators)
+
+    clone_visitor = CloneVisitor(
+        site_hostname=new_site_hostname,
+        plan_identifier=new_plan_identifier,
+        plan_name=new_plan_name,
+        copy_name_suffix=general_name_suffix,
+        version_name=version_name,
+        supersede_original_plan=supersede_original_plan,
+        supersede_original_actions=supersede_original_actions,
+    )
+
+    with transaction.atomic():
+        return _clone_plan_objects(plan, clone_visitor, root_page_title_suffix, copy_indicators)
 
 
 def update_references(

--- a/copying/main.py
+++ b/copying/main.py
@@ -681,9 +681,15 @@ class UpdateReferencesVisitor(AbstractVisitor):
 
         raise TypeError("Unexpected source field type")
 
-    def update_indexed_references(self, instance: Model) -> list[str]:
+    def update_indexed_references(
+            self,
+            instance: Model,
+            filter_reference: Callable[[ReferenceIndex], bool] | None = None,
+    ) -> list[str]:
         update_fields = set()
         for ref in ReferenceIndex.get_references_for_object(instance):
+            if filter_reference is not None and not filter_reference(ref):
+                continue
             to_model = ref.to_content_type.model_class()
             try:
                 to_object = ref.to_content_type.get_object_for_this_type(id=ref.to_object_id)
@@ -1044,6 +1050,13 @@ def update_references_in_indicators(indicators: list[Indicator], clone_visitor: 
 
     update_references_visitor = UpdateReferencesVisitor(clone_visitor)
 
+    # Set up filter to only process references whose content path is `indicators.<n>.*`, where `<n>` is the PK of an
+    # indicator we copied.
+    indicator_pks = {i.pk for i in indicators}
+    def filter_reference(ref: ReferenceIndex) -> bool:
+        field, pk_str, _ = ref.content_path.split('.')
+        return field == 'indicators' and int(pk_str) in indicator_pks
+
     # Collect all organizations that contain the copied indicators
     org_ids = set()
     for indicator in indicators:
@@ -1056,7 +1069,7 @@ def update_references_in_indicators(indicators: list[Indicator], clone_visitor: 
     for org_id in org_ids:
         org = Organization.objects.get(pk=org_id)
         # Process indexed references (this modifies cluster children in memory)
-        update_references_visitor.update_indexed_references(org)
+        update_references_visitor.update_indexed_references(org, filter_reference)
         # Save only the modified cluster-related indicators, not the org itself
         for _, child in get_cluster_related_objects(org):
             if isinstance(child, Indicator) and clone_visitor.is_copy(child):

--- a/copying/main.py
+++ b/copying/main.py
@@ -19,7 +19,7 @@ from django.db.models import Count, Field, ForeignKey, Manager, ManyToOneRel, Mo
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
 from wagtail.fields import RichTextField, StreamField
-from wagtail.models import Page, Revision, Site
+from wagtail.models import Page, Revision, RevisionMixin, Site
 from wagtail.models.i18n import Locale
 from wagtail.models.media import Collection
 from wagtail.models.reference_index import ReferenceIndex
@@ -779,24 +779,48 @@ def copy_root_pages(
     return copies
 
 
-def copy_action_drafts(plan_copy: Plan, clone_visitor: CloneVisitor):
+def _copy_instance_revision(
+    instance: RevisionMixin, clone_visitor: CloneVisitor, update_references_visitor: UpdateReferencesVisitor,
+) -> None:
+    try:
+        rev_obj = instance.latest_revision.as_object()
+    except Exception:
+        # Some non-ClusterableModel models with i18n fields that reference FKs
+        # (e.g., default_language_field='plan__primary_language_lowercase') cannot be
+        # deserialized from revision content because the FK isn't in the serialized data.
+        # Clear the stale reference to the original's revision.
+        model_name = type(instance).__name__
+        logger.warning(f'Failed to deserialize revision for {model_name} pk={instance.pk}, skipping')
+        instance.latest_revision = None
+        instance.save(update_fields=['latest_revision'])
+        return
+    # as_object() sets pk from the revision's content_object (the original), so fix it to the copy's pk
+    rev_obj.pk = instance.pk
+    if hasattr(rev_obj, 'uuid'):
+        rev_obj.uuid = instance.uuid
+    if hasattr(rev_obj, 'copy_of'):
+        rev_obj.copy_of = instance.copy_of
+    # Update but don't save `rev_obj`. (Otherwise we'd overwrite published instances with drafts. We just want to
+    # create a revision out of `rev_obj` and save that.)
+    update_references_visitor.update_instance(rev_obj, save=False)
+    draft_attributes = getattr(rev_obj, 'draft_attributes', None)
+    if draft_attributes:
+        draft_attributes.replace_references(clone_visitor)
+    new_rev = rev_obj.save_revision(changed=False)
+    instance.latest_revision = new_rev
+    instance.save(update_fields=['latest_revision'])
+
+
+def copy_revisions(clone_visitor: CloneVisitor):
     update_references_visitor = UpdateReferencesVisitor(clone_visitor)
-    for action in Action.objects.filter(plan=plan_copy, latest_revision__isnull=False).select_related('latest_revision'):
-        assert isinstance(action.latest_revision, Revision)
-        rev_obj = action.latest_revision.as_object()
-        # The PK of `rev_obj` is that of the original from which `action` was copied
-        rev_obj.pk = action.pk
-        rev_obj.uuid = action.uuid
-        assert action.copy_of
-        rev_obj.copy_of = action.copy_of
-        # Update but don't save `rev_obj`. (Otherwise we'd overwrite published actions with drafts. We just want to
-        # create a revision out of `rev_obj` and save that.
-        update_references_visitor.update_instance(rev_obj, save=False)
-        if rev_obj.draft_attributes:
-            rev_obj.draft_attributes.replace_references(clone_visitor)
-        new_rev = rev_obj.save_revision(changed=False)
-        action.latest_revision = new_rev
-        action.save(update_fields=['latest_revision'])
+    for instance in clone_visitor.copies.values():
+        if not isinstance(instance, RevisionMixin):
+            continue
+        if isinstance(instance, Page):
+            continue  # Page revisions handled by UpdateReferencesVisitor.update_page_draft()
+        if instance.latest_revision is None:
+            continue
+        _copy_instance_revision(instance, clone_visitor, update_references_visitor)
 
 
 def copy_collection_with_contents(collection: Collection, clone_visitor: CloneVisitor):
@@ -982,11 +1006,11 @@ def _clone_plan_objects(
     plan_copy.site.root_page = root_page_copy
     plan_copy.site.save(update_fields=['root_page'])
 
-    # Action revisions have not been copied yet. (`Action.revisions` is not a reverse accessor, so we can't include
+    # Revisions have not been copied yet. (`Action.revisions` is not a reverse accessor, so we can't include action
     # revisions in the clone hierarchy.)
-    # We decided that, when copying an action, we start with a clean slate revision-wise, except for the latest
-    # revision, which may be the current, yet unpublished, draft.
-    copy_action_drafts(plan_copy, clone_visitor)
+    # We decided that, when copying, we start with a clean slate revision-wise, except for the latest revision, which
+    # may be the current, yet unpublished, draft.
+    copy_revisions(clone_visitor)
 
     if copy_indicators:
         indicators = list(plan.indicators.all())

--- a/copying/main.py
+++ b/copying/main.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 from uuid import uuid4
 
 import wagtail.signal_handlers
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
@@ -18,6 +19,7 @@ from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Page, Revision, Site
+from wagtail.models.i18n import Locale
 from wagtail.models.media import Collection
 from wagtail.models.reference_index import ReferenceIndex
 
@@ -26,9 +28,10 @@ from relations_iterator import AbstractVisitor, ConfigurableRelationTree, Relati
 
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
-from actions.models.category import Category, CategoryType
+from actions.models.category import Category, CategoryType, CommonCategory, CommonCategoryType
 from actions.models.plan import Plan
 from actions.signals import create_notification_settings, create_plan_features_and_sync_group_permissions
+from admin_site.models import Client
 from content.apps import create_site_general_content
 from copying.utils import (
     get_foreign_keys,
@@ -40,9 +43,14 @@ from copying.utils import (
 from documentation.models import DocumentationRootPage
 from documents.models import AplansDocument
 from images.models import AplansImage
+from indicators.models.common_indicator import CommonIndicator
 from indicators.models.dimensions import Dimension
 from indicators.models.indicator import Indicator, IndicatorLevel
+from indicators.models.metadata import Quantity, Unit
+from orgs.models import Organization
 from pages.models import PlanRootPage
+from people.models import Person
+from users.models import User
 
 if TYPE_CHECKING:
     from wagtail.documents.models import AbstractDocument
@@ -144,6 +152,23 @@ INDICATOR_CLONE_STRUCTURE: CloneStructure = {
 DIMENSION_CLONE_STRUCTURE: CloneStructure = {
     'categories': {},
 }
+
+# Models that are not scoped by a plan and thus deliberately excluded from copying. References to these models are
+# skipped in `UpdateReferencesVisitor.get_references()` and warnings are suppressed in `update_reference()`.
+MODELS_NOT_COPIED = [
+    Client,
+    CommonCategory,
+    CommonCategoryType,
+    CommonIndicator,
+    ContentType,
+    Group,
+    Locale,
+    Organization,
+    Person,
+    Quantity,
+    Unit,
+    User,
+]
 
 
 class CloneVisitor(AbstractVisitor):
@@ -421,7 +446,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
         if exclude_fields is None:
             exclude_fields = []
         for fk in get_foreign_keys(instance):
-            if fk.name not in exclude_fields:
+            if fk.name not in exclude_fields and fk.related_model not in MODELS_NOT_COPIED:
                 yield fk
         for gfk in get_generic_foreign_keys(instance):
             if gfk.name not in exclude_fields:
@@ -517,6 +542,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
             assert hasattr(fk, 'name')
             related_object = getattr(instance, fk.name)
             if related_object:
+                if related_object._meta.model in MODELS_NOT_COPIED:
+                    continue
                 try:
                     copy = self.clone_visitor.get_copy(related_object)
                 except KeyError:
@@ -540,6 +567,9 @@ class UpdateReferencesVisitor(AbstractVisitor):
 
         Returns true if and only if the instance was updated.
         """
+
+        if to_object._meta.model in MODELS_NOT_COPIED:
+            return False
 
         try:
             copy = self.clone_visitor.get_copy(to_object)

--- a/copying/main.py
+++ b/copying/main.py
@@ -183,6 +183,7 @@ class CloneVisitor(AbstractVisitor):
             self.copy_name_suffix = ''
         self.version_name = version_name
         self.copies = {}
+        self._copy_to_original_pk: dict[int, Any] = {}
         self.removed_links = {}
         self.supersede_original_plan = supersede_original_plan
         self.supersede_original_actions = supersede_original_actions
@@ -204,9 +205,7 @@ class CloneVisitor(AbstractVisitor):
 
     def _get_original_pk(self, copy: Model) -> Any:
         """Get the PK of the original instance for the given copy."""
-        # This is inefficient, but for now we only call it in exceptional cases.
-        _, pk = list(self.copies.keys())[list(self.copies.values()).index(copy)]
-        return pk
+        return self._copy_to_original_pk[id(copy)]
 
     def register_copy[M: Model](self, original: M, copy: M):
         """
@@ -220,6 +219,7 @@ class CloneVisitor(AbstractVisitor):
         assert not self.has_copy(original)  # should be the same as the previous line, but you never know
         assert not self.is_copy(copy)  # `copy` can't be a copy of multiple originals
         self.copies[key] = copy
+        self._copy_to_original_pk[id(copy)] = original.pk
 
     def visit(self, node: TreeNode):
         """

--- a/copying/main.py
+++ b/copying/main.py
@@ -493,8 +493,13 @@ class UpdateReferencesVisitor(AbstractVisitor):
                         updated = True
         return updated
 
-    def update_cluster_related_object(self, parent: Model, cro: Model) -> bool:
-        updated = False
+    def _remap_cluster_object_pk(self, parent: Model, cro: Model) -> bool:
+        """
+        Remap the primary key of a cluster-related object from its original value to the copy's value.
+
+        Returns True if the PK was changed (or cleared), False if no remapping was needed because the
+        object is already a copy.
+        """
         try:
             cro_copy = self.clone_visitor.get_copy(cro)
         except KeyError:
@@ -506,18 +511,20 @@ class UpdateReferencesVisitor(AbstractVisitor):
                     f"copy for {type(cro).__name__} {cro.pk}: {cro}"
                 )
                 cro.pk = None
-                updated = True
-        else:
-            assert cro.pk != cro_copy.pk
-            cro.pk = cro_copy.pk
-            updated = True
-            logger.trace(
-                f"In cluster related objects of {type(parent).__name__} {parent.pk}: Set primary key "
-                f"of {type(cro).__name__} {cro.pk} to: {cro_copy.pk}"
-            )
+                return True
+            return False
+        assert cro.pk != cro_copy.pk
+        cro.pk = cro_copy.pk
+        logger.trace(
+            f"In cluster related objects of {type(parent).__name__} {parent.pk}: Set primary key "
+            f"of {type(cro).__name__} {cro.pk} to: {cro_copy.pk}"
+        )
+        return True
 
-        updated_extractable_refs = self.update_extractable_references(cro)
-        if updated_extractable_refs:
+    def update_cluster_related_object(self, parent: Model, cro: Model) -> bool:
+        updated = self._remap_cluster_object_pk(parent, cro)
+
+        if self.update_extractable_references(cro):
             updated = True
 
         for fk in self.get_references(cro):

--- a/copying/main.py
+++ b/copying/main.py
@@ -957,7 +957,7 @@ def register_page_copies(clone_visitor: CloneVisitor, original_root: Page, root_
 
 
 def may_copy_indicators(plan: Plan) -> bool:
-    return not plan.shared_indicators().exists()
+    return not plan.shared_indicators().exists() and not plan.indicators.filter(common__isnull=False).exists()
 
 
 def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, new_site_hostname: str, copy_indicators: bool) -> None:
@@ -974,12 +974,15 @@ def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, new_site_host
     if not copy_indicators:
         return
 
-    if not may_copy_indicators(plan):
+    if plan.shared_indicators().exists():
+        assert not may_copy_indicators(plan)
         raise ValueError("Cannot copy indicators as the plan shares indicators with another plan")
     # We decided not to copy organizations and common indicators. So the unique constraint on `(common_id,
     # organization_id)` in `Indicator` prevents us from copying indicators that are instances of a common indicator.
     if plan.indicators.filter(common__isnull=False).exists():
+        assert not may_copy_indicators(plan)
         raise ValueError("Cannot copy indicators as some are instances of a common indicator")
+    assert may_copy_indicators(plan)
 
 
 def _copy_collection_site_and_pages(

--- a/copying/main.py
+++ b/copying/main.py
@@ -781,13 +781,16 @@ def _copy_instance_revision(
 ) -> None:
     try:
         rev_obj = instance.latest_revision.as_object()
-    except Exception:
+    except Exception as exc:
         # Some non-ClusterableModel models with i18n fields that reference FKs
         # (e.g., default_language_field='plan__primary_language_lowercase') cannot be
         # deserialized from revision content because the FK isn't in the serialized data.
         # Clear the stale reference to the original's revision.
         model_name = type(instance).__name__
-        logger.warning(f'Failed to deserialize revision for {model_name} pk={instance.pk}, skipping')
+        logger.opt(exception=True).warning(
+            f'Failed to deserialize revision for {model_name} pk={instance.pk}, skipping '
+            f'({type(exc).__name__}: {exc})'
+        )
         instance.latest_revision = None
         instance.save(update_fields=['latest_revision'])
         return

--- a/copying/main.py
+++ b/copying/main.py
@@ -209,7 +209,8 @@ class CloneVisitor(AbstractVisitor):
             self.copy_name_suffix = ''
         self.version_name = version_name
         self.copies = {}
-        self._copy_to_original_pk: dict[int, Any] = {}
+        self._copy_keys: set[tuple[type[Model], Any]] = set()
+        self._copy_to_original_pk: dict[tuple[type[Model], Any], Any] = {}
         self.removed_links = {}
         self.supersede_original_plan = supersede_original_plan
         self.supersede_original_actions = supersede_original_actions
@@ -220,7 +221,7 @@ class CloneVisitor(AbstractVisitor):
 
     def is_copy(self, instance: Model) -> bool:
         """Return true if the given instance is a copy of something."""
-        return instance in self.copies.values()
+        return (type(instance), instance.pk) in self._copy_keys
 
     def get_copy[M: Model](self, instance: M) -> M:
         """Get the copy that has been created for the given instance."""
@@ -231,7 +232,7 @@ class CloneVisitor(AbstractVisitor):
 
     def _get_original_pk(self, copy: Model) -> Any:
         """Get the PK of the original instance for the given copy."""
-        return self._copy_to_original_pk[id(copy)]
+        return self._copy_to_original_pk[(type(copy), copy.pk)]
 
     def register_copy[M: Model](self, original: M, copy: M):
         """
@@ -245,7 +246,8 @@ class CloneVisitor(AbstractVisitor):
         assert not self.has_copy(original)  # should be the same as the previous line, but you never know
         assert not self.is_copy(copy)  # `copy` can't be a copy of multiple originals
         self.copies[key] = copy
-        self._copy_to_original_pk[id(copy)] = original.pk
+        self._copy_keys.add((type(copy), copy.pk))
+        self._copy_to_original_pk[(type(copy), copy.pk)] = original.pk
 
     def visit(self, node: TreeNode):
         """
@@ -469,7 +471,7 @@ class UpdateReferencesVisitor(AbstractVisitor):
 
     @get_references.register
     def _(self, instance: Page) -> Generator[Field | GenericForeignKey]:
-        # Pages are copied via Wagtail's Page.copy(), which handles certain fields  internally. These objects are not
+        # Pages are copied via Wagtail's Page.copy(), which handles certain fields internally. These objects are not
         # registered in the clone visitor, so skip them to avoid spurious warnings.
         return self._get_references(instance, exclude_fields=[
             'page_ptr', 'latest_revision', 'live_revision', 'staticpage_ptr',
@@ -613,8 +615,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
             # propagate changes to its value to the StreamField's value.
             field_name, *content_path_rest = content_path.split('.')
             assert field_name == source_field.name
-            # Make sure we only update copies
-            assert self.clone_visitor.is_copy(from_object)
+            # Make sure we only update copies (pk is None for draft-only objects deserialized from revisions)
+            assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
             update_streamfield_block(from_object, field_name, content_path_rest, to_object, copy)
             return True
 
@@ -672,8 +674,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
             field_name, *content_path_rest = content_path.split('.')
             assert field_name == source_field.name
             assert content_path_rest == ['']
-            # Make sure we only update copies
-            assert self.clone_visitor.is_copy(from_object)
+            # Make sure we only update copies (pk is None for draft-only objects deserialized from revisions)
+            assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
             update_rich_text_reference_in_field(
                 instance=from_object,
                 field_name=field_name,
@@ -737,7 +739,9 @@ class UpdateReferencesVisitor(AbstractVisitor):
         self.update_instance(node.instance)
 
 
-def copy_root_pages(root_page: PlanRootPage | DocumentationRootPage, title_suffix=None) -> Page:
+def copy_root_pages(
+    root_page: PlanRootPage | DocumentationRootPage, title_suffix: str | None = None,
+) -> list[tuple[Page, Page]]:
     """
     Copy the given root page and all its translations.
 
@@ -746,7 +750,7 @@ def copy_root_pages(root_page: PlanRootPage | DocumentationRootPage, title_suffi
     A suffix can be appended to the title field of the root page using the argument `title_suffix` (defaults to `''`).
     If a suffix is appended, a space is put before it.
 
-    Returns the copy of `root_page`.
+    Returns a list of (original, copy) tuples for the root page and each of its translations.
     """
     if title_suffix is None:
         title_suffix = ''
@@ -759,10 +763,10 @@ def copy_root_pages(root_page: PlanRootPage | DocumentationRootPage, title_suffi
         'slug': root_page.default_slug_for_copying(),
     }
     root_page_copy = root_page.copy(recursive=True, update_attrs=update_attrs)
+    copies: list[tuple[Page, Page]] = [(root_page, root_page_copy)]
     new_translation_key = root_page_copy.translation_key
     assert root_page_copy.translation_key != root_page.translation_key
     # When copying the translations of `root_page`, reuse this translation key
-    update_attrs['translation_key'] = new_translation_key
     for page in root_page.get_translations():
         assert isinstance(page, PlanRootPage)
         update_attrs = {
@@ -770,13 +774,14 @@ def copy_root_pages(root_page: PlanRootPage | DocumentationRootPage, title_suffi
             'title': page.title + title_suffix,
             'slug': page.default_slug_for_copying(),
         }
-        page.copy(recursive=True, update_attrs=update_attrs)
-    return root_page_copy
+        translation_copy = page.copy(recursive=True, update_attrs=update_attrs)
+        copies.append((page, translation_copy))
+    return copies
 
 
 def copy_action_drafts(plan_copy: Plan, clone_visitor: CloneVisitor):
     update_references_visitor = UpdateReferencesVisitor(clone_visitor)
-    for action in plan_copy.actions.all():
+    for action in Action.objects.filter(plan=plan_copy, latest_revision__isnull=False).select_related('latest_revision'):
         if action.latest_revision:
             assert isinstance(action.latest_revision, Revision)
             rev_obj = action.latest_revision.as_object()
@@ -927,11 +932,13 @@ def _clone_plan_objects(
     clone(Plan.objects.get(pk=plan.pk).site, {}, clone_visitor)
     assert plan.site
     assert isinstance(plan.site.root_page.specific, PlanRootPage)
-    root_page_copy = copy_root_pages(
+    root_page_copies = copy_root_pages(
         root_page=plan.site.root_page.specific,
         title_suffix=root_page_title_suffix,
     )
-    register_page_copies(clone_visitor, plan.site.root_page.specific, root_page_copy)
+    for original_root, root_copy in root_page_copies:
+        register_page_copies(clone_visitor, original_root, root_copy)
+    root_page_copy = root_page_copies[0][1]
     plan_copy = Plan.objects.get(pk=plan.pk)
     # Hack to avoid site (and root page) initialization in Plan.save()  # noqa: FIX004
     plan_copy._site_created = True
@@ -949,14 +956,16 @@ def _clone_plan_objects(
 
     # Copy documentation page hierarchy
     for documentation_root_page in plan.documentation_root_pages.all():
-        root_page = copy_root_pages(
+        doc_page_copies = copy_root_pages(
             root_page=documentation_root_page,
             title_suffix=root_page_title_suffix,
         )
-        assert isinstance(root_page, DocumentationRootPage)
-        root_page.plan = plan_copy
-        root_page.save(update_fields=['plan'])
-        register_page_copies(clone_visitor, documentation_root_page, root_page)
+        for original_doc_root, doc_root_copy in doc_page_copies:
+            register_page_copies(clone_visitor, original_doc_root, doc_root_copy)
+        doc_root_page_copy = doc_page_copies[0][1]
+        assert isinstance(doc_root_page_copy, DocumentationRootPage)
+        doc_root_page_copy.plan = plan_copy
+        doc_root_page_copy.save(update_fields=['plan'])
 
     # Attribute types use generic foreign keys, so we need to copy them ourselves
     plan_ct = ContentType.objects.get_for_model(Plan)
@@ -1089,8 +1098,13 @@ def update_references_in_indicators(indicators: list[Indicator], clone_visitor: 
     # indicator we copied.
     indicator_pks = {i.pk for i in indicators}
     def filter_reference(ref: ReferenceIndex) -> bool:
-        field, pk_str, _ = ref.content_path.split('.')
-        return field == 'indicators' and int(pk_str) in indicator_pks
+        parts = ref.content_path.split('.', maxsplit=2)
+        if len(parts) < 2:
+            return False
+        field, pk_str = parts[0], parts[1]
+        if field != 'indicators' or not pk_str.isdigit():
+            return False
+        return int(pk_str) in indicator_pks
 
     # Collect all organizations that contain the copied indicators
     org_ids = set()

--- a/copying/main.py
+++ b/copying/main.py
@@ -469,9 +469,11 @@ class UpdateReferencesVisitor(AbstractVisitor):
 
     @get_references.register
     def _(self, instance: Page) -> Generator[Field | GenericForeignKey]:
-        # Pages are copied via Wagtail's Page.copy(), which handles page_ptr, latest_revision, and live_revision
-        # internally. These objects are not registered in the clone visitor, so skip them to avoid spurious warnings.
-        return self._get_references(instance, exclude_fields=['page_ptr', 'latest_revision', 'live_revision'])
+        # Pages are copied via Wagtail's Page.copy(), which handles certain fields  internally. These objects are not
+        # registered in the clone visitor, so skip them to avoid spurious warnings.
+        return self._get_references(instance, exclude_fields=[
+            'page_ptr', 'latest_revision', 'live_revision', 'staticpage_ptr',
+        ])
 
     def update_extractable_references(self, instance: Model) -> bool:
         updated = False
@@ -880,20 +882,19 @@ def register_page_copies(clone_visitor: CloneVisitor, original_root: Page, root_
             clone_visitor.register_copy(original_child, child_copy)
 
 
-def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, copy_indicators: bool) -> str:
+def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, new_site_hostname: str, copy_indicators: bool) -> None:
     """
     Validate arguments for copy_plan before any mutations.
 
-    Returns the new site hostname. Raises ValueError if validation fails.
+    Raises ValueError if validation fails.
     """
     if Plan.objects.filter(identifier=new_plan_identifier).exists():
         raise ValueError(f"A plan with identifier '{new_plan_identifier}' already exists")
-    new_site_hostname = _new_site_hostname(plan, new_plan_identifier)
     if Site.objects.filter(hostname=new_site_hostname).exists():
         raise ValueError(f"A site with hostname '{new_site_hostname}' already exists")
 
     if not copy_indicators:
-        return new_site_hostname
+        return
 
     plan_has_shared_indicator = (
         IndicatorLevel.objects.filter(indicator__in=plan.indicators.all())
@@ -905,8 +906,6 @@ def _validate_copy_plan_args(plan: Plan, new_plan_identifier: str, copy_indicato
     # organization_id)` in `Indicator` prevents us from copying indicators that are instances of a common indicator.
     if plan.indicators.filter(common__isnull=False).exists():
         raise ValueError("Cannot copy indicators as some are instances of a common indicator")
-
-    return new_site_hostname
 
 
 def _clone_plan_objects(
@@ -1034,7 +1033,8 @@ def copy_plan(
     if new_plan_name is None:
         new_plan_name = plan.default_name_for_copying()
 
-    new_site_hostname = _validate_copy_plan_args(plan, new_plan_identifier, copy_indicators)
+    new_site_hostname = _new_site_hostname(plan, new_plan_identifier)
+    _validate_copy_plan_args(plan, new_plan_identifier, new_site_hostname, copy_indicators)
 
     clone_visitor = CloneVisitor(
         site_hostname=new_site_hostname,

--- a/copying/management/commands/copy_plan.py
+++ b/copying/management/commands/copy_plan.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from django.core.management.base import BaseCommand
-from django.db import transaction
 
 from actions.models.plan import Plan
 
@@ -54,15 +53,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         plan = Plan.objects.get(identifier=options['identifier'])
-        with transaction.atomic():
-            copy_plan(
-                plan=plan,
-                new_plan_identifier=options['dest_identifier'],
-                new_plan_name=options['dest_name'],
-                general_name_suffix=options['name_suffix'],
-                root_page_title_suffix=options['root_page_title_suffix'],
-                version_name=options['version_name'],
-                supersede_original_plan=options['supersede_original_plan'],
-                supersede_original_actions=options['supersede_original_actions'],
-                copy_indicators=options['copy_indicators'],
-            )
+        copy_plan(
+            plan=plan,
+            new_plan_identifier=options['dest_identifier'],
+            new_plan_name=options['dest_name'],
+            general_name_suffix=options['name_suffix'],
+            root_page_title_suffix=options['root_page_title_suffix'],
+            version_name=options['version_name'],
+            supersede_original_plan=options['supersede_original_plan'],
+            supersede_original_actions=options['supersede_original_actions'],
+            copy_indicators=options['copy_indicators'],
+        )

--- a/copying/tasks.py
+++ b/copying/tasks.py
@@ -15,6 +15,7 @@ def copy_plan(
     version_name: str,
     supersede_original_plan: bool,
     supersede_original_actions: bool,
+    copy_indicators: bool,
 ):
     plan = Plan.objects.get(id=plan_id)
     copy_plan_implementation(
@@ -24,4 +25,5 @@ def copy_plan(
         version_name=version_name,
         supersede_original_plan=supersede_original_plan,
         supersede_original_actions=supersede_original_actions,
+        copy_indicators=copy_indicators,
     )

--- a/copying/tasks.py
+++ b/copying/tasks.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from django.db import transaction
-
 from celery import shared_task
 
 from actions.models.plan import Plan
@@ -19,12 +17,11 @@ def copy_plan(
     supersede_original_actions: bool,
 ):
     plan = Plan.objects.get(id=plan_id)
-    with transaction.atomic():
-        copy_plan_implementation(
-            plan=plan,
-            new_plan_identifier=new_plan_identifier,
-            new_plan_name=new_plan_name,
-            version_name=version_name,
-            supersede_original_plan=supersede_original_plan,
-            supersede_original_actions=supersede_original_actions,
-        )
+    copy_plan_implementation(
+        plan=plan,
+        new_plan_identifier=new_plan_identifier,
+        new_plan_name=new_plan_name,
+        version_name=version_name,
+        supersede_original_plan=supersede_original_plan,
+        supersede_original_actions=supersede_original_actions,
+    )

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from django.contrib.contenttypes.models import ContentType
-from wagtail.models import Revision
+from wagtail.models import Page, Revision
 from wagtail.rich_text import RichText
 
 import pytest
 
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
+from actions.models.category import CategoryType
 from actions.models.plan import Plan
 from actions.tests.factories import (
     ActionContactFactory,
@@ -21,6 +22,7 @@ from actions.tests.factories import (
     PlanFactory,
     WorkflowFactory,
 )
+from documentation.models import DocumentationRootPage
 from django.db import transaction
 from wagtail.models.reference_index import ReferenceIndex
 
@@ -594,6 +596,59 @@ def test_report_type_category_field_references_are_updated(plan_with_pages):
     category_type_copy = category_field_copy.value['category_type']
     assert category_type_copy.pk != category_type.pk
     assert category_type_copy.plan == plan_copy
+
+
+def test_documentation_pages_are_copied(plan_with_pages):
+    global_root = Page.get_first_root_node()
+    assert global_root is not None
+    doc_root = DocumentationRootPage(title='Documentation', plan=plan_with_pages, slug='docs')
+    global_root.add_child(instance=doc_root)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    assert plan_copy.documentation_root_pages.count() == 1
+    doc_root_copy = plan_copy.documentation_root_pages.get()
+    assert doc_root_copy.pk != doc_root.pk
+    assert doc_root_copy.plan == plan_copy
+
+
+def test_documentation_pages_original_is_unchanged(plan_with_pages):
+    global_root = Page.get_first_root_node()
+    assert global_root is not None
+    doc_root = DocumentationRootPage(title='Documentation', plan=plan_with_pages, slug='docs')
+    global_root.add_child(instance=doc_root)
+
+    copy_plan(plan_with_pages)
+
+    doc_root.refresh_from_db()
+    assert doc_root.plan == plan_with_pages
+    assert plan_with_pages.documentation_root_pages.count() == 1
+
+
+def test_copy_attribute_types_excludes_other_plans_category_type_scoped_attribute_types(plan_with_pages):
+    # AttributeType uses a generic foreign key for its scope, so _copy_attribute_types must filter by
+    # scope_id__in=plan.category_types.all() to avoid accidentally copying attribute types that belong
+    # to another plan's category types. A regression in that filter could silently copy foreign attribute
+    # types into the plan copy, corrupting the copied plan's data.
+    category_type = CategoryTypeFactory.create(plan=plan_with_pages)
+    attribute_type = AttributeTypeFactory.create(scope=category_type)
+
+    other_plan = PlanFactory.create()
+    other_category_type = CategoryTypeFactory.create(plan=other_plan)
+    other_attribute_type = AttributeTypeFactory.create(scope=other_category_type)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    category_type_ct = ContentType.objects.get_for_model(CategoryType)
+    category_type_copy = plan_copy.category_types.get()
+    copied_ats = AttributeType.objects.filter(scope_content_type=category_type_ct, scope_id=category_type_copy.pk)
+    assert copied_ats.count() == 1
+    assert copied_ats.get().pk != attribute_type.pk
+
+    # The other plan's attribute type must not be copied or modified
+    other_ats = AttributeType.objects.filter(scope_content_type=category_type_ct, scope_id=other_category_type.pk)
+    assert other_ats.count() == 1
+    assert other_ats.get() == other_attribute_type
 
 
 class TestUpdateReferenceIndexImmediately:

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -7,9 +7,15 @@ from wagtail.rich_text import RichText
 import pytest
 
 from actions.models.action import Action
+from actions.models.attributes import AttributeType
+from actions.models.plan import Plan
 from actions.tests.factories import (
     ActionContactFactory,
     ActionStatusFactory,
+    ActionTaskFactory,
+    AttributeChoiceWithTextFactory,
+    AttributeRichTextFactory,
+    AttributeTypeChoiceOptionFactory,
     AttributeTypeFactory,
     CategoryTypeFactory,
     PlanFactory,
@@ -422,6 +428,69 @@ def test_indicator_reference_in_action_draft_updated_when_copying_indicators(
     indicator_copy = plan_copy.indicators.get(name=indicator.name)
     draft_obj = action_copy.latest_revision.as_object()
     assert draft_obj.description == html_with_references([indicator_copy])
+
+
+@pytest.mark.parametrize('indicator__common', [None])
+def test_indicator_reference_in_action_task_comment_updated_when_copying_indicators(
+    plan_with_pages, action, indicator,
+):
+    """When copying a plan with indicators, indicator references in action task comments should be updated."""
+    task = ActionTaskFactory.create(action=action, comment=html_with_references([indicator]))
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+    action_copy = plan_copy.actions.get()
+    task_copy = action_copy.tasks.get(name=task.name)
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    assert task_copy.comment == html_with_references([indicator_copy])
+
+
+@pytest.mark.parametrize('indicator__common', [None])
+def test_indicator_reference_in_attribute_rich_text_updated_when_copying_indicators(
+    plan_with_pages, action, indicator,
+):
+    """When copying a plan with indicators, indicator references in AttributeRichText.text should be updated."""
+    action_ct = ContentType.objects.get_for_model(Action)
+    plan_ct = ContentType.objects.get_for_model(Plan)
+    attribute_type = AttributeTypeFactory.create(
+        scope=plan_with_pages,
+        object_content_type=action_ct,
+        format=AttributeType.AttributeFormat.RICH_TEXT,
+    )
+    AttributeRichTextFactory.create(
+        type=attribute_type,
+        content_object=action,
+        text=html_with_references([indicator]),
+    )
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    at_copy = AttributeType.objects.get(scope_content_type=plan_ct, scope_id=plan_copy.pk, name=attribute_type.name)
+    rich_text_attr_copy = at_copy.rich_text_attributes.get()
+    assert rich_text_attr_copy.text == html_with_references([indicator_copy])
+
+
+@pytest.mark.parametrize('indicator__common', [None])
+def test_indicator_reference_in_attribute_choice_with_text_updated_when_copying_indicators(
+    plan_with_pages, action, indicator,
+):
+    """When copying a plan with indicators, indicator references in AttributeChoiceWithText.text should be updated."""
+    action_ct = ContentType.objects.get_for_model(Action)
+    plan_ct = ContentType.objects.get_for_model(Plan)
+    attribute_type = AttributeTypeFactory.create(
+        scope=plan_with_pages,
+        object_content_type=action_ct,
+        format=AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT,
+    )
+    choice_option = AttributeTypeChoiceOptionFactory.create(type=attribute_type)
+    AttributeChoiceWithTextFactory.create(
+        type=attribute_type,
+        content_object=action,
+        choice=choice_option,
+        text=html_with_references([indicator]),
+    )
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    at_copy = AttributeType.objects.get(scope_content_type=plan_ct, scope_id=plan_copy.pk, name=attribute_type.name)
+    choice_with_text_attr_copy = at_copy.choice_with_text_attributes.get()
+    assert choice_with_text_attr_copy.text == html_with_references([indicator_copy])
 
 
 def test_action_revision_is_copied(plan_with_pages, action, user):

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -395,6 +395,35 @@ def test_rich_text_field_indicator_references(plan_with_pages):
     assert indicator2_copy.description == html_with_references([indicator1_copy])
 
 
+@pytest.mark.parametrize('indicator__common', [None])
+def test_indicator_reference_in_action_description_updated_when_copying_indicators(
+    plan_with_pages, action, indicator,
+):
+    """When copying a plan with indicators, indicator references in action descriptions should be updated."""
+    action.description = html_with_references([indicator])
+    action.save(update_fields=['description'])
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+    action_copy = plan_copy.actions.get()
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    assert action_copy.description == html_with_references([indicator_copy])
+
+
+@pytest.mark.parametrize('indicator__common', [None])
+def test_indicator_reference_in_action_draft_updated_when_copying_indicators(
+    plan_with_pages, action, indicator, user,
+):
+    """When copying a plan with indicators, indicator references in action draft descriptions should be updated."""
+    action.description = html_with_references([indicator])
+    action.save(update_fields=['description'])
+    action.save_revision(user=user)
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+    action_copy = plan_copy.actions.get()
+    assert action_copy.latest_revision is not None
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    draft_obj = action_copy.latest_revision.as_object()
+    assert draft_obj.description == html_with_references([indicator_copy])
+
+
 def test_action_revision_is_copied(plan_with_pages, action, user):
     action.save_revision(user=user)
     plan_copy = copy_plan(plan_with_pages)

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -6,7 +6,7 @@ from wagtail.rich_text import RichText
 import pytest
 
 from actions.tests.factories import ActionContactFactory, PlanFactory, WorkflowFactory
-from copying.main import copy_plan
+from copying.main import _new_site_hostname, _validate_copy_plan_args, copy_plan
 from documents.models import AplansDocument
 from documents.tests.factories import AplansDocumentFactory
 from images.models import AplansImage
@@ -25,6 +25,47 @@ from pages.models import StaticPage
 from pages.tests.factories import CategoryTypePageLevelLayoutFactory
 
 pytestmark = pytest.mark.django_db
+
+
+class TestValidateCopyPlanArgs:
+    def test_rejects_duplicate_plan_identifier(self, plan):
+        new_site_hostname = _new_site_hostname(plan, 'new-identifier')
+        with pytest.raises(ValueError, match="already exists"):
+            _validate_copy_plan_args(plan, plan.identifier, new_site_hostname, copy_indicators=False)
+
+    def test_rejects_duplicate_site_hostname(self, plan_with_pages):
+        assert plan_with_pages.site is not None
+        existing_hostname = plan_with_pages.site.hostname
+        with pytest.raises(ValueError, match="already exists"):
+            _validate_copy_plan_args(plan_with_pages, 'unique-identifier', existing_hostname, copy_indicators=False)
+
+    def test_passes_with_valid_args(self, plan):
+        new_identifier = 'brand-new-plan'
+        new_site_hostname = _new_site_hostname(plan, new_identifier)
+        # Should not raise
+        _validate_copy_plan_args(plan, new_identifier, new_site_hostname, copy_indicators=False)
+
+    def test_rejects_shared_indicators(self, plan, indicator):
+        another_plan = PlanFactory.create()
+        IndicatorLevelFactory.create(plan=another_plan, indicator=indicator)
+        new_identifier = 'new-plan'
+        new_site_hostname = _new_site_hostname(plan, new_identifier)
+        with pytest.raises(ValueError, match='shares indicators with another plan'):
+            _validate_copy_plan_args(plan, new_identifier, new_site_hostname, copy_indicators=True)
+
+    def test_rejects_common_indicator_instances(self, plan, indicator):
+        assert indicator.common is not None
+        new_identifier = 'new-plan'
+        new_site_hostname = _new_site_hostname(plan, new_identifier)
+        with pytest.raises(ValueError, match='some are instances of a common indicator'):
+            _validate_copy_plan_args(plan, new_identifier, new_site_hostname, copy_indicators=True)
+
+    @pytest.mark.parametrize('indicator__common', [None])
+    def test_passes_with_copy_indicators(self, plan, indicator):
+        new_identifier = 'new-plan'
+        new_site_hostname = _new_site_hostname(plan, new_identifier)
+        # Should not raise when indicators are not shared and have no common indicator
+        _validate_copy_plan_args(plan, new_identifier, new_site_hostname, copy_indicators=True)
 
 
 def get_page_copy(page, plan_copy):

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -15,7 +15,18 @@ from actions.tests.factories import (
     PlanFactory,
     WorkflowFactory,
 )
-from copying.main import _new_site_hostname, _validate_copy_plan_args, copy_plan
+from django.db import transaction
+from wagtail.models.reference_index import ReferenceIndex
+
+from copying.main import (
+    CloneVisitor,
+    UpdateReferencesVisitor,
+    _clone_plan_objects,
+    _new_site_hostname,
+    _update_reference_index_immediately_ctx,
+    _validate_copy_plan_args,
+    copy_plan,
+)
 from documents.models import AplansDocument
 from documents.tests.factories import AplansDocumentFactory
 from images.models import AplansImage
@@ -485,3 +496,67 @@ def test_report_type_category_field_references_are_updated(plan_with_pages):
     category_type_copy = category_field_copy.value['category_type']
     assert category_type_copy.pk != category_type.pk
     assert category_type_copy.plan == plan_copy
+
+
+class TestUpdateReferenceIndexImmediately:
+    def test_forces_immediate_indexing(self, plan_with_pages, static_page):
+        doc = AplansDocumentFactory.create(collection=plan_with_pages.root_collection, title='doc')
+        # StaticPage is tracked by Wagtail's reference index.
+        # Without the context manager, the index update is deferred to transaction commit,
+        # which never happens in test transactions — so the index stays empty.
+        static_page.body = [('paragraph', RichText(html_with_references([doc])))]
+        static_page.save()
+        assert list(ReferenceIndex.get_references_for_object(static_page)) == []
+
+        # With the context manager, enqueue_on_commit=False causes the index to be updated immediately.
+        with _update_reference_index_immediately_ctx():
+            static_page.save()
+        refs = list(ReferenceIndex.get_references_for_object(static_page))
+        assert any(str(ref.to_object_id) == str(doc.pk) for ref in refs)
+
+    def test_update_indexed_references_uses_immediate_index(self, plan_with_pages, static_page):
+        doc = AplansDocumentFactory.create(collection=plan_with_pages.root_collection, title='doc')
+        # doc_copy uses the same title so html_with_references produces the same text content.
+        doc_copy = AplansDocumentFactory.create(collection=plan_with_pages.root_collection, title='doc')
+
+        static_page.body = [('paragraph', RichText(html_with_references([doc])))]
+
+        clone_visitor = CloneVisitor(site_hostname='copy.example.com')
+        clone_visitor.register_copy(doc, doc_copy)
+        # Register static_page as a "copy" so _update_stream_field_reference allows modifying it.
+        fake_original = StaticPage(pk=static_page.pk + 999999)
+        clone_visitor.register_copy(fake_original, static_page)
+
+        # Save within the context manager so the reference index is updated immediately.
+        with _update_reference_index_immediately_ctx():
+            static_page.save()
+
+        fields = UpdateReferencesVisitor(clone_visitor).update_indexed_references(static_page)
+        assert 'body' in fields
+        assert static_page.body[0].value.source == html_with_references([doc_copy])
+
+    def test_without_decorator_leaves_stale_rich_text_references(self, plan_with_pages, static_page):
+        doc = AplansDocumentFactory.create(collection=plan_with_pages.root_collection, title='doc')
+        static_page.body = [('paragraph', RichText(html_with_references([doc])))]
+        static_page.save()
+
+        new_plan_identifier = plan_with_pages.default_identifier_for_copying()
+        new_plan_name = plan_with_pages.default_name_for_copying()
+        new_site_hostname = _new_site_hostname(plan_with_pages, new_plan_identifier)
+        clone_visitor = CloneVisitor(
+            site_hostname=new_site_hostname,
+            plan_identifier=new_plan_identifier,
+            plan_name=new_plan_name,
+        )
+
+        # Call _clone_plan_objects directly without the @update_reference_index_immediately decorator.
+        with transaction.atomic():
+            plan_copy = _clone_plan_objects(plan_with_pages, clone_visitor, None, copy_indicators=False)
+
+        page_copy = plan_copy.root_page.get_children().type(StaticPage).get().specific
+        assert isinstance(page_copy, StaticPage)
+        doc_copy = AplansDocument.objects.get(collection=plan_copy.root_collection, title=doc.title)
+        # Without the decorator, update_indexed_references() finds nothing in the un-updated index.
+        # The page copy's body still references the original doc pk (stale reference).
+        assert page_copy.body[0].value.source == html_with_references([doc])
+        assert page_copy.body[0].value.source != html_with_references([doc_copy])

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from django.contrib.contenttypes.models import ContentType
 from wagtail.models import Revision
 from wagtail.rich_text import RichText
 
 import pytest
 
+from actions.models.action import Action
 from actions.tests.factories import (
     ActionContactFactory,
     ActionStatusFactory,
+    AttributeTypeFactory,
+    CategoryTypeFactory,
     PlanFactory,
     WorkflowFactory,
 )
@@ -28,6 +32,7 @@ from indicators.tests.factories import (
 )
 from pages.models import StaticPage
 from pages.tests.factories import CategoryTypePageLevelLayoutFactory
+from reports.tests.factories import ReportTypeFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -444,3 +449,39 @@ def test_model_without_revision_is_not_affected(plan_with_pages, action):
     plan_copy = copy_plan(plan_with_pages)
     action_copy = plan_copy.actions.get()
     assert action_copy.latest_revision is None
+
+
+def test_report_type_attribute_field_references_are_updated(plan_with_pages):
+    """When copying a plan, attribute_type references in ReportType.fields are updated to the copy."""
+    action_ct = ContentType.objects.get_for_model(Action)
+    attribute_type = AttributeTypeFactory.create(
+        scope=plan_with_pages,
+        object_content_type=action_ct,
+    )
+    ReportTypeFactory.create(
+        plan=plan_with_pages,
+        fields__0__attribute__attribute_type=attribute_type,
+    )
+    plan_copy = copy_plan(plan_with_pages)
+    report_type_copy = plan_copy.report_types.get()
+    attribute_field_copy = report_type_copy.fields[0]
+    assert attribute_field_copy.block_type == 'attribute'
+    attribute_type_copy = attribute_field_copy.value['attribute_type']
+    assert attribute_type_copy.pk != attribute_type.pk
+    assert attribute_type_copy.scope_id == plan_copy.pk
+
+
+def test_report_type_category_field_references_are_updated(plan_with_pages):
+    """When copying a plan, category_type references in ReportType.fields are updated to the copy."""
+    category_type = CategoryTypeFactory.create(plan=plan_with_pages)
+    ReportTypeFactory.create(
+        plan=plan_with_pages,
+        fields__0__categories__category_type=category_type,
+    )
+    plan_copy = copy_plan(plan_with_pages)
+    report_type_copy = plan_copy.report_types.get()
+    category_field_copy = report_type_copy.fields[0]
+    assert category_field_copy.block_type == 'categories'
+    category_type_copy = category_field_copy.value['category_type']
+    assert category_type_copy.pk != category_type.pk
+    assert category_type_copy.plan == plan_copy

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
 from wagtail.models import Page, Revision
+from wagtail.models.reference_index import ReferenceIndex
 from wagtail.rich_text import RichText
 
 import pytest
@@ -22,10 +24,6 @@ from actions.tests.factories import (
     PlanFactory,
     WorkflowFactory,
 )
-from documentation.models import DocumentationRootPage
-from django.db import transaction
-from wagtail.models.reference_index import ReferenceIndex
-
 from copying.main import (
     CloneVisitor,
     UpdateReferencesVisitor,
@@ -35,6 +33,7 @@ from copying.main import (
     _validate_copy_plan_args,
     copy_plan,
 )
+from documentation.models import DocumentationRootPage
 from documents.models import AplansDocument
 from documents.tests.factories import AplansDocumentFactory
 from images.models import AplansImage
@@ -512,6 +511,7 @@ def test_action_revision_references_are_updated(plan_with_pages, action, user):
     action.save_revision(user=user)
     plan_copy = copy_plan(plan_with_pages)
     action_copy = plan_copy.actions.get()
+    assert action_copy.latest_revision is not None
     rev_obj = action_copy.latest_revision.as_object()
     assert rev_obj.plan_id == plan_copy.pk
 
@@ -711,5 +711,9 @@ class TestUpdateReferenceIndexImmediately:
         doc_copy = AplansDocument.objects.get(collection=plan_copy.root_collection, title=doc.title)
         # Without the decorator, update_indexed_references() finds nothing in the un-updated index.
         # The page copy's body still references the original doc pk (stale reference).
-        assert page_copy.body[0].value.source == html_with_references([doc])
-        assert page_copy.body[0].value.source != html_with_references([doc_copy])
+        body = page_copy.body
+        assert body is not None
+        body_value = body[0].value
+        assert body_value is not None
+        assert body_value.source == html_with_references([doc])
+        assert body_value.source != html_with_references([doc_copy])

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -415,21 +415,24 @@ def test_original_action_revision_is_unchanged(plan_with_pages, action, user):
     assert original_rev_obj.uuid == action.uuid
 
 
-def test_model_with_deserializable_revision_skipped_gracefully(plan_with_pages):
+def test_non_clusterable_model_revision_is_copied(plan_with_pages):
     """
-    Verify that copy_revisions skips models with incompatible revision deserialization.
+    Verify that revisions are copied for non-ClusterableModel RevisionMixin models.
 
-    RevisionMixin models whose i18n default_language_field traverses a regular ForeignKey (not ParentalKey) fail to
-    deserialize via as_object() due to a modeltrans/modelcluster incompatibility.
+    These models have i18n default_language_field that traverses a regular ForeignKey
+    (not ParentalKey), e.g., 'plan__primary_language_lowercase'.
     """
     action_status = ActionStatusFactory.create(plan=plan_with_pages, name='On time')
     action_status.save_revision()
     original_rev = action_status.latest_revision
-    # Should not crash — the revision is skipped with a warning
     plan_copy = copy_plan(plan_with_pages)
     status_copy = plan_copy.action_statuses.get(name='On time')
-    # Revision is not copied because as_object() fails for this model
-    assert status_copy.latest_revision is None
+    # Revision is copied and points to the copy's plan
+    assert status_copy.latest_revision is not None
+    assert status_copy.latest_revision != original_rev
+    rev_obj = status_copy.latest_revision.as_object()
+    assert rev_obj.pk == status_copy.pk
+    assert rev_obj.plan_id == plan_copy.pk
     # The original's revision is unchanged
     action_status.refresh_from_db()
     assert action_status.latest_revision == original_rev

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -5,7 +5,12 @@ from wagtail.rich_text import RichText
 
 import pytest
 
-from actions.tests.factories import ActionContactFactory, PlanFactory, WorkflowFactory
+from actions.tests.factories import (
+    ActionContactFactory,
+    ActionStatusFactory,
+    PlanFactory,
+    WorkflowFactory,
+)
 from copying.main import _new_site_hostname, _validate_copy_plan_args, copy_plan
 from documents.models import AplansDocument
 from documents.tests.factories import AplansDocumentFactory
@@ -372,3 +377,67 @@ def test_rich_text_field_indicator_references(plan_with_pages):
     assert indicator2 != indicator2_copy
     assert indicator1_copy.description == indicator1.description
     assert indicator2_copy.description == html_with_references([indicator1_copy])
+
+
+def test_action_revision_is_copied(plan_with_pages, action, user):
+    action.save_revision(user=user)
+    plan_copy = copy_plan(plan_with_pages)
+    action_copy = plan_copy.actions.get()
+    assert isinstance(action_copy.latest_revision, Revision)
+    assert action_copy.latest_revision != action.latest_revision
+    rev_obj = action_copy.latest_revision.as_object()
+    assert rev_obj.pk == action_copy.pk
+    assert rev_obj.uuid == action_copy.uuid
+    assert rev_obj.name == action.name
+
+
+def test_action_revision_references_are_updated(plan_with_pages, action, user):
+    """The revision content should reference the copied plan, not the original."""
+    action.save_revision(user=user)
+    plan_copy = copy_plan(plan_with_pages)
+    action_copy = plan_copy.actions.get()
+    rev_obj = action_copy.latest_revision.as_object()
+    assert rev_obj.plan_id == plan_copy.pk
+
+
+def test_original_action_revision_is_unchanged(plan_with_pages, action, user):
+    """Copying a plan must not modify the original action's revision."""
+    action.save_revision(user=user)
+    original_rev_pk = action.latest_revision.pk
+    copy_plan(plan_with_pages)
+    action.refresh_from_db()
+    # The original action still points to the same revision
+    assert action.latest_revision_id == original_rev_pk
+    # The revision content is unchanged (references still point to the original plan)
+    original_rev_obj = action.latest_revision.as_object()
+    assert original_rev_obj.plan_id == plan_with_pages.pk
+    assert original_rev_obj.pk == action.pk
+    assert original_rev_obj.uuid == action.uuid
+
+
+def test_model_with_deserializable_revision_skipped_gracefully(plan_with_pages):
+    """
+    Verify that copy_revisions skips models with incompatible revision deserialization.
+
+    RevisionMixin models whose i18n default_language_field traverses a regular ForeignKey (not ParentalKey) fail to
+    deserialize via as_object() due to a modeltrans/modelcluster incompatibility.
+    """
+    action_status = ActionStatusFactory.create(plan=plan_with_pages, name='On time')
+    action_status.save_revision()
+    original_rev = action_status.latest_revision
+    # Should not crash — the revision is skipped with a warning
+    plan_copy = copy_plan(plan_with_pages)
+    status_copy = plan_copy.action_statuses.get(name='On time')
+    # Revision is not copied because as_object() fails for this model
+    assert status_copy.latest_revision is None
+    # The original's revision is unchanged
+    action_status.refresh_from_db()
+    assert action_status.latest_revision == original_rev
+
+
+def test_model_without_revision_is_not_affected(plan_with_pages, action):
+    """Models without a latest_revision should not get a revision created by copying."""
+    assert action.latest_revision is None
+    plan_copy = copy_plan(plan_with_pages)
+    action_copy = plan_copy.actions.get()
+    assert action_copy.latest_revision is None

--- a/copying/views.py
+++ b/copying/views.py
@@ -15,6 +15,7 @@ from celery.contrib.django.task import DjangoTask
 from loguru import logger
 
 from actions.models.plan import Plan
+from copying.main import may_copy_indicators
 from copying.tasks import copy_plan
 
 if TYPE_CHECKING:
@@ -60,6 +61,16 @@ class PlanCopyForm(forms.Form):
             help_text=_("Set if copies of actions should supersede their original"),
             initial=False,
             required=False,
+        )
+        self.fields['copy_indicators'] = forms.BooleanField(
+            label=_("Copy indicators"),
+            help_text=_(
+                "Set if indicators should be copied instead of being shared with the original plan. "
+                "This is only allowed if the plan has no shared indicators yet."
+            ),
+            initial=False,
+            required=False,
+            disabled=not may_copy_indicators(self.plan),
         )
 
     def clean_identifier(self) -> str:
@@ -131,6 +142,7 @@ class PlanCopyView(WagtailAdminTemplateMixin, FormView):
             version_name=form.cleaned_data['version_name'],
             supersede_original_plan=form.cleaned_data['supersede_original_plan'],
             supersede_original_actions=form.cleaned_data['supersede_original_actions'],
+            copy_indicators=form.cleaned_data['copy_indicators'],
         )
         messages.success(self.request, _(
             "The copy will be created in the background. This may take a few minutes. The copy will appear in the list "

--- a/copying/views.py
+++ b/copying/views.py
@@ -66,7 +66,8 @@ class PlanCopyForm(forms.Form):
             label=_("Copy indicators"),
             help_text=_(
                 "Set if indicators should be copied instead of being shared with the original plan. "
-                "This is only allowed if the plan has no shared indicators yet."
+                "Indicators can only be copied if no indicator is shared with another plan or is an instance of a common "
+                "indicator."
             ),
             initial=False,
             required=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,7 @@ authenticate = "always"
 
 [tool.uv.sources]
 graphene-django-optimizer = { url = "https://github.com/kausaltech/graphene-django-optimizer/archive/f18d827d0d58c1148288b6b886c167dd2fc1931a.zip" }
-django-modeltrans = { url = "https://github.com/kausaltech/django-modeltrans/archive/a734040c3f38c2e404a61dc0be2c017874a9ea45.zip" }
+django-modeltrans = { url = "https://github.com/kausaltech/django-modeltrans/archive/37ed924498fa0e6a431e0b6fc1e6982a3f3b3a84.zip" }
 kausal-paths-extensions = { index = "kausal"}
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -746,15 +746,15 @@ wheels = [
 
 [[package]]
 name = "django-modeltrans"
-version = "0.7.5"
-source = { url = "https://github.com/kausaltech/django-modeltrans/archive/a734040c3f38c2e404a61dc0be2c017874a9ea45.zip" }
+version = "0.9.0"
+source = { url = "https://github.com/kausaltech/django-modeltrans/archive/37ed924498fa0e6a431e0b6fc1e6982a3f3b3a84.zip" }
 dependencies = [
     { name = "django", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { hash = "sha256:4bc9c5feb7fb675ac6a23980e7f616207d68d76fc346b4ba6b0511871c9980c0" }
+sdist = { hash = "sha256:36c83d5c370efe0afbf6a7b3121d1a74e2a6e6345aa9960b07bd7d5bd4582c74" }
 
 [package.metadata]
-requires-dist = [{ name = "django", specifier = ">=3.2" }]
+requires-dist = [{ name = "django", specifier = ">=4.2" }]
 
 [[package]]
 name = "django-npm"
@@ -1822,7 +1822,7 @@ requires-dist = [
     { name = "django-filter" },
     { name = "django-hijack" },
     { name = "django-image-cropping" },
-    { name = "django-modeltrans", url = "https://github.com/kausaltech/django-modeltrans/archive/a734040c3f38c2e404a61dc0be2c017874a9ea45.zip" },
+    { name = "django-modeltrans", url = "https://github.com/kausaltech/django-modeltrans/archive/37ed924498fa0e6a431e0b6fc1e6982a3f3b3a84.zip" },
     { name = "django-npm" },
     { name = "django-oauth-toolkit" },
     { name = "django-parler" },


### PR DESCRIPTION
## Description

### Summary

- **New feature: Optional indicator copying** — The plan copy UI now offers a "Copy indicators" checkbox. When enabled, indicators are fully copied into the new plan rather than shared with the original. The option is disabled if the plan already has shared indicators with other plans.
- **Report types are now copied** — Previously excluded due to unresolved attribute type references in streamfield JSON; this has been fixed and report types are now included in the copy.
- **Fixed indicator references not updated in action draft descriptions** — References to indicators embedded in rich text draft content were not being remapped after copying.
- **Fixed page translation registration and root page handling** — Several robustness issues in copying Wagtail pages, including a wrong assertion for `DocumentationRootPage` translations and root pages not being registered in the copy map.
- **Fixed page-internal fields causing spurious warnings** — Fields like `latest_revision` and `live_revision` are now excluded from reference update processing since Wagtail manages them internally.
- **Dependency upgrade: `django-modeltrans`** — Updated to fix a bug affecting model field translations.

### Refactoring

- `copy_plan()` decomposed into focused helpers: `_validate_copy_plan_args`, `_copy_collection_site_and_pages`, `_copy_plan_with_structure`, `_copy_documentation_pages`, `_copy_attribute_types`, `_copy_indicators`, `_clone_plan_objects`.
- `_get_original_pk` lookup optimized from O(n) to O(1) using a dedicated reverse-lookup dict.
- `MODELS_NOT_COPIED` list introduced to centralize which models are intentionally excluded from copying (e.g. `Organization`, `User`, `CommonIndicator`), suppressing spurious warnings for references to these models.
- `update_reference_index_immediately` context manager extracted for independent testability.
- `_remap_cluster_object_pk` extracted from `update_cluster_related_object`.
- Per-field-type handlers extracted from `update_reference` using `singledispatchmethod`.
- Local `visit_tree()` replaces `clone()` from `relations_iterator`.
- Transaction management moved into `copy_plan()` itself; callers no longer need to wrap in `transaction.atomic()`.

### Tests

- Unit tests added for: `_copy_documentation_pages`, `_copy_attribute_types`, `_update_reference_index_immediately_ctx`, `_validate_copy_plan_args` hostname computation.
- Integration tests verifying that indicator references in action tasks and attribute values (including draft content) are correctly remapped after copying.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213278068858210?focus=true)

## Requirements, dependencies and related PRs
Updates the dependency on our fork of django-modeltrans because this PR relies on a [bugfix](https://github.com/kausaltech/django-modeltrans/pull/1) in our fork.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
