### PR TITLE
Preserve order of actions when publishing actions

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -681,6 +681,8 @@ class Action(
 
     def publish(self, revision: Revision[Self], user: User | None = None, **kwargs) -> None:  # type: ignore[override]
         attributes = revision.content.pop('attributes')
+        self.refresh_from_db(fields=['order'])
+        revision.content['order'] = self.order
         self._renormalize_revision_items(revision, 'responsible_parties', 'organization')
         self._renormalize_revision_items(revision, 'contact_persons', 'person')
         super().publish(revision, user=user, **kwargs)

--- a/actions/tests/test_admin.py
+++ b/actions/tests/test_admin.py
@@ -763,3 +763,45 @@ def test_action_contact_person_swap_on_publish_draft(plan):
     # Verify the persons have been swapped to the correct roles
     assert contact_b_after.role == ActionContactPerson.Role.EDITOR
     assert contact_a_after.role == ActionContactPerson.Role.MODERATOR
+
+
+def test_publish_does_not_overwrite_order(plan):
+    """
+    Publishing a revision must not revert the action's order to the value stored in the revision.
+
+    The order field is managed outside the revision workflow (e.g. via
+    drag-and-drop reordering) and must be preserved.
+    """
+    from wagtail.models import Revision
+
+    from actions.models import Action
+    from actions.tests.factories import ActionFactory
+
+    action = ActionFactory.create(plan=plan)
+    action.order = 5
+    action.save()
+
+    # Create a revision that captures order=5.
+    # save_revision() auto-publishes on non-workflow plans, which mutates
+    # revision.content in-place (pops 'attributes' and 'order'), so we
+    # need to reconstruct the content for our test revision.
+    initial_revision = action.save_revision()
+    revision_content = initial_revision.content.copy()
+    revision_content.setdefault('attributes', {})
+    revision_content['order'] = 5
+
+    # Simulate an order change that happened after the revision was created
+    Action.objects.filter(pk=action.pk).update(order=42)
+
+    # Create a new revision from the old content and publish it
+    new_revision: Revision = Revision(
+        content_type=initial_revision.content_type,
+        base_content_type=initial_revision.base_content_type,
+        object_id=action.pk,
+    )
+    new_revision.content = revision_content
+    new_revision.save()
+    new_revision.publish()
+
+    action.refresh_from_db()
+    assert action.order == 42


### PR DESCRIPTION
When moderation / drafts are in use, the order field value for the draft should not change the order of the published actions

## Description
Overwrites the draft "order" value with the already-existing db value.

## Screenshots/Videos (if applicable)
N/A

## Related issue
https://app.asana.com/1/1201243246741462/project/1204765078896581/task/1208387067125864
https://kausaltech.slack.com/archives/C05B87BS9NY/p1772610468206839

## Requirements, dependencies and related PRs
N/A

## Additional Notes
There might be other cases where order changes. But this has confirmed to be one problem case.
------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to publish-time data assignment plus a regression test; main risk is unintended interaction with Wagtail revision serialization/publish behavior.
> 
> **Overview**
> Publishing an `Action` revision now refreshes the instance from the DB and forces `revision.content['order']` to the current persisted value before `super().publish()`, preventing older draft revisions from reverting drag-and-drop ordering.
> 
> Adds a unit test (`test_publish_does_not_overwrite_order`) that recreates and publishes a stale revision and asserts the action’s `order` remains unchanged in the database.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e1471d3d26cd18dd1c845bf108d33932e122efe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->