### PR TITLE
Add exportPdf GraphQL field to ActionNode for PDF export

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1528,6 +1528,12 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode[Action
 
     datasets = graphene.List(graphene.NonNull('datasets.schema.DatasetNode'), required=True)
 
+    export_pdf = graphene.Field(
+        'aplans.graphql_types.ExportPdfRequest',
+        required=False,
+        description='PDF export request details. Null if PDF export is not enabled for this plan.',
+    )
+
     class Meta:
         model = Action
         fields = Action.public_fields
@@ -1659,6 +1665,23 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode[Action
         url_helper = ActionAdmin().url_helper
         edit_url = url_helper.get_action_url('edit', root.id).lstrip('/')
         return f'{base_url}/{edit_url}'
+
+    @staticmethod
+    @gql_optimizer.resolver_hints(
+        model_field=('plan', 'identifier'),
+    )
+    def resolve_export_pdf(root: Action, info: GQLInfo) -> dict[str, str] | None:
+        plan = root.plan
+        if not plan.features.enable_action_pdf_export_in_public_ui:
+            return None
+        base_url = plan.get_view_url(request=info.context)
+        if not base_url:
+            return None
+        return {
+            'url': '%s/api/export-pdf' % base_url.rstrip('/'),
+            'path': '/actions/%s' % root.identifier,
+            'locale': get_language(),
+        }
 
     @staticmethod
     @gql_optimizer.resolver_hints(

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1669,6 +1669,7 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode[Action
     @staticmethod
     @gql_optimizer.resolver_hints(
         model_field=('plan', 'identifier'),
+        select_related=('plan__features',),
     )
     def resolve_export_pdf(root: Action, info: GQLInfo) -> dict[str, str] | None:
         plan = root.plan

--- a/aplans/graphql_types.py
+++ b/aplans/graphql_types.py
@@ -119,6 +119,21 @@ class AdminButton(graphene.ObjectType[Any]):
     icon = graphene.String(required=False)
 
 
+class ExportPdfRequest(graphene.ObjectType[Any]):
+    url = graphene.String(
+        required=True,
+        description='The endpoint URL to POST to.',
+    )
+    path = graphene.String(
+        required=True,
+        description='The page path to include in the POST body.',
+    )
+    locale = graphene.String(
+        required=True,
+        description='The locale to include in the POST body.',
+    )
+
+
 @sb.enum(name='WorkflowState')
 class WorkflowStateEnum(Enum):
     PUBLISHED = 'PUBLISHED'


### PR DESCRIPTION
Add ExportPdfRequest type with url, path, and locale fields so the front-end (either the public UI itself or, e.g., the React-based action list in the admin UI) can construct the POST request to the public UI's export-pdf endpoint. The field resolves to null when the enable_action_pdf_export_in_public_ui feature is disabled.

## Related issue

[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211834357577170?focus=true)

## Requirements, dependencies and related PRs

[kausal-extensions PR](https://github.com/kausaltech/kausal-extensions/pull/197) that calls this endpoint from the action list in the admin UI
[kausal-watch-ui PR](https://github.com/kausaltech/kausal-watch-ui/pull/692) that provides the export-pdf endpoint


------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
