### PR TITLE
Rename legacy Dataset model in indicators app to ExternalDataset

### DIFF
--- a/actions/perms.py
+++ b/actions/perms.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query_utils import Q
-from wagtail.models import PAGE_PERMISSION_TYPES, GroupPagePermission, Page
+from wagtail.models import PAGE_PERMISSION_TYPES, GroupPagePermission
 
 from loguru import logger
 from treelib import Tree
@@ -18,10 +18,10 @@ from audit_logging.models import PlanScopedModelLogEntry, PlanScopedPageLogEntry
 from content.models import SiteGeneralContent
 from indicators.models import (
     ActionIndicator,
-    Dataset,
-    DatasetLicense,
     Dimension,
     DimensionCategory,
+    ExternalDataset,
+    ExternalDatasetLicense,
     Indicator,
     IndicatorContactPerson,
     IndicatorDimension,
@@ -72,6 +72,7 @@ if typing.TYPE_CHECKING:
 
     from django.db.models.base import Model
     from django.db.models.query import QuerySet
+    from wagtail.models import Page
     from wagtail.models.media import Collection
 
     from users.models import User as UserModel
@@ -300,8 +301,8 @@ PLAN_ADMIN_PERMS: tuple[tuple[type[Model], tuple[str, ...]], ...] = (
     (RelatedIndicator, ALL_PERMS),
     (Unit, ALL_PERMS),
     (Quantity, ALL_PERMS),
-    (Dataset, ALL_PERMS),
-    (DatasetLicense, ALL_PERMS),
+    (ExternalDataset, ALL_PERMS),
+    (ExternalDatasetLicense, ALL_PERMS),
     (Dimension, ALL_PERMS),
     (DimensionCategory, ALL_PERMS),
     (IndicatorDimension, ALL_PERMS),

--- a/indicators/migrations/0049_rename_dataset_to_externaldataset.py
+++ b/indicators/migrations/0049_rename_dataset_to_externaldataset.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('indicators', '0048_indicatorgoaldatapoint_and_more'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name='DatasetLicense',
+            new_name='ExternalDatasetLicense',
+        ),
+        migrations.RenameModel(
+            old_name='Dataset',
+            new_name='ExternalDataset',
+        ),
+    ]

--- a/indicators/migrations/0050_rename_indicator_datasets_to_external_datasets.py
+++ b/indicators/migrations/0050_rename_indicator_datasets_to_external_datasets.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('indicators', '0049_rename_dataset_to_externaldataset'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='indicator',
+            old_name='datasets',
+            new_name='external_datasets',
+        ),
+    ]

--- a/indicators/models/__init__.py
+++ b/indicators/models/__init__.py
@@ -53,8 +53,8 @@ from indicators.models.indicator import (
 # Import and expose all models for backwards compatibility
 # Metadata models
 from indicators.models.metadata import (
-    Dataset,
-    DatasetLicense,
+    ExternalDataset,
+    ExternalDatasetLicense,
     Framework,
     Quantity,
     Unit,
@@ -81,11 +81,11 @@ __all__ = [
     'CommonIndicator',
     'CommonIndicatorDimension',
     'CommonIndicatorNormalizator',
-    'Dataset',
-    'DatasetLicense',
     'DatasetMetricComputation',
     'Dimension',
     'DimensionCategory',
+    'ExternalDataset',
+    'ExternalDatasetLicense',
     'Framework',
     'FrameworkIndicator',
     'Indicator',

--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -59,7 +59,7 @@ if typing.TYPE_CHECKING:
     from indicators.models.action_links import ActionIndicator
     from indicators.models.contact_persons import IndicatorContactPerson
     from indicators.models.dimensions import IndicatorDimension
-    from indicators.models.metadata import Dataset, Unit
+    from indicators.models.metadata import ExternalDataset, Unit
     from indicators.models.relationships import RelatedIndicator
     from indicators.models.values import IndicatorGoal
     from paths_integration._generated_.graphql_client.node_values import NodeValuesNodeMetricDim
@@ -235,10 +235,10 @@ class Indicator(
         verbose_name=_('reference value'),
         on_delete=models.SET_NULL,
     )
-    datasets: M2M[Dataset, Any] = models.ManyToManyField(
-        'indicators.Dataset',
+    external_datasets: M2M[ExternalDataset, Any] = models.ManyToManyField(
+        'indicators.ExternalDataset',
         blank=True,
-        verbose_name=_('datasets'),
+        verbose_name=_('external datasets'),
     )
     dataset_schema: OneToOne[DatasetSchema | None] = models.OneToOneField(
         'datasets.DatasetSchema',
@@ -380,7 +380,7 @@ class Indicator(
         'time_resolution',
         'latest_value',
         'latest_graph',
-        'datasets',
+        'external_datasets',
         'updated_at',
         'created_at',
         'values',
@@ -514,9 +514,9 @@ class Indicator(
         now = timezone.now()
         return self.goals.filter(date__gte=now).exists()
 
-    @display(boolean=True, description=_('Has datasets'))
-    def has_datasets(self):
-        return self.datasets.exists()
+    @display(boolean=True, description=_('Has external datasets'))
+    def has_external_datasets(self):
+        return self.external_datasets.exists()
 
     @display(boolean=True, description=_('Has data'))
     def has_data(self):

--- a/indicators/models/metadata.py
+++ b/indicators/models/metadata.py
@@ -92,7 +92,7 @@ class Unit(ClusterableModel, ModificationTracking):
         return str(self)
 
 
-class DatasetLicense(models.Model):
+class ExternalDatasetLicense(models.Model):
     name = models.CharField(max_length=50, verbose_name=_('name'), unique=True)
 
     class Meta:
@@ -103,7 +103,7 @@ class DatasetLicense(models.Model):
         return self.name
 
 
-class Dataset(ClusterableModel):
+class ExternalDataset(ClusterableModel):
     name = models.CharField(max_length=100, verbose_name=_('name'))
     description = models.TextField(blank=True, verbose_name=_('description'))
     url = models.URLField(null=True, blank=True, verbose_name=_('URL'))
@@ -118,13 +118,13 @@ class Dataset(ClusterableModel):
         help_text=_('Set if owner organization is not available'),
     )
     license = models.ForeignKey(
-        'indicators.DatasetLicense', null=True, blank=True, verbose_name=_('license'),
+        'indicators.ExternalDatasetLicense', null=True, blank=True, verbose_name=_('license'),
         on_delete=models.SET_NULL,
     )
 
     class Meta:
-        verbose_name = _('dataset')
-        verbose_name_plural = _('datasets')
+        verbose_name = _('external dataset')
+        verbose_name_plural = _('external datasets')
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
## Description
We are currently implementing light-weight dataset support for indicators based on the Dataset model in kausal-backend-common. However, the `indicators` app already has an old model called Dataset. It looks like a legacy system from the pre-Wagtail days. To prevent confusion, I believe it's best to rename the old Dataset model to ExternalDataset (because that's what it seems to be about).

I believe this takes care of all references to the old names, but I'm not too familiar with the legacy system.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
