### PR TITLE
Filter unpublished parent plans from public child plan GraphQL responses

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -562,11 +562,25 @@ class PlanNode(DjangoNode[Plan]):
         return not root.features.has_action_official_name
 
     @staticmethod
-    @gql_optimizer.resolver_hints(
-        select_related=('parent',),
-    )
+    def resolve_parent(root: Plan, info: GQLInfo) -> Plan | None:
+        parent = root.parent
+        if parent is None:
+            return None
+        if not parent.is_visible_for_user(info.context.user):
+            return None
+        return parent
+
+    @staticmethod
     def resolve_all_related_plans(root: Plan, info: GQLInfo) -> PlanQuerySet:
+        # NOTE: The previous select_related=('parent',) optimizer hint was removed
+        # because it conflicts with graphene-django-optimizer's field deferral when
+        # the client doesn't also request `parent` on the same Plan type.
         return root.get_all_related_plans().visible_for_user(info.context.user)
+
+    @staticmethod
+    def resolve_children(root: Plan, info: GQLInfo) -> PlanQuerySet:
+        qs = Plan.objects.qs.filter(parent=root)
+        return qs.visible_for_user(info.context.user)
 
     @staticmethod
     @gql_optimizer.resolver_hints(

--- a/actions/tests/test_graphql_plan_parent_visibility.py
+++ b/actions/tests/test_graphql_plan_parent_visibility.py
@@ -1,0 +1,174 @@
+"""
+Tests that unpublished parent plans are not exposed to public child plans.
+
+When an umbrella (parent) plan is internal/unpublished but some of its child
+plans are public, the GraphQL API should not return the parent in `parent` or
+`allRelatedPlans` for the published children.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+PARENT_QUERY = """
+    query GetPlan($id: ID!) {
+        plan(id: $id) {
+            id
+            parent {
+                id
+                identifier
+            }
+        }
+    }
+"""
+
+RELATED_PLANS_QUERY = """
+    query GetPlan($id: ID!) {
+        plan(id: $id) {
+            id
+            allRelatedPlans {
+                id
+                identifier
+            }
+        }
+    }
+"""
+
+CHILDREN_QUERY = """
+    query GetPlan($id: ID!) {
+        plan(id: $id) {
+            id
+            children {
+                id
+                identifier
+            }
+        }
+    }
+"""
+
+
+def _make_published_plan(plan_factory, **kwargs):
+    plan = plan_factory(
+        published_at=timezone.now() - timedelta(days=1),
+        **kwargs,
+    )
+    plan.features.expose_unpublished_plan_only_to_authenticated_user = False
+    plan.features.save()
+    return plan
+
+
+def _make_unpublished_plan(plan_factory, **kwargs):
+    plan = plan_factory(
+        published_at=None,
+        **kwargs,
+    )
+    plan.features.expose_unpublished_plan_only_to_authenticated_user = True
+    plan.features.save()
+    return plan
+
+
+class TestParentPlanVisibility:
+    """Test that unpublished parent plans are hidden from public child plans."""
+
+    def test_published_child_hides_unpublished_parent(self, graphql_client_query_data, plan_factory):
+        """Anonymous user querying a published child should not see the unpublished parent."""
+        parent = _make_unpublished_plan(plan_factory)
+        child = _make_published_plan(plan_factory, parent=parent)
+
+        data = graphql_client_query_data(
+            PARENT_QUERY,
+            variables={'id': child.identifier},
+        )
+
+        assert data['plan'] is not None
+        assert data['plan']['parent'] is None
+
+    def test_published_child_shows_published_parent(self, graphql_client_query_data, plan_factory):
+        """Anonymous user querying a published child should see a published parent."""
+        parent = _make_published_plan(plan_factory)
+        child = _make_published_plan(plan_factory, parent=parent)
+
+        data = graphql_client_query_data(
+            PARENT_QUERY,
+            variables={'id': child.identifier},
+        )
+
+        assert data['plan'] is not None
+        assert data['plan']['parent'] is not None
+        assert data['plan']['parent']['identifier'] == parent.identifier
+
+
+class TestAllRelatedPlansVisibility:
+    """Test that allRelatedPlans excludes unpublished plans."""
+
+    def test_published_child_excludes_unpublished_parent_from_related(self, graphql_client_query_data, plan_factory):
+        """AllRelatedPlans for a published child should not include the unpublished parent."""
+        parent = _make_unpublished_plan(plan_factory)
+        child = _make_published_plan(plan_factory, parent=parent)
+
+        data = graphql_client_query_data(
+            RELATED_PLANS_QUERY,
+            variables={'id': child.identifier},
+        )
+
+        assert data['plan'] is not None
+        related_identifiers = [p['identifier'] for p in data['plan']['allRelatedPlans']]
+        assert parent.identifier not in related_identifiers
+
+    def test_published_child_excludes_unpublished_sibling_from_related(self, graphql_client_query_data, plan_factory):
+        """AllRelatedPlans should not include unpublished siblings."""
+        parent = _make_unpublished_plan(plan_factory)
+        child_public = _make_published_plan(plan_factory, parent=parent)
+        child_internal = _make_unpublished_plan(plan_factory, parent=parent)
+
+        data = graphql_client_query_data(
+            RELATED_PLANS_QUERY,
+            variables={'id': child_public.identifier},
+        )
+
+        assert data['plan'] is not None
+        related_identifiers = [p['identifier'] for p in data['plan']['allRelatedPlans']]
+        assert parent.identifier not in related_identifiers
+        assert child_internal.identifier not in related_identifiers
+
+    def test_published_child_includes_published_sibling_in_related(self, graphql_client_query_data, plan_factory):
+        """AllRelatedPlans should include published siblings."""
+        parent = _make_unpublished_plan(plan_factory)
+        child1 = _make_published_plan(plan_factory, parent=parent)
+        child2 = _make_published_plan(plan_factory, parent=parent)
+
+        data = graphql_client_query_data(
+            RELATED_PLANS_QUERY,
+            variables={'id': child1.identifier},
+        )
+
+        assert data['plan'] is not None
+        related_identifiers = [p['identifier'] for p in data['plan']['allRelatedPlans']]
+        assert child2.identifier in related_identifiers
+        assert parent.identifier not in related_identifiers
+
+
+class TestChildrenVisibility:
+    """Test that children field filters out plans not visible to user."""
+
+    def test_children_excludes_invisible_children(self, graphql_client_query_data, plan_factory):
+        """Children should only include plans visible to the requesting user."""
+        parent = _make_published_plan(plan_factory)
+        child_public = _make_published_plan(plan_factory, parent=parent)
+        child_internal = _make_unpublished_plan(plan_factory, parent=parent)
+
+        data = graphql_client_query_data(
+            CHILDREN_QUERY,
+            variables={'id': parent.identifier},
+        )
+
+        assert data['plan'] is not None
+        child_identifiers = [c['identifier'] for c in data['plan']['children']]
+        assert child_public.identifier in child_identifiers
+        assert child_internal.identifier not in child_identifiers


### PR DESCRIPTION
Add visibility checks to parent, children, and allRelatedPlans resolvers so that unpublished umbrella plans are not exposed to anonymous users querying published child plans. Uses the existing permission policy, so publishing the parent later automatically restores two-way navigation.

Remove select_related('parent') optimizer hint from resolve_all_related_plans because it conflicts with graphene-django-optimizer's field deferral when the client doesn't also request `parent` in the same query.

## Related issue
[Discussion in Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213467323268079?focus=true)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
