### PR TITLE
Disable notifications in copied plans

### DIFF
--- a/copying/main.py
+++ b/copying/main.py
@@ -48,7 +48,7 @@ from indicators.models.common_indicator import CommonIndicator
 from indicators.models.dimensions import Dimension
 from indicators.models.indicator import Indicator
 from indicators.models.metadata import Quantity, Unit
-from notifications.models import AutomaticNotificationTemplate, BaseTemplate, ContentBlock
+from notifications.models import AutomaticNotificationTemplate, BaseTemplate, ContentBlock, NotificationSettings
 from orgs.models import Organization
 from pages.models import PlanRootPage
 from people.models import Person
@@ -361,7 +361,7 @@ class CloneVisitor(AbstractVisitor):
         """
         Create a copy of the instance of the given node.
 
-        Behavior can be customized for each instance type using the hooks `pre_visit` and `save_copy`.
+        Behavior can be customized for each instance type using the hooks `pre_visit`, `save_copy` and `post_visit`.
         """
         original_instance = shallow_copy(node.instance)
         self.pre_visit(node.instance)
@@ -519,6 +519,12 @@ class CloneVisitor(AbstractVisitor):
     @save_copy.register
     def _(self, instance: CategoryType) -> None:
         instance.save(skip_page_synchronization=True)
+
+    @save_copy.register
+    def _(self, instance: NotificationSettings) -> None:
+        # Disable notifications for plan copies regardless of the original plan's setting
+        instance.notifications_enabled = False
+        instance.save()
 
     @singledispatchmethod
     def post_visit(self, original, copy) -> None:
@@ -1244,15 +1250,6 @@ def _copy_indicators(plan: Plan, clone_visitor: CloneVisitor) -> list[Indicator]
     return indicators
 
 
-def _post_copying_steps(plan_copy: Plan) -> None:
-    """Perform actions that need to be done after copying."""
-
-    # Force disabling notifications. Most likely the copied plan is under work
-    # or in an archived state where sending notifications makes no sense.
-    plan_copy.notification_settings.notifications_enabled = False
-    plan_copy.notification_settings.save(update_fields=['notifications_enabled'])
-
-
 def _clone_plan_objects(
     plan: Plan,
     clone_visitor: CloneVisitor,
@@ -1287,8 +1284,6 @@ def _clone_plan_objects(
     # Restore temporarily removed links
     clone_visitor.restore_removed_links()
     update_references(plan_copy, attribute_types, indicators, clone_visitor)
-
-    _post_copying_steps(plan_copy)
 
     return plan_copy
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -1244,6 +1244,15 @@ def _copy_indicators(plan: Plan, clone_visitor: CloneVisitor) -> list[Indicator]
     return indicators
 
 
+def _post_copying_steps(plan_copy: Plan) -> None:
+    """Perform actions that need to be done after copying."""
+
+    # Force disabling notifications. Most likely the copied plan is under work
+    # or in an archived state where sending notifications makes no sense.
+    plan_copy.notification_settings.notifications_enabled = False
+    plan_copy.notification_settings.save(update_fields=['notifications_enabled'])
+
+
 def _clone_plan_objects(
     plan: Plan,
     clone_visitor: CloneVisitor,
@@ -1278,6 +1287,8 @@ def _clone_plan_objects(
     # Restore temporarily removed links
     clone_visitor.restore_removed_links()
     update_references(plan_copy, attribute_types, indicators, clone_visitor)
+
+    _post_copying_steps(plan_copy)
 
     return plan_copy
 

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -806,3 +806,13 @@ def test_copy_plan_does_not_duplicate_template_specific_content_block(plan_with_
     assert template_block.template == template_copy
     assert template_block.template.base == template_block.base
     assert template_block.identifier == 'intro'
+
+
+def test_copy_plan_disables_notifications(plan_with_pages):
+    """Copied plan always has notifications_enabled=False, even if the original has it enabled."""
+    plan_with_pages.notification_settings.notifications_enabled = True
+    plan_with_pages.notification_settings.save(update_fields=['notifications_enabled'])
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    assert not plan_copy.notification_settings.notifications_enabled


### PR DESCRIPTION
## Description
Disable notifications in copied plans.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Slack](https://kausaltech.slack.com/archives/C07R954EV7D/p1775634911185349?thread_ts=1775566861.346659&cid=C07R954EV7D)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    \-

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
