### PR TITLE
Set primary languages of organizations properly in REST

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1570,12 +1570,16 @@ class OrganizationPermission(WatchObjectPermissions):
 
 class OrganizationSerializer(TreebeardModelSerializerMixin[Organization], serializers.ModelSerializer[Organization]):  # type: ignore[misc]
     uuid = serializers.UUIDField(required=False)
-    primary_language = serializers.CharField(required=False, allow_blank=True)
 
     class Meta:
         model = Organization
         list_serializer_class = BulkListSerializer
-        fields: ClassVar = [*public_fields(Organization), 'primary_language']
+        fields: ClassVar = public_fields(Organization)
+        extra_kwargs: ClassVar = {
+            # Allow omitting primary_language since it
+            # can then be taken from the plan
+            'primary_language': {'required': False},
+        }
 
     def create(self, validated_data):
         plan = self.context.get('plan')

--- a/actions/api.py
+++ b/actions/api.py
@@ -1570,17 +1570,21 @@ class OrganizationPermission(WatchObjectPermissions):
 
 class OrganizationSerializer(TreebeardModelSerializerMixin[Organization], serializers.ModelSerializer[Organization]):  # type: ignore[misc]
     uuid = serializers.UUIDField(required=False)
+    primary_language = serializers.CharField(required=False, allow_blank=True)
 
     class Meta:
         model = Organization
         list_serializer_class = BulkListSerializer
-        fields: ClassVar = public_fields(Organization)
+        fields: ClassVar = [*public_fields(Organization), 'primary_language']
 
     def create(self, validated_data):
+        plan = self.context.get('plan')
+        if plan is None:
+            request = cast('WatchAdminRequest', self.context.get('request'))
+            plan = request.get_active_admin_plan()
+        if not validated_data.get('primary_language'):
+            validated_data['primary_language'] = plan.primary_language
         instance = super().create(validated_data)
-        # Add instance to active plan's related organizations
-        request = cast('WatchAdminRequest', self.context.get('request'))
-        plan = request.get_active_admin_plan()
         plan.related_organizations.add(instance)
         return instance
 
@@ -1615,11 +1619,39 @@ class OrganizationViewSet(HandleProtectedErrorMixin, AuditLoggingBulkModelViewSe
         except Plan.DoesNotExist:
             raise exceptions.NotFound(detail='Plan not found') from None
 
+    def user_is_authorized_for_plan(self, plan: Plan) -> bool:
+        user = user_or_none(self.request.user)
+        return (
+            user is not None
+            and user.is_authenticated
+            and (
+                user.is_general_admin_for_plan(plan)
+                or user.is_contact_person_in_plan(plan)
+                or user.is_organization_admin_in_plan(plan)
+            )
+        )
+
+    def user_is_general_admin_for_plan(self, plan: Plan) -> bool:
+        user = user_or_none(self.request.user)
+        return user is not None and user.is_authenticated and user.is_general_admin_for_plan(plan)
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        plan = self.get_plan()
+        if plan is None:
+            return context
+        if not self.user_is_general_admin_for_plan(plan):
+            raise exceptions.PermissionDenied(detail='Not authorized')
+        context['plan'] = plan
+        return context
+
     def get_queryset(self):
         queryset = super().get_queryset().order_by('id')
         plan = self.get_plan()
         if plan is None:
             return queryset
+        if not self.user_is_authorized_for_plan(plan):
+            raise exceptions.PermissionDenied(detail='Not authorized')
         return Organization.objects.qs.available_for_plan(plan).order_by('id')
 
 

--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -348,8 +348,6 @@ else:
 
 
 class CategoryTypeQueryParameterMixin[M: Model](ModelAdminMixinBase[M]):
-    request: HttpRequest
-
     @property
     def index_url(self):
         return append_query_parameter(self.request, super().index_url, 'category_type')

--- a/actions/tests/test_api_organization_create.py
+++ b/actions/tests/test_api_organization_create.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from django.urls import reverse
+
+import pytest
+
+from actions.tests.factories import PlanFactory
+from orgs.models import Organization
+from orgs.tests.factories import OrganizationFactory
+from people.tests.factories import PersonFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def organization_list_url():
+    return reverse('organization-list')
+
+
+def test_organization_list_unauthenticated_with_plan_returns_403(api_client, organization_list_url):
+    plan = PlanFactory.create()
+    OrganizationFactory.create()
+    organization = Organization.objects.first()
+    assert organization
+    plan.related_organizations.add(organization)
+
+    api_client.logout()
+    response = api_client.get(organization_list_url, data={'plan': plan.identifier})
+    assert response.status_code == 403
+
+
+def test_organization_list_unauthorized_user_for_plan_returns_403(api_client, organization_list_url):
+    admin_plan = PlanFactory.create()
+    admin_person = PersonFactory.create(
+        organization=admin_plan.organization,
+        general_admin_plans=[admin_plan],
+    )
+
+    other_plan = PlanFactory.create()
+    OrganizationFactory.create()
+    organization = Organization.objects.last()
+    assert organization
+    other_plan.related_organizations.add(organization)
+
+    api_client.force_login(admin_person.user)
+    response = api_client.get(organization_list_url, data={'plan': other_plan.identifier})
+    assert response.status_code == 403
+
+
+def test_organization_list_authorized_user_for_plan_returns_200(api_client, organization_list_url):
+    plan = PlanFactory.create()
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+
+    api_client.force_login(admin_person.user)
+    response = api_client.get(organization_list_url, data={'plan': plan.identifier})
+    assert response.status_code == 200
+
+
+def test_create_organization_unauthorized_for_plan_returns_403(api_client, organization_list_url):
+    admin_plan = PlanFactory.create()
+    admin_person = PersonFactory.create(
+        organization=admin_plan.organization,
+        general_admin_plans=[admin_plan],
+    )
+
+    other_plan = PlanFactory.create()
+
+    api_client.force_login(admin_person.user)
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Sneaky Org', 'parent': None, 'left_sibling': None},
+        QUERY_STRING=f'plan={other_plan.identifier}',
+    )
+    assert response.status_code == 403
+
+
+def test_create_organization_gets_primary_language_from_plan_query_param(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='fi')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'New Org', 'parent': None, 'left_sibling': None},
+        QUERY_STRING=f'plan={plan.identifier}',
+    )
+    assert response.status_code == 201, response.json_data
+    org = Organization.objects.get(pk=response.json_data['id'])
+    assert org.primary_language == 'fi'
+    assert plan.related_organizations.filter(pk=org.pk).exists()
+
+
+def test_create_organization_falls_back_to_active_admin_plan(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='sv')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Fallback Org', 'parent': None, 'left_sibling': None},
+    )
+    assert response.status_code == 201, response.json_data
+    org = Organization.objects.get(pk=response.json_data['id'])
+    assert org.primary_language == 'sv'
+    assert plan.related_organizations.filter(pk=org.pk).exists()
+
+
+def test_create_organization_explicit_language_overrides_plan_query_param(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='fi')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Explicit Org', 'parent': None, 'left_sibling': None, 'primary_language': 'de'},
+        QUERY_STRING=f'plan={plan.identifier}',
+    )
+    assert response.status_code == 201, response.json_data
+    org = Organization.objects.get(pk=response.json_data['id'])
+    assert org.primary_language == 'de'
+
+
+def test_create_organization_explicit_language_overrides_active_admin_plan(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='sv')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Explicit Org 2', 'parent': None, 'left_sibling': None, 'primary_language': 'en'},
+    )
+    assert response.status_code == 201, response.json_data
+    org = Organization.objects.get(pk=response.json_data['id'])
+    assert org.primary_language == 'en'
+
+
+def test_update_organization_preserves_primary_language_when_omitted(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='fi')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    # Create an org with 'de' language
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Org To Update', 'parent': None, 'left_sibling': None, 'primary_language': 'de'},
+        QUERY_STRING=f'plan={plan.identifier}',
+    )
+    assert response.status_code == 201, response.json_data
+    org_id = response.json_data['id']
+    org_uuid = response.json_data['uuid']
+
+    # PATCH without primary_language — it should stay 'de'
+    detail_url = reverse('organization-detail', kwargs={'pk': org_id})
+    response = api_client.patch(
+        detail_url,
+        data={'id': org_id, 'uuid': org_uuid, 'name': 'Renamed Org', 'parent': None, 'left_sibling': None},
+    )
+    assert response.status_code == 200, response.json_data
+    org = Organization.objects.get(pk=org_id)
+    assert org.name == 'Renamed Org'
+    assert org.primary_language == 'de'

