### PR TITLE
Improve plan copying: exhaustive clone structure coverage and notification template/block copying

### DIFF
--- a/copying/main.py
+++ b/copying/main.py
@@ -59,24 +59,48 @@ if TYPE_CHECKING:
     from wagtail.documents.models import AbstractDocument
     from wagtail.images.models import AbstractImage
 
-    from relations_iterator import TreeNode
+    from relations_iterator import TreeNode  # type: ignore
 
-type CloneStructure = dict[str, CloneStructure]
+class Excluded:
+    """Sentinel: marks a relation as deliberately excluded from copying."""
+
+
+EXCLUDED = Excluded()
+
+type CloneEntry = CloneStructure | Excluded
+type CloneStructure = dict[str, CloneEntry]
 
 # TODO: Models from other apps: budget, feedback, etc.
 PLAN_CLONE_STRUCTURE: CloneStructure = {
-    'action_decision_levels': {},
-    'action_dependency_roles': {},
-    'action_impacts': {},
-    'action_implementation_phases': {},
-    'action_schedules': {},
-    'action_statuses': {},
+    'action_decision_levels': {
+        'actions': EXCLUDED,  # Action already copied via Plan → actions
+    },
+    'action_dependency_roles': {
+        'actions': EXCLUDED,  # Action already copied via Plan → actions
+    },
+    'action_impacts': {
+        'actions': EXCLUDED,  # Action already copied via Plan → actions
+    },
+    'action_implementation_phases': {
+        'actions': EXCLUDED,  # Action already copied via Plan → actions
+        'action': EXCLUDED,  # reverse OneToOne from Action.latest_phase; Action already copied
+    },
+    'action_schedules': {
+        'action': EXCLUDED,  # reverse M2M accessor; Action already copied via Plan → actions
+        'actionschedulethrough': EXCLUDED,  # ActionScheduleThrough already copied via actions → action_schedule_through
+    },
+    'action_statuses': {
+        'actions': EXCLUDED,  # Action already copied via Plan → actions
+        'action': EXCLUDED,  # reverse OneToOne from Action.latest_status; Action already copied
+    },
     'features': {},
     'actions': {
         'action_category_through': {},
         'action_monitoring_quality_points_through': {},
         'action_schedule_through': {},
-        'contact_persons': {},
+        'contact_persons': {
+            'notification_preferences': EXCLUDED,  # notification preferences are personal/runtime state, not plan content
+        },
         'dependent_relationships': {},
         'impact_groups': {},
         'links': {},
@@ -85,19 +109,48 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
         'responsible_parties': {},
         'status_updates': {},
         'tasks': {},
+        'preceding_relationships': EXCLUDED,  # reverse of dependent_relationships; already covered from the dependent side
+        'merged_actions': EXCLUDED,
+        'superseded_actions': EXCLUDED,
+        'copies': EXCLUDED,
+        'relatedactionsthrough': EXCLUDED,  # reverse of RelatedActionsThrough.to_action; covered via related_actions_through
+        'change_log_messages': EXCLUDED,
+        'pledge': EXCLUDED,
+        'pledgeactionthrough': EXCLUDED,
+        'user_feedbacks': EXCLUDED,
     },
     'built_in_field_customizations': {},
     'category_types': {
         'categories': {
             'indicator_category_through': {},  # We don't copy the indicators themselves
+            'icons': EXCLUDED,  # TODO: should likely be copied
+            'children': EXCLUDED,  # all categories are already copied via category_type → categories
+            'indicator_relationships': EXCLUDED,  # handled via the indicator side
+            'actions': EXCLUDED,  # reverse M2M; ActionCategoryThrough already copied via actions → action_category_through
+            'actioncategorythrough': EXCLUDED,  # same
+            'change_log_messages': EXCLUDED,
+            'user_feedbacks': EXCLUDED,
+            'indicators': EXCLUDED,  # reverse M2M; IndicatorCategoryThrough already copied via indicator_category_through
+            'category_pages': EXCLUDED,  # pages handled separately by Wagtail's copy mechanism
         },
-        'levels': {},
+        'levels': {
+            'level_layouts': EXCLUDED,  # pages handled separately by Wagtail's copy mechanism
+        },
+        'primary_classification_for_plan': EXCLUDED,  # back-reference to Plan (the root), not traversed from here
+        'secondary_classification_for_plan': EXCLUDED,  # same
+        'category_type_pages': EXCLUDED,  # pages handled separately by Wagtail's copy mechanism
+        'actionlistpage': EXCLUDED,  # same
     },
     'clients': {},
-    # 'domains': {},  # deliberately don't copy domains because hostname + base path should be unique
-    'general_admins_ordered': {},
+    'domains': EXCLUDED,  # deliberately not copied: hostname + base path must be unique per plan
+    'general_admins_ordered': {
+        'notification_preferences': EXCLUDED,  # notification preferences are personal/runtime state, not plan content
+    },
     'general_content': {},
-    'impact_groups': {},
+    'impact_groups': {
+        'actions': EXCLUDED,  # ImpactGroupAction already copied via actions → impact_groups
+        'children': EXCLUDED,  # all ImpactGroups are already copied via plan → impact_groups
+    },
     'indicator_levels': {},  # We copy the indicators themselves separately and optionally
     'notification_settings': {},
     'plan_common_category_types_through': {},
@@ -108,17 +161,37 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
         # original plan within the serialized data, and (b) it might be justifiable for many use cases to skip copying
         # reports. We could do something about (a) by meddling with the serialized data, but it's going to be an
         # error-prone ordeal, so maybe this is fine for now.
-        # 'reports': {
-        #     'action_snapshots': {},  # As we don't copy `action_version`, original action will be linked to snapshot
-        # },
+        'reports': EXCLUDED,  # deliberately not copied (see comment above)
     },
     'scenarios': {},
     # Note that `Dimension` instances are copied separately when `copy_indicators` is true.
     'dimensions': {},  # copies through model (`PlanDimension`) instances, not `Dimension` instances
