### PR TITLE
Add pledges block for action details page

### DIFF
--- a/actions/action_fields.py
+++ b/actions/action_fields.py
@@ -174,7 +174,7 @@ def initialize():
             has_report_block=False,
         )
     )
-    for field_name in ['contact_persons', 'links', 'related_actions', 'schedule']:
+    for field_name in ['contact_persons', 'links', 'pledges', 'related_actions', 'schedule']:
         register(
             Field(
                 field_name,

--- a/actions/api.py
+++ b/actions/api.py
@@ -1022,6 +1022,9 @@ class ActionSerializer(  # type: ignore[misc]
             del fields['internal_notes']
             del fields['internal_admin_notes']
 
+        if not self.plan.features.enable_community_engagement:
+            fields.pop('pledges', None)
+
         if user is not None:
             fields['modifiable_by_user'] = serializers.SerializerMethodField()
 

--- a/actions/blocks/action_content.py
+++ b/actions/blocks/action_content.py
@@ -68,6 +68,7 @@ ActionMainContentBlock = generate_stream_block(
         'related_actions',
         'dependencies',
         'related_indicators',
+        'pledges',
         ('contact_form', ActionContactFormBlock(required=True)),
         ('report_comparison', ReportComparisonBlock()),
         ('indicator_causal_chain', IndicatorCausalChainBlock()),

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -97,6 +97,7 @@ if typing.TYPE_CHECKING:
 
     from actions.attributes import DraftAttributes
     from actions.models.category import CategoryType
+    from actions.models.pledge import Pledge
     from indicators.models import ActionIndicator, ActionIndicatorQuerySet, IndicatorQuerySet
     from people.models import Person
 
@@ -800,6 +801,7 @@ class Action(
     copies: RevMany[Action]
     tasks: RevMany[ActionTask]
     responsible_parties: RevMany[ActionResponsibleParty]
+    pledges: RevMany[Pledge]
 
     verbose_name_partitive = pgettext_lazy('partitive', 'action')
 

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -785,6 +785,7 @@ class Action(
         'dependent_relationships',
         'dependency_role',
         'visibility',
+        'pledges',
     ]
 
     # type annotations for related objects

--- a/actions/models/pledge.py
+++ b/actions/models/pledge.py
@@ -162,6 +162,7 @@ class Pledge(
     actions: M2MQS[Action, PledgeActionThrough, ActionQuerySet] = ParentalManyToManyField(  # type: ignore[assignment]  # pyright: ignore[reportAssignmentType]
         'actions.Action',
         through='PledgeActionThrough',
+        related_name='pledges',
         blank=True,
         verbose_name=_('actions'),
         help_text=_('Actions this pledge supports'),

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1741,6 +1741,12 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode[Action
         return root.get_redacted_contact_persons(user, show_all_contact_persons, cache)
 
     @staticmethod
+    def resolve_pledges(root: Action, info: GQLInfo):
+        if not root.plan.features.enable_community_engagement:
+            return []
+        return root.pledges.all()
+
+    @staticmethod
     def resolve_similar_actions(root: Action, info: GQLInfo) -> list[Action]:
         if not (lang := info.context.graphql_query_language):
             return []

--- a/actions/tests/test_api.py
+++ b/actions/tests/test_api.py
@@ -58,6 +58,24 @@ def test_action_api_get(api_client, action_list_url, action):
     assert obj['plan'] == action.plan_id
 
 
+def test_action_api_excludes_pledges_when_feature_disabled(api_client, action_list_url, action: Action):
+    action.plan.features.enable_community_engagement = False
+    action.plan.features.save()
+
+    response = api_client.get(action_list_url)
+    obj = response.json_data['results'][0]
+    assert 'pledges' not in obj
+
+
+def test_action_api_includes_pledges_when_feature_enabled(api_client, action_list_url, action: Action):
+    action.plan.features.enable_community_engagement = True
+    action.plan.features.save()
+
+    response = api_client.get(action_list_url)
+    obj = response.json_data['results'][0]
+    assert 'pledges' in obj
+
+
 PERSON_COUNT = 10
 
 

--- a/actions/tests/test_graphql_pledge.py
+++ b/actions/tests/test_graphql_pledge.py
@@ -87,6 +87,19 @@ PLAN_FEATURES_QUERY = """
 """
 
 
+ACTION_PLEDGES_QUERY = """
+    query($actionId: ID!) {
+        action(id: $actionId) {
+            id
+            pledges {
+                id
+                name
+            }
+        }
+    }
+"""
+
+
 class TestPledgeQueryById:
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -1228,3 +1241,39 @@ class TestPledgeCommitmentCountAnnotation:
             """,
             variables={'plan': self.plan.identifier},
         )
+
+
+class TestActionPledgesFeatureFlag:
+    """Test that pledges on ActionNode are gated behind enable_community_engagement."""
+
+    def test_action_pledges_returned_when_feature_enabled(self, graphql_client_query_data):
+        plan = PlanFactory.create()
+        plan.features.enable_community_engagement = True
+        plan.features.save()
+
+        action = ActionFactory.create(plan=plan)
+        pledge = PledgeFactory.create(plan=plan, actions=[action])
+
+        data = graphql_client_query_data(
+            ACTION_PLEDGES_QUERY,
+            variables={'actionId': str(action.id)},
+        )
+
+        pledges = data['action']['pledges']
+        assert len(pledges) == 1
+        assert pledges[0]['id'] == str(pledge.id)
+
+    def test_action_pledges_empty_when_feature_disabled(self, graphql_client_query_data):
+        plan = PlanFactory.create()
+        plan.features.enable_community_engagement = False
+        plan.features.save()
+
+        action = ActionFactory.create(plan=plan)
+        PledgeFactory.create(plan=plan, actions=[action])
+
+        data = graphql_client_query_data(
+            ACTION_PLEDGES_QUERY,
+            variables={'actionId': str(action.id)},
+        )
+
+        assert data['action']['pledges'] == []

--- a/copying/main.py
+++ b/copying/main.py
@@ -115,8 +115,8 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
         'copies': EXCLUDED,
         'relatedactionsthrough': EXCLUDED,  # reverse of RelatedActionsThrough.to_action; covered via related_actions_through
         'change_log_messages': EXCLUDED,
-        'pledge': EXCLUDED,
-        'pledgeactionthrough': EXCLUDED,
+        'pledgeactionthrough': EXCLUDED,  # reverse of PledgeActionThrough.action; covered via pledges.pledge_action_through
+        'pledges': EXCLUDED,  # reverse M2M; copied as part of Plan.pledges
         'user_feedbacks': EXCLUDED,
     },
     'built_in_field_customizations': {},
@@ -174,7 +174,11 @@ PLAN_CLONE_STRUCTURE: CloneStructure = {
     'superseded_plans': EXCLUDED,
     'copies': EXCLUDED,
     'monitoring_quality_points': EXCLUDED,  # legacy
-    'pledges': EXCLUDED,
+    'pledges': {
+        'commitments': EXCLUDED,  # deliberately don't copy commitments as this should depend on approval of citizens
+        'pledge_action_through': {},
+        'user_feedbacks': EXCLUDED,
+    },
     'documentation_root_pages': EXCLUDED,  # handled separately by _copy_documentation_pages
     'user_feedbacks': EXCLUDED,
     'plan_common_indicator_through': EXCLUDED,  # common indicator assignments are not plan-owned


### PR DESCRIPTION
Register pledges as a many-type field block and add it to ActionMainContentBlock so it can be used in the sections of action details pages.

## Related issue
[Asana task](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213893804379191?focus=true)

## Requirements, dependencies and related PRs
[Frontend PR that takes the block into use](https://github.com/kausaltech/kausal-watch-ui/pull/707)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
