### PR TITLE
Add image credit (data-image-credit) to rich-text-embedded images

### DIFF
--- a/images/apps.py
+++ b/images/apps.py
@@ -12,11 +12,23 @@ class ImagesConfig(AppConfig):
 
         from wagtail.images import permissions
 
+        # Register custom rich text image embed handler that injects
+        # data-image-credit attributes on <img> tags in rich text.
+        # We force a feature scan first so that Wagtail's default hooks
+        # have already run, then override the 'image' embed type with
+        # ours and clear the rewriter cache.
+        from wagtail.rich_text import features as rich_text_features, get_rewriter
+
         # Register graphql types overrides for grapple
         from . import schema  # noqa: F401
 
         # monkeypatch new permission policy
         from .permissions import permission_policy
+        from .rich_text import ImageEmbedHandler
+
+        rich_text_features.get_embed_types()  # ensure scan has completed
+        rich_text_features.register_embed_type(ImageEmbedHandler)
+        get_rewriter.cache_clear()
 
         permissions.permission_policy = permission_policy
 

--- a/images/rich_text.py
+++ b/images/rich_text.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from wagtail.images.formats import get_image_format
+from wagtail.images.rich_text import ImageEmbedHandler as WagtailImageEmbedHandler
+
+
+class ImageEmbedHandler(WagtailImageEmbedHandler):
+    """
+    Custom image embed handler that injects image credit as a data attribute.
+
+    This ensures that images embedded in rich text fields carry their
+    ``image_credit`` metadata so the frontend can render bylines.
+    """
+
+    identifier = 'image'
+
+    @classmethod
+    def expand_db_attributes_many(cls, attrs_list: list[dict]) -> list[str]:
+        images = cls.get_many(attrs_list)
+
+        tags: list[str] = []
+        for attrs, image in zip(attrs_list, images, strict=True):
+            if image:
+                image_format = get_image_format(attrs['format'])
+                extra_attributes: dict[str, str] = {}
+                image_credit = getattr(image, 'image_credit', '')
+                if image_credit:
+                    extra_attributes['data-image-credit'] = image_credit
+                tag = image_format.image_to_html(image, attrs.get('alt', ''), extra_attributes=extra_attributes)
+            else:
+                tag = '<img alt="">'
+            tags.append(tag)
+
+        return tags