+    'actionchangelogmessage_set': EXCLUDED,
+    'indicatorchangelogmessage_set': EXCLUDED,
+    'categorychangelogmessage_set': EXCLUDED,
+    'pagechangelogmessage_set': EXCLUDED,
+    'children': EXCLUDED,  # child plans are independent plans
+    'superseded_plans': EXCLUDED,
+    'copies': EXCLUDED,
+    'monitoring_quality_points': EXCLUDED,  # TODO: should likely be copied
+    'pledges': EXCLUDED,
+    'documentation_root_pages': EXCLUDED,  # handled separately by _copy_documentation_pages
+    'user_feedbacks': EXCLUDED,
+    'plan_common_indicator_through': EXCLUDED,  # common indicator assignments are not plan-owned
+    'indicators': EXCLUDED,  # handled separately via the copy_indicators parameter
+    'notification_base_template': EXCLUDED,  # TODO: should likely be copied
+    'organization_plan_admins': EXCLUDED,
+    'links': EXCLUDED,  # TODO: should likely be copied (PlanLink is a cluster child)
+    'planscopedmodellogentry': EXCLUDED,
+    'planscopedpagelogentry': EXCLUDED,
 }
 
 ATTRIBUTE_TYPE_CLONE_STRUCTURE: CloneStructure = {
-    'choice_options': {},
+    'choice_options': {
+        'choice_attributes': EXCLUDED,  # AttributeChoice already copied via AttributeType → choice_attributes
+        # AttributeChoiceWithText already copied via AttributeType → choice_with_text_attributes
+        'choice_with_text_attributes': EXCLUDED,
+    },
     'category_choice_attributes': {},
     'choice_attributes': {},
     'choice_with_text_attributes': {},
@@ -137,6 +210,8 @@ INDICATOR_CLONE_STRUCTURE: CloneStructure = {
     'contact_persons': {},
     'values': {
         'category_links': {},  # copies through model instances, not `DimensionCategory` instances
+        # back-reference to Indicator.reference_value; Indicator is the copy root, not traversed from here
+        'reference_for_indicator': EXCLUDED,
     },
     # 'related_actions': {},  # ActionIndicator instances are already copied in PLAN_CLONE_STRUCTURE
     'related_causes': {},
@@ -144,10 +219,25 @@ INDICATOR_CLONE_STRUCTURE: CloneStructure = {
     # twice as it's already done due to `related_causes`.
     'goals': {},
     'dimensions': {},  # copies through model (`IndicatorDimension`) instances, not `Dimension` instances
+    'category_relationships': EXCLUDED,  # handled via the category side
+    'actions': EXCLUDED,  # reverse M2M; ActionIndicator already copied via actions → related_indicators
+    'change_log_messages': EXCLUDED,
+    'related_effects': EXCLUDED,  # only related_causes is copied to avoid duplicating RelatedIndicator instances
+    'related_actions': EXCLUDED,  # ActionIndicator already copied via actions → related_indicators
+    'values_import_logs': EXCLUDED,
+    'graphs': EXCLUDED,
+    'indicator_category_through': EXCLUDED,  # copied via Category → indicator_category_through
+    'levels': EXCLUDED,  # IndicatorLevel copied via PLAN_CLONE_STRUCTURE['indicator_levels']
 }
 
 DIMENSION_CLONE_STRUCTURE: CloneStructure = {
-    'categories': {},
+    'categories': {
+        'indicator_value_links': EXCLUDED,  # IndicatorValueCategory already copied via IndicatorValue → category_links
+        'values': EXCLUDED,  # reverse M2M; IndicatorValue already copied via Indicator → values
+    },
+    'plans': EXCLUDED,  # PlanDimension copied via PLAN_CLONE_STRUCTURE['dimensions']
+    'instances': EXCLUDED,  # IndicatorDimension copied via INDICATOR_CLONE_STRUCTURE['dimensions']
+    'common_indicators': EXCLUDED,  # CommonIndicator is not plan-scoped
 }
 
 # Models that are not scoped by a plan and thus deliberately excluded from copying. References to these models are
@@ -1269,7 +1359,11 @@ def update_references_in_indicators(indicators: list[Indicator], clone_visitor: 
         visit_tree(indicator, INDICATOR_CLONE_STRUCTURE, update_references_visitor)
 
 
-def visit_tree(root: Model, config: dict, visitor: AbstractVisitor) -> None:
-    tree = ConfigurableRelationTree(root=root, structure=config)
+def _to_copy_structure(structure: CloneStructure) -> dict:
+    return {k: _to_copy_structure(v) for k, v in structure.items() if not isinstance(v, Excluded)}
+
+
+def visit_tree(root: Model, config: CloneStructure, visitor: AbstractVisitor) -> None:
+    tree = ConfigurableRelationTree(root=root, structure=_to_copy_structure(config))
     for node in RelationTreeIterator(tree=tree):
         visitor.visit(node)

--- a/copying/main.py
+++ b/copying/main.py
@@ -6,7 +6,7 @@ from contextlib import ExitStack, contextmanager
 from copy import copy as shallow_copy
 from functools import singledispatchmethod, wraps
 from itertools import chain
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 import wagtail.signal_handlers
@@ -48,6 +48,7 @@ from indicators.models.common_indicator import CommonIndicator
 from indicators.models.dimensions import Dimension
 from indicators.models.indicator import Indicator
 from indicators.models.metadata import Quantity, Unit
+from notifications.models import AutomaticNotificationTemplate, BaseTemplate, ContentBlock
 from orgs.models import Organization
 from pages.models import PlanRootPage
 from people.models import Person
@@ -123,7 +124,7 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     'category_types': {
         'categories': {
             'indicator_category_through': {},  # We don't copy the indicators themselves
-            'icons': EXCLUDED,  # TODO: should likely be copied
+            'icons': {},
             'children': EXCLUDED,  # all categories are already copied via category_type → categories
             'indicator_relationships': EXCLUDED,  # handled via the indicator side
             'actions': EXCLUDED,  # reverse M2M; ActionCategoryThrough already copied via actions → action_category_through
@@ -173,13 +174,27 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     'children': EXCLUDED,  # child plans are independent plans
     'superseded_plans': EXCLUDED,
     'copies': EXCLUDED,
-    'monitoring_quality_points': EXCLUDED,  # TODO: should likely be copied
+    'monitoring_quality_points': EXCLUDED,  # legacy
     'pledges': EXCLUDED,
     'documentation_root_pages': EXCLUDED,  # handled separately by _copy_documentation_pages
     'user_feedbacks': EXCLUDED,
     'plan_common_indicator_through': EXCLUDED,  # common indicator assignments are not plan-owned
     'indicators': EXCLUDED,  # handled separately via the copy_indicators parameter
-    'notification_base_template': EXCLUDED,  # TODO: should likely be copied
+    'notification_base_template': {
+        # templates must be copied before content_blocks so that template-specific ContentBlocks
+        # can look up their template copy in CloneVisitor.pre_visit for ContentBlock.
+        'templates': {
+            # Exclude template-specific content blocks from copying here. Each content block in
+            # notification_base_template -> templates -> content_blocks also occurs in notification_base_template ->
+            # content_blocks, and thus will be copied due to the declaration for the second path below.
+            'content_blocks': EXCLUDED,
+        },
+        # All ContentBlocks (both base-level and template-specific) are reachable via
+        # base.content_blocks, so we copy them all in one pass here. Template-specific ones
+        # have their template FK remapped to the copy in CloneVisitor.pre_visit for ContentBlock.
+        'content_blocks': {},
+        'manually_scheduled_notification_templates': {},
+    },
     'organization_plan_admins': EXCLUDED,
     'links': EXCLUDED,  # TODO: should likely be copied (PlanLink is a cluster child)
     'planscopedmodellogentry': EXCLUDED,
@@ -417,6 +432,38 @@ class CloneVisitor(AbstractVisitor):
         # `always_update=True` and is unique per plan. So when saving the copy, it references the same plan as the
         # original, thus getting a suffix appended to the slug to make it unique.
         instance.scope = self.get_copy(instance.scope)  # type: ignore
+
+    @pre_visit.register
+    def _(self, instance: ContentBlock) -> None:
+        self.prepare_instance_for_copy(instance)
+        # All ContentBlocks are copied via the base → content_blocks path, which covers both
+        # base-level blocks (template=None) and template-specific blocks (template!=None), since
+        # BaseTemplate.content_blocks returns all blocks regardless of template.
+        #
+        # For template-specific ContentBlocks, two FK references need fixing before save():
+        #
+        # 1. base: Although visit() will set base_id to the copy's PK via the joining-field
+        #    logic, Django's FK cache may still hold the original (or already-modified in-memory)
+        #    BaseTemplate object. We set base to the copy explicitly to be safe.
+        #
+        # 2. template: visit() only updates the joining field (base, for this path), so
+        #    template_id still points to the original template. ContentBlock.save() checks
+        #    self.template.base == self.base; if template still refers to the original,
+        #    self.template.base is the original BaseTemplate while self.base is the copy →
+        #    mismatch exception. AutomaticNotificationTemplate copies exist by this point
+        #    because `templates` precedes `content_blocks` in the clone structure dict.
+        #
+        # We use the raw _id integer fields rather than the FK accessors because Django's FK
+        # cache may hold already-modified in-memory parent objects whose PK has been changed to
+        # the copy's PK. self.copies is keyed by original PK, so the stored integer (which
+        # reflects the original DB value and is never mutated by in-memory object changes) is
+        # the only reliable key.
+        if instance.template_id is not None:
+            instance.base = cast('BaseTemplate', self.copies[(BaseTemplate, instance.base_id)])
+            instance.template = cast(
+                'AutomaticNotificationTemplate',
+                self.copies[(AutomaticNotificationTemplate, instance.template_id)],
+            )
 
     @pre_visit.register
     def _(self, instance: Plan) -> None:

--- a/copying/main.py
+++ b/copying/main.py
@@ -199,6 +199,7 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     'links': EXCLUDED,  # TODO: should likely be copied (PlanLink is a cluster child)
     'planscopedmodellogentry': EXCLUDED,
     'planscopedpagelogentry': EXCLUDED,
+    'mcp_write_authorization_grants': {},
 }
 
 ATTRIBUTE_TYPE_CLONE_STRUCTURE: CloneStructure = {

--- a/copying/tests/test_clone_structure_coverage.py
+++ b/copying/tests/test_clone_structure_coverage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db.models import ManyToManyRel, ManyToOneRel
+
+from actions.models.attributes import AttributeType
+from actions.models.plan import Plan
+from copying.main import (
+    ATTRIBUTE_TYPE_CLONE_STRUCTURE,
+    DIMENSION_CLONE_STRUCTURE,
+    INDICATOR_CLONE_STRUCTURE,
+    PLAN_CLONE_STRUCTURE,
+    Excluded,
+    _is_excluded_model,
+)
+from indicators.models.dimensions import Dimension
+from indicators.models.indicator import Indicator
+
+if TYPE_CHECKING:
+    from django.db.models import Model
+
+    from copying.main import CloneStructure
+
+
+def _check_coverage(model_class: type[Model], structure: CloneStructure, visited: set[type[Model]]) -> None:
+    if model_class in visited:
+        return
+    visited.add(model_class)
+
+    covered = set(structure.keys())
+    missing = []
+    for field in model_class._meta.get_fields():
+        if not isinstance(field, (ManyToOneRel, ManyToManyRel)):
+            continue
+        related = field.related_model
+        # The type stubs allow `related_model` to be a string for unresolved
+        # lazy relations, but all models are fully initialized by test time.
+        assert not isinstance(related, str), (
+            f"Unexpected unresolved related model '{related}' on {model_class.__name__}.{field.name}"
+        )
+        if field.name in covered:
+            entry = structure[field.name]
+            if not isinstance(entry, Excluded):
+                _check_coverage(related, entry, visited)
+            continue
+        if _is_excluded_model(related):
+            continue
+        missing.append(f"  '{field.name}' -> {related.__name__}")
+
+    if missing:
+        raise AssertionError(
+            f"{model_class.__name__} has relations not accounted for in its clone structure.\n"
+            "Add them as sub-structures to copy, or mark as EXCLUDED:\n"
+            + "\n".join(missing)
+        )
+
+
+class TestCloneStructureCoverage:
+    def test_plan_clone_structure_coverage(self):
+        _check_coverage(Plan, PLAN_CLONE_STRUCTURE, set())
+
+    def test_attribute_type_clone_structure_coverage(self):
+        _check_coverage(AttributeType, ATTRIBUTE_TYPE_CLONE_STRUCTURE, set())
+
+    def test_indicator_clone_structure_coverage(self):
+        _check_coverage(Indicator, INDICATOR_CLONE_STRUCTURE, set())
+
+    def test_dimension_clone_structure_coverage(self):
+        _check_coverage(Dimension, DIMENSION_CLONE_STRUCTURE, set())

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -48,6 +48,8 @@ from indicators.tests.factories import (
     IndicatorValueFactory,
     RelatedIndicatorFactory,
 )
+from notifications.models import ContentBlock
+from notifications.tests.factories import AutomaticNotificationTemplateFactory, BaseTemplateFactory
 from pages.models import StaticPage
 from pages.tests.factories import CategoryTypePageLevelLayoutFactory
 from reports.tests.factories import ReportTypeFactory
@@ -738,3 +740,69 @@ class TestUpdateReferenceIndexImmediately:
         assert body_value is not None
         assert body_value.source == html_with_references([doc])
         assert body_value.source != html_with_references([doc_copy])
+
+
+def test_copy_plan_copies_base_level_content_block(plan_with_pages):
+    """ContentBlock with template=None is copied and its base points to the copy of BaseTemplate."""
+    base = BaseTemplateFactory.create(plan=plan_with_pages)
+    ContentBlock.objects.create(base=base, template=None, identifier='intro', content='<p>Intro</p>')
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    base_copy = plan_copy.notification_base_template
+    assert base_copy != base
+    assert base_copy.content_blocks.count() == 1
+    block_copy = base_copy.content_blocks.get()
+    assert block_copy.base == base_copy
+    assert block_copy.template is None
+    assert block_copy.identifier == 'intro'
+
+
+def test_copy_plan_copies_template_specific_content_block(plan_with_pages):
+    """ContentBlock with template!=None is copied; both base and template point to their copies."""
+    base = BaseTemplateFactory.create(plan=plan_with_pages)
+    template = AutomaticNotificationTemplateFactory.create(base=base)
+    ContentBlock.objects.create(base=base, template=template, identifier='intro', content='<p>Template intro</p>')
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    base_copy = plan_copy.notification_base_template
+    assert base_copy != base
+    template_copy = base_copy.templates.get()
+    assert template_copy != template
+    assert base_copy.content_blocks.count() == 1
+    block_copy = base_copy.content_blocks.get()
+    assert block_copy.base == base_copy
+    assert block_copy.template == template_copy
+    # ContentBlock.save() enforces this invariant; verify the copy satisfies it
+    assert block_copy.template.base == block_copy.base
+    assert block_copy.identifier == 'intro'
+
+
+def test_copy_plan_does_not_duplicate_template_specific_content_block(plan_with_pages):
+    """
+    Template-specific ContentBlocks must not be copied twice.
+
+    Since base.content_blocks returns ALL ContentBlocks (including template-specific ones), traversing both base ->
+    content_blocks and base -> templates -> content_blocks in the clone structure would register the same block twice,
+    which would cause an AssertionError in register_copy.
+    """
+    base = BaseTemplateFactory.create(plan=plan_with_pages)
+    template = AutomaticNotificationTemplateFactory.create(base=base)
+    ContentBlock.objects.create(base=base, template=None, identifier='outro', content='<p>Base outro</p>')
+    ContentBlock.objects.create(base=base, template=template, identifier='intro', content='<p>Template intro</p>')
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    base_copy = plan_copy.notification_base_template
+    template_copy = base_copy.templates.get()
+    # Each original block must produce exactly one copy
+    assert base_copy.content_blocks.count() == 2
+    base_block = base_copy.content_blocks.get(template__isnull=True)
+    assert base_block.base == base_copy
+    assert base_block.identifier == 'outro'
+    template_block = ContentBlock.objects.get(base=base_copy, template=template_copy)
+    assert template_block.base == base_copy
+    assert template_block.template == template_copy
+    assert template_block.template.base == template_block.base
+    assert template_block.identifier == 'intro'

--- a/notifications/models.py
+++ b/notifications/models.py
@@ -34,6 +34,8 @@ if typing.TYPE_CHECKING:
 
     from modelcluster.fields import PK
 
+    from kausal_common.models.types import FK, RevMany
+
     from actions.models.plan import Plan
     from admin_site.models import Client
 
@@ -199,6 +201,11 @@ class BaseTemplate(ClusterableModel, PlanRelatedModelWithRevision):
 
     verbose_name_partitive = pgettext_lazy('partitive', 'base templates')
 
+    # Type annotations for related models etc.
+    templates: RevMany[AutomaticNotificationTemplate]
+    manually_scheduled_notification_templates: RevMany[ManuallyScheduledNotificationTemplate]
+    content_blocks: RevMany[ContentBlock]
+
     class Meta:
         verbose_name = _('base template')
         verbose_name_plural = _('base templates')
@@ -341,6 +348,9 @@ class AutomaticNotificationTemplate(NotificationTemplate):
         blank=True,
         choices=ContactPersonFallbackChain.choices,
     )
+
+    # Type annotations for related models etc.
+    content_blocks: RevMany[ContentBlock]
 
     def clean(self):
         if self.send_to_contact_persons and not self.concerns_action and not self.concerns_indicator:
@@ -519,8 +529,9 @@ class ContentBlockManager(models.Manager):
 class ContentBlock(models.Model):
     content = RichTextField(verbose_name=_('content'), help_text=_('HTML content for the block'))
 
-    base = ParentalKey(BaseTemplate, on_delete=models.CASCADE, related_name='content_blocks', editable=False)
-    template = models.ForeignKey(
+    base_id: int
+    base: FK[BaseTemplate] = ParentalKey(BaseTemplate, on_delete=models.CASCADE, related_name='content_blocks', editable=False)
+    template: FK[AutomaticNotificationTemplate | None] = models.ForeignKey(
         AutomaticNotificationTemplate,
         null=True,
         blank=True,


### PR DESCRIPTION
## Summary

This PR improves the plan-copying subsystem in three areas:

1. **Exhaustive clone structure coverage enforced by tests** – Introduces an `Excluded` sentinel class so that relations deliberately omitted from copying are expressed explicitly (with explanatory comments) rather than silently skipped. All four clone structures (`PLAN_CLONE_STRUCTURE`, `ATTRIBUTE_TYPE_CLONE_STRUCTURE`, `INDICATOR_CLONE_STRUCTURE`, `DIMENSION_CLONE_STRUCTURE`) are updated to enumerate every reverse relation (`ManyToOneRel`, `OneToOneRel`, `ManyToManyRel`) on each covered model, either as a nested copy sub-structure or as `EXCLUDED`. A new test module (`copying/tests/test_clone_structure_coverage.py`) walks each structure at import time (no DB required) and fails immediately if any relation is unaccounted for, preventing future silent regressions.

2. **Fix copying of notification base templates and their content blocks** – The plan clone structure now includes `notification_base_template` with its `templates` (automatic and manually-scheduled notification templates) and `content_blocks`. Template-specific `ContentBlock` instances require special handling in `CloneVisitor.pre_visit`: the `base` FK must be remapped to the copied `BaseTemplate`, and the `template` FK must be remapped to the copied `AutomaticNotificationTemplate` (whose copy is guaranteed to exist because `templates` precedes `content_blocks` in the dict). Template-specific blocks are copied exclusively via the `base → content_blocks` path to avoid double-registration.

3. **Unit tests for notification template/block copying** – Three new test cases in `copying/tests/test_copying.py` verify:
   - A base-level `ContentBlock` (no template) is copied and linked to the new `BaseTemplate`.
   - A template-specific `ContentBlock` is copied with both `base` and `template` pointing to their respective copies, satisfying `ContentBlock.save()`'s invariant check.
   - Template-specific blocks are not duplicated (not copied twice) even though they appear in both `base.content_blocks` and `template.content_blocks`.

## Changes

- `copying/main.py` – Add `Excluded`/`EXCLUDED` sentinel; update all four clone structures to be exhaustive; add `CloneVisitor.pre_visit` handler for `ContentBlock`; add `_to_copy_structure()` helper to strip `Excluded` entries before passing to `RelationTreeIterator`.
- `copying/tests/test_clone_structure_coverage.py` – New test class that validates exhaustive coverage for all four clone structures.
- `copying/tests/test_copying.py` – Three new integration tests for copying plans with notification base templates and content blocks.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2483ba85756709513b8be482976bb43be10fcaae. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->