### PR TITLE
Fix superscript/subscript missing from rich text editor

### DIFF
--- a/admin_site/tests/test_apps.py
+++ b/admin_site/tests/test_apps.py
@@ -5,3 +5,11 @@ def test_language_choices():
     # _get_language_choices breaks if a language unknown to Django is in settings.LANGUAGES but not in
     # settings.LOCAL_LANGUAGE_NAMES
     assert _get_language_choices()  # should not raise an exception, and at least shouldn't be empty either
+
+
+def test_rich_text_default_features_include_superscript():
+    from wagtail.rich_text import features
+
+    default = features.get_default_features()  # type: ignore[attr-defined]
+    assert 'superscript' in default
+    assert 'subscript' in default

--- a/admin_site/wagtail_admin.py
+++ b/admin_site/wagtail_admin.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+from wagtail.admin.panels import FieldPanel, InlinePanel
+from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.snippets import SnippetViewSet
+
+from .models import Client
+
+
+class ClientViewSet(SnippetViewSet[Client]):
+    model = Client
+    icon = 'globe'
+    menu_order = 520
+    list_display = ('name',)
+    search_fields = ('name',)
+    add_to_admin_menu = True
+
+    panels = [
+        FieldPanel('name'),
+        FieldPanel('logo'),
+        FieldPanel('auth_backend'),
+        InlinePanel('email_domains', panels=[FieldPanel('domain')], heading=_('Email domains')),
+        InlinePanel('plans', panels=[FieldPanel('plan')], heading=_('Plans')),
+    ]
+
+
+register_snippet(ClientViewSet)

--- a/admin_site/wagtail_hooks.py
+++ b/admin_site/wagtail_hooks.py
@@ -10,18 +10,13 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 from wagtail.admin.menu import DismissibleMenuItem, Menu, MenuItem, SubmenuMenuItem
-from wagtail.admin.panels import FieldPanel, InlinePanel
 from wagtail.admin.ui.components import Component
-from wagtail.snippets.models import register_snippet
-from wagtail.snippets.views.snippets import SnippetViewSet
 
 from kausal_common.users import user_or_bust
 
 from aplans.context_vars import get_admin_cache
 
 from actions.models import CommonCategoryType
-
-from .models import Client
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -176,26 +171,6 @@ def construct_homepage_panels(request, panels):
 @hooks.register('construct_homepage_summary_items', order=1000)
 def remove_default_site_summary_items(request, items: list[MenuItem]):
     items.clear()
-
-
-class ClientViewSet(SnippetViewSet[Client]):
-    model = Client
-    icon = 'globe'
-    menu_order = 520
-    list_display = ('name',)
-    search_fields = ('name',)
-    add_to_admin_menu = True
-
-    panels = [
-        FieldPanel('name'),
-        FieldPanel('logo'),
-        FieldPanel('auth_backend'),
-        InlinePanel('email_domains', panels=[FieldPanel('domain')], heading=_('Email domains')),
-        InlinePanel('plans', panels=[FieldPanel('plan')], heading=_('Plans')),
-    ]
-
-
-register_snippet(ClientViewSet)
 
 
 @hooks.register('insert_global_admin_css')

--- a/admin_site/wagtail_hooks.py
+++ b/admin_site/wagtail_hooks.py
@@ -350,3 +350,8 @@ def hack_wagtail_rich_text_fields():
         });
         </script>
         """)
+
+
+# Imported at the end because wagtail.snippets triggers re-entrant hook
+# discovery, and all hooks above must be registered before that happens.
+import admin_site.wagtail_admin  # noqa: E402, F401


### PR DESCRIPTION
## Description
Move ClientViewSet out of wagtail_hooks.py into wagtail_admin.py to
break a circular import: importing wagtail.snippets triggers re-entrant
search_for_hooks() while the module is still loading, so the
register_rich_text_features hook hadn't been reached yet and the feature
scan completed without superscript/subscript.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213564999551697

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