--- a/images/tests/test_rich_text.py
+++ b/images/tests/test_rich_text.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from images.rich_text import ImageEmbedHandler
+from images.tests.factories import AplansImageFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestImageEmbedHandlerCredit:
+    """Tests for image credit injection in rich text image rendering."""
+
+    def test_no_credit_attribute_when_empty(self):
+        image = AplansImageFactory.create(image_credit='')
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': str(image.pk),
+            'format': 'fullwidth',
+            'alt': 'test',
+        })
+        assert 'data-image-credit' not in result
+
+    def test_no_credit_attribute_when_blank(self):
+        image = AplansImageFactory.create()
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': str(image.pk),
+            'format': 'left',
+            'alt': 'test',
+        })
+        assert 'data-image-credit' not in result
+
+    def test_credit_html_escaped(self):
+        image = AplansImageFactory.create(image_credit='Smith & Sons / "The Agency"')
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': str(image.pk),
+            'format': 'fullwidth',
+            'alt': 'test',
+        })
+        # The credit should be present but HTML-escaped by the img_tag renderer
+        assert 'data-image-credit=' in result
+        assert 'Smith &amp; Sons' in result
+        assert '&quot;The Agency&quot;' in result
+
+    def test_credit_works_with_all_builtin_formats(self):
+        image = AplansImageFactory.create(image_credit='Credit')
+        for fmt in ('fullwidth', 'left', 'right'):
+            result = ImageEmbedHandler.expand_db_attributes({
+                'id': str(image.pk),
+                'format': fmt,
+                'alt': 'test',
+            })
+            assert 'data-image-credit="Credit"' in result, f'Failed for format {fmt}'
+
+    def test_credit_works_with_zoomable_format(self):
+        image = AplansImageFactory.create(image_credit='Unsplash')
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': str(image.pk),
+            'format': 'fullwidth-zoomable',
+            'alt': 'test',
+        })
+        assert 'data-image-credit="Unsplash"' in result
+        # Zoomable format should still add its own data attributes
+        assert 'data-original-width=' in result
+
+
+class TestImageEmbedHandlerExpandMany:
+    """Tests for batch expansion of multiple images."""
+
+    def test_multiple_images_with_different_credits(self):
+        img1 = AplansImageFactory.create(image_credit='Credit A')
+        img2 = AplansImageFactory.create(image_credit='Credit B')
+        results = ImageEmbedHandler.expand_db_attributes_many([
+            {'id': str(img1.pk), 'format': 'left', 'alt': 'img1'},
+            {'id': str(img2.pk), 'format': 'right', 'alt': 'img2'},
+        ])
+        assert len(results) == 2
+        assert 'data-image-credit="Credit A"' in results[0]
+        assert 'data-image-credit="Credit B"' in results[1]
+
+    def test_mixed_credited_and_uncredited(self):
+        img_with = AplansImageFactory.create(image_credit='Reuters')
+        img_without = AplansImageFactory.create(image_credit='')
+        results = ImageEmbedHandler.expand_db_attributes_many([
+            {'id': str(img_with.pk), 'format': 'fullwidth', 'alt': 'a'},
+            {'id': str(img_without.pk), 'format': 'fullwidth', 'alt': 'b'},
+        ])
+        assert 'data-image-credit="Reuters"' in results[0]
+        assert 'data-image-credit' not in results[1]
+
+
+class TestImageEmbedHandlerBaseBehavior:
+    """Tests that base Wagtail behavior is preserved."""
+
+    def test_nonexistent_image_returns_empty_img(self):
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': '999999',
+            'format': 'left',
+            'alt': '',
+        })
+        assert result == '<img alt="">'
+
+    def test_alt_text_preserved(self):
+        image = AplansImageFactory.create()
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': str(image.pk),
+            'format': 'left',
+            'alt': 'A beautiful sunset',
+        })
+        assert 'alt="A beautiful sunset"' in result
+
+    def test_css_class_preserved(self):
+        image = AplansImageFactory.create()
+        result = ImageEmbedHandler.expand_db_attributes({
+            'id': str(image.pk),
+            'format': 'left',
+            'alt': 'test',
+        })
+        assert 'class="richtext-image left"' in result
+
+    def test_identifier_is_image(self):
+        assert ImageEmbedHandler.identifier == 'image'
+
+
+class TestImageEmbedHandlerRegistration:
+    """Tests that the custom handler is registered in Wagtail's feature registry."""
+
+    def test_custom_handler_registered_in_feature_registry(self):
+        from wagtail.rich_text import features
+
+        embed_types = features.get_embed_types()
+        assert embed_types['image'] is ImageEmbedHandler
+
+    def test_expand_db_html_uses_custom_handler(self):
+        """End-to-end: expand_db_html should produce data-image-credit."""
+        from wagtail.rich_text import expand_db_html
+
+        image = AplansImageFactory.create(image_credit='AP Photo')
+        html = f'<embed embedtype="image" id="{image.pk}" format="fullwidth" alt="test"/>'
+        result = expand_db_html(html)
+        assert 'data-image-credit="AP Photo"' in result


### PR DESCRIPTION
Images embedded in rich-text fields were missing byline/source attribution, unlike images in content blocks (e.g. Large Image) which already displayed credits. This adds a custom ImageEmbedHandler that injects the image's `image_credit` field as a `data-image-credit` HTML attribute on `<img>` tags rendered inside rich text.

The handler is registered by overriding Wagtail's feature registry after the default feature scan completes, then clearing the `get_rewriter` LRU cache. This avoids a timing issue where Wagtail's own hook would overwrite our handler during the scan.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213362889049060?focus=true)

## Requirements, dependencies and related PRs
[Front-end PR](https://github.com/kausaltech/kausal-watch-ui/pull/697)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