--- a/actions/tests/test_api_organization_create.py
+++ b/actions/tests/test_api_organization_create.py
@@ -149,6 +149,38 @@ def test_create_organization_explicit_language_overrides_active_admin_plan(api_c
     assert org.primary_language == 'en'
 
 
+def test_create_organization_rejects_invalid_language_choice(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='fi')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Bad Lang Org', 'parent': None, 'left_sibling': None, 'primary_language': 'xx-invalid'},
+        QUERY_STRING=f'plan={plan.identifier}',
+    )
+    assert response.status_code == 400
+
+
+def test_create_organization_rejects_too_long_language_code(api_client, organization_list_url):
+    plan = PlanFactory.create(primary_language='fi')
+    admin_person = PersonFactory.create(
+        organization=plan.organization,
+        general_admin_plans=[plan],
+    )
+    api_client.force_login(admin_person.user)
+
+    response = api_client.post(
+        organization_list_url,
+        data={'name': 'Long Lang Org', 'parent': None, 'left_sibling': None, 'primary_language': 'a' * 9},
+        QUERY_STRING=f'plan={plan.identifier}',
+    )
+    assert response.status_code == 400
+
+
 def test_update_organization_preserves_primary_language_when_omitted(api_client, organization_list_url):
     plan = PlanFactory.create(primary_language='fi')
     admin_person = PersonFactory.create(

--- a/orgs/tests/factories.py
+++ b/orgs/tests/factories.py
@@ -34,6 +34,7 @@ class OrganizationFactory(ModelFactory[Organization]):
     classification = SubFactory[Organization, OrganizationClass](OrganizationClassFactory)
     name = Sequence(lambda i: f'Organization {i}')
     abbreviation = Sequence(lambda i: f'org{i}')
+    primary_language = 'en'
     description = RichText('<p>Description</p>')
     url = 'https://example.org'
 


### PR DESCRIPTION
Previously the primary language was empty

## Description
Either use the explicit value in the payload, or the primary_language of the plan in the query parameter, or as a fallback, the primary_language of the active admin plan.

## Screenshots/Videos (if applicable)
N/A

## Related issue
Part 2 of ensuring org.primary_language always gets set

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Create orgs in the table editor. See that their language matches the plan's.
    
### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
Please merge at the same time as https://github.com/kausaltech/kausal-backend-common/pull/88