### PR TITLE
Support country codes in Watch UI plan wildcard hostnames

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -101,11 +101,12 @@ def get_timezones() -> list[tuple[str, str]]:
 def _matches_any_wildcard_domain(domain: str, wildcard_domains: list[str]) -> bool:
     domain_lower = domain.lower()
     for wd in wildcard_domains:
-        if '*' in wd:
-            is_match, _ = matches_hostname_pattern(domain_lower, wd, allow_shortened=True)
+        wd_lower = wd.lower()
+        if '*' in wd_lower:
+            is_match, _ = matches_hostname_pattern(domain_lower, wd_lower, allow_shortened=True)
             if is_match:
                 return True
-        elif domain_lower == wd:
+        elif domain_lower == wd_lower:
             return True
     return False
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -48,7 +48,7 @@ from aplans.utils import (
     IdentifierField,
     OrderedModel,
     PlanRelatedModelWithRevision,
-    _matches_hostname_pattern,
+    matches_hostname_pattern,
 )
 
 from actions.permission_policy import PlanPermissionPolicy
@@ -102,7 +102,7 @@ def _matches_any_wildcard_domain(domain: str, wildcard_domains: list[str]) -> bo
     domain_lower = domain.lower()
     for wd in wildcard_domains:
         if '*' in wd:
-            is_match, _ = _matches_hostname_pattern(domain_lower, wd, allow_shortened=True)
+            is_match, _ = matches_hostname_pattern(domain_lower, wd, allow_shortened=True)
             if is_match:
                 return True
         elif domain_lower == wd:
@@ -163,7 +163,7 @@ def get_canonical_wildcard_hostname(
     for wd in all_wildcard_domains:
         if '*' not in wd:
             continue
-        is_match, matched_region = _matches_hostname_pattern(domain, wd, allow_shortened=True)
+        is_match, matched_region = matches_hostname_pattern(domain, wd, allow_shortened=True)
         if is_match and matched_region:
             plan_region = plan.country.code.lower()
             if matched_region.lower() != plan_region:

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -48,6 +48,7 @@ from aplans.utils import (
     IdentifierField,
     OrderedModel,
     PlanRelatedModelWithRevision,
+    _matches_hostname_pattern,
 )
 
 from actions.permission_policy import PlanPermissionPolicy
@@ -97,9 +98,27 @@ def get_timezones() -> list[tuple[str, str]]:
     return [(x, x) for x in sorted(zoneinfo.available_timezones(), key=str.lower)]
 
 
+def _matches_any_wildcard_domain(domain: str, wildcard_domains: list[str]) -> bool:
+    domain_lower = domain.lower()
+    for wd in wildcard_domains:
+        if '*' in wd:
+            is_match, _ = _matches_hostname_pattern(domain_lower, wd, allow_shortened=True)
+            if is_match:
+                return True
+        elif domain_lower == wd:
+            return True
+    return False
+
+
 def get_plan_identifier_from_wildcard_domain(
     hostname: str, request: WatchRequest | WatchGraphQLContext | None = None
 ) -> tuple[str, str] | tuple[None, None]:
+    """
+    Match the incoming hostname having a plan identifier + potential country code with a wildcard domain.
+
+    Returns a tuple of (plan_identifier, matched wildcard domain)
+
+    """
     from aplans.schema_context import WatchGraphQLContext
 
     # Get plan identifier from hostname for development and testing
@@ -109,9 +128,60 @@ def get_plan_identifier_from_wildcard_domain(
     else:
         req_wildcards = getattr(request, 'wildcard_domains', None) or []
     wildcard_domains = (settings.HOSTNAME_PLAN_DOMAINS or []) + req_wildcards
-    if len(parts) == 2 and parts[1].lower() in wildcard_domains:
+    if len(parts) == 2 and _matches_any_wildcard_domain(parts[1], wildcard_domains):
         return (parts[0], parts[1])
     return (None, None)
+
+
+def _get_all_wildcard_domains(
+    request: WatchRequest | WatchGraphQLContext | None = None,
+) -> list[str]:
+    from aplans.schema_context import WatchGraphQLContext
+
+    if isinstance(request, WatchGraphQLContext):
+        req_wildcards = request.wildcard_domains
+    else:
+        req_wildcards = getattr(request, 'wildcard_domains', None) or []
+    return (settings.HOSTNAME_PLAN_DOMAINS or []) + req_wildcards
+
+
+def get_canonical_wildcard_hostname(
+    hostname: str,
+    plan: Plan,
+    request: WatchRequest | WatchGraphQLContext | None = None,
+) -> str | None:
+    """If hostname uses wrong region for this plan, return the correct hostname."""
+    if not plan.country:
+        return None
+    parts = hostname.split('.', maxsplit=1)
+    if len(parts) != 2:
+        return None
+    identifier, domain = parts
+
+    all_wildcard_domains = _get_all_wildcard_domains(request)
+
+    for wd in all_wildcard_domains:
+        if '*' not in wd:
+            continue
+        is_match, matched_region = _matches_hostname_pattern(domain, wd, allow_shortened=True)
+        if is_match and matched_region:
+            plan_region = plan.country.code.lower()
+            if matched_region.lower() != plan_region:
+                domain_parts = domain.split('.')
+                pattern_parts = wd.split('.')
+                for i, pp in enumerate(pattern_parts):
+                    if pp == '*':
+                        domain_parts[i] = plan_region
+                        break
+                return f'{identifier}.{".".join(domain_parts)}'
+        elif is_match and matched_region is None:
+            plan_region = plan.country.code.lower()
+            domain_parts = domain.split('.')
+            pattern_parts = wd.split('.')
+            wildcard_idx = pattern_parts.index('*')
+            domain_parts.insert(wildcard_idx, plan_region)
+            return f'{identifier}.{".".join(domain_parts)}'
+    return None
 
 
 def get_page_translation(page: Page, fallback=True) -> Page:
@@ -1099,7 +1169,12 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
             default_domain = next(iter(hostname_plan_domains))
         except StopIteration as e:
             raise Exception('Cannot create default hostname if no hostname plan domains are configured') from e
-        return '%s.%s' % (self.identifier, default_domain)
+        if '*' in default_domain:
+            country_code = self.country.code.lower() if self.country else None
+            if not country_code:
+                raise Exception(f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'")
+            default_domain = default_domain.replace('*', country_code, 1)
+        return f'{self.identifier}.{default_domain}'
 
     def get_all_related_plans(self, inclusive=False) -> PlanQuerySet:
         q = Q(related_plans=self)

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -93,6 +93,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Placeholder used in hostname patterns where country code is injected
+COUNTRY_PLACEHOLDER = '<country>'
+
+
 @cache
 def get_timezones() -> list[tuple[str, str]]:
     return [(x, x) for x in sorted(zoneinfo.available_timezones(), key=str.lower)]
@@ -102,8 +106,8 @@ def _matches_any_wildcard_domain(domain: str, wildcard_domains: list[str]) -> bo
     domain_lower = domain.lower()
     for wd in wildcard_domains:
         wd_lower = wd.lower()
-        if '*' in wd_lower:
-            is_match, _ = matches_hostname_pattern(domain_lower, wd_lower, allow_shortened=True)
+        if COUNTRY_PLACEHOLDER in wd_lower:
+            is_match, _ = matches_hostname_pattern(domain_lower, wd_lower, allow_shortened=True, placeholder=COUNTRY_PLACEHOLDER)
             if is_match:
                 return True
         elif domain_lower == wd_lower:
@@ -162,16 +166,16 @@ def get_canonical_wildcard_hostname(
     all_wildcard_domains = _get_all_wildcard_domains(request)
 
     for wd in all_wildcard_domains:
-        if '*' not in wd:
+        if COUNTRY_PLACEHOLDER not in wd:
             continue
-        is_match, matched_region = matches_hostname_pattern(domain, wd, allow_shortened=True)
+        is_match, matched_region = matches_hostname_pattern(domain, wd, allow_shortened=True, placeholder=COUNTRY_PLACEHOLDER)
         if is_match and matched_region:
             plan_region = plan.country.code.lower()
             if matched_region.lower() != plan_region:
                 domain_parts = domain.split('.')
                 pattern_parts = wd.split('.')
                 for i, pp in enumerate(pattern_parts):
-                    if pp == '*':
+                    if pp == COUNTRY_PLACEHOLDER:
                         domain_parts[i] = plan_region
                         break
                 return f'{identifier}.{".".join(domain_parts)}'
@@ -179,7 +183,7 @@ def get_canonical_wildcard_hostname(
             plan_region = plan.country.code.lower()
             domain_parts = domain.split('.')
             pattern_parts = wd.split('.')
-            wildcard_idx = pattern_parts.index('*')
+            wildcard_idx = pattern_parts.index(COUNTRY_PLACEHOLDER)
             domain_parts.insert(wildcard_idx, plan_region)
             return f'{identifier}.{".".join(domain_parts)}'
     return None
@@ -1170,11 +1174,11 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
             default_domain = next(iter(hostname_plan_domains))
         except StopIteration as e:
             raise Exception('Cannot create default hostname if no hostname plan domains are configured') from e
-        if '*' in default_domain:
+        if COUNTRY_PLACEHOLDER in default_domain:
             country_code = self.country.code.lower() if self.country else None
             if not country_code:
                 raise Exception(f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'")
-            default_domain = default_domain.replace('*', country_code, 1)
+            default_domain = default_domain.replace(COUNTRY_PLACEHOLDER, country_code, 1)
         return f'{self.identifier}.{default_domain}'
 
     def get_all_related_plans(self, inclusive=False) -> PlanQuerySet:

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -231,6 +231,8 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
         model_field='domains',
     )
     def resolve_domain(root: Plan, info, hostname=None) -> PlanDomain | None:
+        from actions.models.plan import get_canonical_wildcard_hostname
+
         context_hostname = getattr(info.context, '_plan_hostname', None)
         if not hostname:
             hostname = context_hostname
@@ -243,7 +245,7 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
         implicit_domain = PlanDomain(
             plan=root,
             hostname=hostname,
-            redirect_to_hostname=None,
+            redirect_to_hostname=get_canonical_wildcard_hostname(hostname, root, request=info.context),
             base_path='',
             redirect_aliases=[],
         )

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -1,0 +1,142 @@
+"""
+Tests for Plan.get_view_url without wildcard (*) hostname patterns.
+
+These tests verify that the non-wildcard get_view_url behavior is preserved
+when wildcard hostname support is added.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from actions.tests.factories import PlanDomainFactory, PlanFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def plan():
+    return PlanFactory.create(
+        site_url='https://myplan.example.com',
+        primary_language='en',
+        other_languages=['fi'],
+    )
+
+
+@pytest.fixture(params=['settings', 'request', 'both'], ids=['via_settings', 'via_request', 'via_both'])
+def wildcard_domain(request, settings):
+    retval = {}
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    if request.param in ('settings', 'both'):
+        settings.HOSTNAME_PLAN_DOMAINS = ['dummy.io']
+    if request.param in ('request', 'both'):
+        retval.update({'request': SimpleNamespace(wildcard_domains=['dummy.io'])})
+    return retval
+
+
+@pytest.fixture
+def no_wildcard_domains(settings):
+    settings.HOSTNAME_PLAN_DOMAINS = []
+
+
+class TestGetViewUrlNoClientUrl:
+    def test_returns_site_url(self, plan):
+        assert plan.get_view_url() == 'https://myplan.example.com'
+
+    def test_returns_site_url_with_trailing_slash_stripped(self):
+        plan = PlanFactory.create(site_url='https://myplan.example.com/')
+        assert plan.get_view_url() == 'https://myplan.example.com'
+
+    def test_adds_locale_prefix_for_non_primary_language(self, plan):
+        url = plan.get_view_url(active_locale='fi')
+        assert url == 'https://myplan.example.com/fi'
+
+    def test_no_locale_prefix_for_primary_language(self, plan):
+        url = plan.get_view_url(active_locale='en')
+        assert url == 'https://myplan.example.com'
+
+    def test_no_locale_prefix_for_unknown_language(self, plan):
+        url = plan.get_view_url(active_locale='sv')
+        assert url == 'https://myplan.example.com'
+
+    def test_site_url_without_scheme_gets_https(self):
+        plan = PlanFactory.create(site_url='myplan.example.com')
+        assert plan.get_view_url() == 'https://myplan.example.com'
+
+
+class TestGetViewUrlWithWildcardDomain:
+    """Test get_view_url when client_url matches a HOSTNAME_PLAN_DOMAINS entry (non-* pattern)."""
+
+    def test_returns_url_with_plan_identifier(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='https://anything.dummy.io', **wildcard_domain)
+        assert url == f'https://{plan.identifier}.dummy.io'
+
+    def test_preserves_http_scheme(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='http://anything.dummy.io', **wildcard_domain)
+        assert url == f'http://{plan.identifier}.dummy.io'
+
+    def test_preserves_custom_port(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='https://anything.dummy.io:8080', **wildcard_domain)
+        assert url == f'https://{plan.identifier}.dummy.io:8080'
+
+    def test_strips_default_https_port(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='https://anything.dummy.io:443', **wildcard_domain)
+        assert url == f'https://{plan.identifier}.dummy.io'
+
+    def test_strips_default_http_port(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='http://anything.dummy.io:80', **wildcard_domain)
+        assert url == f'http://{plan.identifier}.dummy.io'
+
+    def test_adds_locale_prefix(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='https://anything.dummy.io', active_locale='fi', **wildcard_domain)
+        assert url == f'https://{plan.identifier}.dummy.io/fi'
+
+    def test_no_locale_prefix_for_primary_language(self, plan, wildcard_domain):
+        url = plan.get_view_url(client_url='https://anything.dummy.io', active_locale='en', **wildcard_domain)
+        assert url == f'https://{plan.identifier}.dummy.io'
+
+
+class TestGetViewUrlWithPlanDomain:
+    """Test get_view_url when client_url matches a PlanDomain."""
+
+    def test_returns_url_with_matching_domain(self, plan):
+        PlanDomainFactory.create(plan=plan, hostname='climate.city.gov')
+        url = plan.get_view_url(client_url='https://climate.city.gov')
+        assert url == 'https://climate.city.gov'
+
+    def test_includes_base_path(self, plan):
+        PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate')
+        url = plan.get_view_url(client_url='https://city.gov')
+        assert url == 'https://city.gov/climate'
+
+    def test_base_path_trailing_slash_stripped(self, plan):
+        PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate/')
+        url = plan.get_view_url(client_url='https://city.gov')
+        assert url == 'https://city.gov/climate'
+
+    def test_preserves_custom_port(self, plan):
+        PlanDomainFactory.create(plan=plan, hostname='climate.city.gov')
+        url = plan.get_view_url(client_url='https://climate.city.gov:8443')
+        assert url == 'https://climate.city.gov:8443'
+
+    def test_adds_locale_prefix(self, plan):
+        PlanDomainFactory.create(plan=plan, hostname='climate.city.gov')
+        url = plan.get_view_url(client_url='https://climate.city.gov', active_locale='fi')
+        assert url == 'https://climate.city.gov/fi'
+
+    def test_locale_prefix_after_base_path(self, plan):
+        PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate')
+        url = plan.get_view_url(client_url='https://city.gov', active_locale='fi')
+        assert url == 'https://city.gov/climate/fi'
+
+
+class TestGetViewUrlFallback:
+    """Test get_view_url falls back to site_url when client_url doesn't match anything."""
+
+    def test_falls_back_when_hostname_not_in_wildcard_or_domains(self, plan, no_wildcard_domains):
+        url = plan.get_view_url(client_url='https://unknown.example.org')
+        assert url == 'https://myplan.example.com'
+
+    def test_falls_back_with_locale_prefix(self, plan, no_wildcard_domains):
+        url = plan.get_view_url(client_url='https://unknown.example.org', active_locale='fi')
+        assert url == 'https://myplan.example.com/fi'

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -1,9 +1,4 @@
-"""
-Tests for Plan.get_view_url without wildcard (*) hostname patterns.
-
-These tests verify that the non-wildcard get_view_url behavior is preserved
-when wildcard hostname support is added.
-"""
+"""Tests for Plan.get_view_url."""
 
 from types import SimpleNamespace
 
@@ -140,3 +135,127 @@ class TestGetViewUrlFallback:
     def test_falls_back_with_locale_prefix(self, plan, no_wildcard_domains):
         url = plan.get_view_url(client_url='https://unknown.example.org', active_locale='fi')
         assert url == 'https://myplan.example.com/fi'
+
+
+@pytest.fixture
+def plan_with_country():
+    return PlanFactory.create(
+        site_url='https://myplan.example.com',
+        primary_language='en',
+        other_languages=['fi'],
+        country='FI',
+    )
+
+
+@pytest.fixture(params=['settings', 'request', 'both'], ids=['via_settings', 'via_request', 'via_both'])
+def mid_wildcard_domain(request, settings):
+    """Provide watch.*.dummy.io pattern via settings, request, or both."""
+    retval = {}
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    if request.param in ('settings', 'both'):
+        settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    if request.param in ('request', 'both'):
+        retval.update({'request': SimpleNamespace(wildcard_domains=['watch.*.dummy.io'])})
+    return retval
+
+
+@pytest.fixture(params=['settings', 'request', 'both'], ids=['via_settings', 'via_request', 'via_both'])
+def simple_wildcard_domain(request, settings):
+    """Provide *.dummy.io pattern via settings, request, or both."""
+    retval = {}
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    if request.param in ('settings', 'both'):
+        settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    if request.param in ('request', 'both'):
+        retval.update({'request': SimpleNamespace(wildcard_domains=['*.dummy.io'])})
+    return retval
+
+
+class TestGetViewUrlWithMidWildcardDomain:
+    """Test get_view_url when client_url matches a watch.*.dummy.io pattern."""
+
+    def test_returns_url_with_plan_identifier(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.watch.fi.dummy.io', **mid_wildcard_domain)
+        assert url == f'https://{plan.identifier}.watch.fi.dummy.io'
+
+    def test_preserves_http_scheme(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='http://anything.watch.fi.dummy.io', **mid_wildcard_domain)
+        assert url == f'http://{plan.identifier}.watch.fi.dummy.io'
+
+    def test_preserves_custom_port(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.watch.fi.dummy.io:8080', **mid_wildcard_domain)
+        assert url == f'https://{plan.identifier}.watch.fi.dummy.io:8080'
+
+    def test_strips_default_https_port(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.watch.fi.dummy.io:443', **mid_wildcard_domain)
+        assert url == f'https://{plan.identifier}.watch.fi.dummy.io'
+
+    def test_strips_default_http_port(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='http://anything.watch.fi.dummy.io:80', **mid_wildcard_domain)
+        assert url == f'http://{plan.identifier}.watch.fi.dummy.io'
+
+    def test_adds_locale_prefix(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.watch.fi.dummy.io', active_locale='fi', **mid_wildcard_domain)
+        assert url == f'https://{plan.identifier}.watch.fi.dummy.io/fi'
+
+    def test_no_locale_prefix_for_primary_language(self, plan_with_country, mid_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.watch.fi.dummy.io', active_locale='en', **mid_wildcard_domain)
+        assert url == f'https://{plan.identifier}.watch.fi.dummy.io'
+
+    def test_preserves_country_from_client_url(self, plan_with_country, mid_wildcard_domain):
+        """The country code in the URL comes from the client_url, not the plan."""
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.watch.de.dummy.io', **mid_wildcard_domain)
+        assert url == f'https://{plan.identifier}.watch.de.dummy.io'
+
+
+class TestGetViewUrlWithSimpleWildcardDomain:
+    """Test get_view_url when client_url matches a *.dummy.io pattern."""
+
+    def test_returns_url_with_plan_identifier(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.fi.dummy.io', **simple_wildcard_domain)
+        assert url == f'https://{plan.identifier}.fi.dummy.io'
+
+    def test_preserves_http_scheme(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='http://anything.fi.dummy.io', **simple_wildcard_domain)
+        assert url == f'http://{plan.identifier}.fi.dummy.io'
+
+    def test_preserves_custom_port(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.fi.dummy.io:8080', **simple_wildcard_domain)
+        assert url == f'https://{plan.identifier}.fi.dummy.io:8080'
+
+    def test_strips_default_https_port(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.fi.dummy.io:443', **simple_wildcard_domain)
+        assert url == f'https://{plan.identifier}.fi.dummy.io'
+
+    def test_strips_default_http_port(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='http://anything.fi.dummy.io:80', **simple_wildcard_domain)
+        assert url == f'http://{plan.identifier}.fi.dummy.io'
+
+    def test_adds_locale_prefix(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.fi.dummy.io', active_locale='fi', **simple_wildcard_domain)
+        assert url == f'https://{plan.identifier}.fi.dummy.io/fi'
+
+    def test_no_locale_prefix_for_primary_language(self, plan_with_country, simple_wildcard_domain):
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.fi.dummy.io', active_locale='en', **simple_wildcard_domain)
+        assert url == f'https://{plan.identifier}.fi.dummy.io'
+
+    def test_preserves_country_from_client_url(self, plan_with_country, simple_wildcard_domain):
+        """The country code in the URL comes from the client_url, not the plan."""
+        plan = plan_with_country
+        url = plan.get_view_url(client_url='https://anything.de.dummy.io', **simple_wildcard_domain)
+        assert url == f'https://{plan.identifier}.de.dummy.io'

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -60,7 +60,7 @@ class TestGetViewUrlNoClientUrl:
 
 
 class TestGetViewUrlWithWildcardDomain:
-    """Test get_view_url when client_url matches a HOSTNAME_PLAN_DOMAINS entry (non-* pattern)."""
+    """Test get_view_url when client_url matches a HOSTNAME_PLAN_DOMAINS entry (without <country> pattern)."""
 
     def test_returns_url_with_plan_identifier(self, plan, wildcard_domain):
         url = plan.get_view_url(client_url='https://anything.dummy.io', **wildcard_domain)
@@ -149,30 +149,30 @@ def plan_with_country():
 
 @pytest.fixture(params=['settings', 'request', 'both'], ids=['via_settings', 'via_request', 'via_both'])
 def mid_wildcard_domain(request, settings):
-    """Provide watch.*.dummy.io pattern via settings, request, or both."""
+    """Provide watch.<country>.dummy.io pattern via settings, request, or both."""
     retval = {}
     settings.HOSTNAME_PLAN_DOMAINS = []
     if request.param in ('settings', 'both'):
-        settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+        settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     if request.param in ('request', 'both'):
-        retval.update({'request': SimpleNamespace(wildcard_domains=['watch.*.dummy.io'])})
+        retval.update({'request': SimpleNamespace(wildcard_domains=['watch.<country>.dummy.io'])})
     return retval
 
 
 @pytest.fixture(params=['settings', 'request', 'both'], ids=['via_settings', 'via_request', 'via_both'])
 def simple_wildcard_domain(request, settings):
-    """Provide *.dummy.io pattern via settings, request, or both."""
+    """Provide <country>.dummy.io pattern via settings, request, or both."""
     retval = {}
     settings.HOSTNAME_PLAN_DOMAINS = []
     if request.param in ('settings', 'both'):
-        settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+        settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
     if request.param in ('request', 'both'):
-        retval.update({'request': SimpleNamespace(wildcard_domains=['*.dummy.io'])})
+        retval.update({'request': SimpleNamespace(wildcard_domains=['<country>.dummy.io'])})
     return retval
 
 
 class TestGetViewUrlWithMidWildcardDomain:
-    """Test get_view_url when client_url matches a watch.*.dummy.io pattern."""
+    """Test get_view_url when client_url matches a watch.<country>.dummy.io pattern."""
 
     def test_returns_url_with_plan_identifier(self, plan_with_country, mid_wildcard_domain):
         plan = plan_with_country
@@ -217,7 +217,7 @@ class TestGetViewUrlWithMidWildcardDomain:
 
 
 class TestGetViewUrlWithSimpleWildcardDomain:
-    """Test get_view_url when client_url matches a *.dummy.io pattern."""
+    """Test get_view_url when client_url matches a <country>.dummy.io pattern."""
 
     def test_returns_url_with_plan_identifier(self, plan_with_country, simple_wildcard_domain):
         plan = plan_with_country

--- a/actions/tests/test_graphql_plans_for_hostname.py
+++ b/actions/tests/test_graphql_plans_for_hostname.py
@@ -9,6 +9,20 @@ from actions.models.plan import PublicationStatus
 pytestmark = pytest.mark.django_db
 
 
+GET_PLAN_DOMAIN_QUERY = """
+  query GetPlansByHostname($hostname: String) {
+    plansForHostname(hostname: $hostname) {
+      ... on Plan {
+        identifier
+      }
+      domain(hostname: $hostname) {
+        hostname
+        redirectToHostname
+      }
+    }
+  }
+"""
+
 GET_PLANS_BY_HOSTNAME_QUERY = """
   query GetPlansByHostname($hostname: String) {
     plansForHostname(hostname: $hostname) {
@@ -126,18 +140,38 @@ def test_get_correct_domain_by_hostname(
         assert message is None
 
 
-DUMMY_DOMAIN = 'dummy.io'
+@pytest.fixture(params=['settings', 'header', 'both'], ids=['via_settings', 'via_header', 'via_both'])
+def hostname_plan_domains_with_country_wildcard(request, settings):
+    """Provide wildcard pattern domain via Django settings, x-wildcard-domains request header, or both."""
+    retval = {}
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    if request.param in ('settings', 'both'):
+        settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    if request.param in ('header', 'both'):
+        retval.update({'headers': {'x-wildcard-domains': 'watch.*.dummy.io'}})
+    return retval
 
 
-@pytest.fixture
-def use_dummy_plan_hostname(settings):
-    settings.HOSTNAME_PLAN_DOMAINS = [DUMMY_DOMAIN]
+@pytest.fixture(params=['settings', 'header', 'both'], ids=['via_settings', 'via_header', 'via_both'])
+def hostname_plan_domains_without_country_wildcard(request, settings):
+    """Provide exact (non-wildcard) domain via Django settings, x-wildcard-domains request header, or both."""
+    retval = {}
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    if request.param in ('settings', 'both'):
+        settings.HOSTNAME_PLAN_DOMAINS = ['dummy.io']
+    if request.param in ('header', 'both'):
+        retval.update({'headers': {'x-wildcard-domains': 'dummy.io'}})
+    return retval
 
 
 @pytest.mark.parametrize('delta_minutes', [-5, 5, None])
 @pytest.mark.parametrize(argnames='expose_flag', argvalues=[True, False])
 def test_plans_for_hostname_without_domains(
-    graphql_client_query_data, use_dummy_plan_hostname, plan_factory, delta_minutes, expose_flag
+    graphql_client_query_data,
+    hostname_plan_domains_without_country_wildcard,
+    plan_factory,
+    delta_minutes,
+    expose_flag,
 ):
     published_at = None
     if delta_minutes is not None:
@@ -147,7 +181,8 @@ def test_plans_for_hostname_without_domains(
     plan.features.save()
     data = graphql_client_query_data(
         GET_PLANS_BY_HOSTNAME_QUERY,
-        variables={'hostname': f'{plan.identifier}.{DUMMY_DOMAIN}'},
+        variables={'hostname': f'{plan.identifier}.dummy.io'},
+        **hostname_plan_domains_without_country_wildcard,
     )
     planData = data['plansForHostname'][0]
     assert len(planData['domains']) == 0
@@ -156,3 +191,216 @@ def test_plans_for_hostname_without_domains(
         assert planData['identifier'] == plan.identifier
     else:
         assert 'identifier' not in planData
+
+
+def test_wildcard_pattern_resolves_plan(graphql_client_query_data, hostname_plan_domains_with_country_wildcard, plan_factory):
+    """Plan resolved via identifier.watch.fi.dummy.io when wildcard domain watch.*.dummy.io is configured."""
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.watch.fi.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+        **hostname_plan_domains_with_country_wildcard,
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    assert plans[0]['identifier'] == plan.identifier
+    assert plans[0]['domain']['redirectToHostname'] is None
+
+
+def test_wildcard_pattern_and_exact_domain_coexist(
+    graphql_client_query_data, hostname_plan_domains_with_country_wildcard, settings, plan_factory
+):
+    """Both pattern and exact domain entries work when configured together."""
+    settings.HOSTNAME_PLAN_DOMAINS = settings.HOSTNAME_PLAN_DOMAINS + ['exact.example.com']
+    plan = plan_factory(country='FI')
+
+    # Via pattern
+    hostname_pattern = f'{plan.identifier}.watch.fi.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname_pattern},
+        **hostname_plan_domains_with_country_wildcard,
+    )
+    assert len(data['plansForHostname']) == 1
+    assert data['plansForHostname'][0]['identifier'] == plan.identifier
+    assert data['plansForHostname'][0]['domain']['redirectToHostname'] is None
+
+    # Via exact domain
+    hostname_exact = f'{plan.identifier}.exact.example.com'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname_exact},
+        **hostname_plan_domains_with_country_wildcard,
+    )
+    assert len(data['plansForHostname']) == 1
+    assert data['plansForHostname'][0]['identifier'] == plan.identifier
+    assert data['plansForHostname'][0]['domain']['redirectToHostname'] is None
+
+
+def test_exact_domain_still_works_with_no_patterns(
+    graphql_client_query_data,
+    hostname_plan_domains_without_country_wildcard,
+    plan_factory,
+):
+    """Backward compat: exact domain entries still resolve plans."""
+    plan = plan_factory()
+    hostname = f'{plan.identifier}.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+        **hostname_plan_domains_without_country_wildcard,
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    assert plans[0]['identifier'] == plan.identifier
+    assert plans[0]['domain']['redirectToHostname'] is None
+
+
+def test_cross_region_redirect(graphql_client_query_data, hostname_plan_domains_with_country_wildcard, plan_factory):
+    """Finnish plan accessed via watch.de.dummy.io gets redirect to watch.fi.dummy.io."""
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.watch.de.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+        **hostname_plan_domains_with_country_wildcard,
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    domain = plans[0]['domain']
+    assert domain['redirectToHostname'] == f'{plan.identifier}.watch.fi.dummy.io'
+
+
+def test_correct_region_no_redirect(graphql_client_query_data, hostname_plan_domains_with_country_wildcard, plan_factory):
+    """Finnish plan accessed via watch.fi.dummy.io has no redirect."""
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.watch.fi.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+        **hostname_plan_domains_with_country_wildcard,
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    domain = plans[0]['domain']
+    assert domain['redirectToHostname'] is None
+
+
+def test_non_pattern_domain_no_redirect(
+    graphql_client_query_data,
+    hostname_plan_domains_without_country_wildcard,
+    plan_factory,
+):
+    """Old-style exact domain — no redirect even if plan has a different country."""
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+        **hostname_plan_domains_without_country_wildcard,
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    domain = plans[0]['domain']
+    assert domain['redirectToHostname'] is None
+
+
+def test_default_hostname_with_wildcard_pattern(settings, plan_factory):
+    """default_hostname() generates identifier.watch.fi.dummy.io for plan with country='FI' and pattern watch.*.dummy.io."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    plan = plan_factory(country='FI')
+    assert plan.default_hostname() == f'{plan.identifier}.watch.fi.dummy.io'
+
+
+def test_default_hostname_with_exact_domain(settings, plan_factory):
+    """default_hostname() with exact domain still works as before."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['dummy.io']
+    plan = plan_factory()
+    assert plan.default_hostname() == f'{plan.identifier}.dummy.io'
+
+
+def test_default_hostname_pattern_no_country_raises(settings, plan_factory):
+    """default_hostname() raises if plan has no country and domain is a pattern."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    plan = plan_factory(country='')
+    with pytest.raises(Exception, match='no country set'):
+        plan.default_hostname()
+
+
+# --- Tests for legacy hostname redirect (<plan>.domain → <plan>.<country>.domain) ---
+
+
+def test_legacy_hostname_resolves_and_redirects(graphql_client_query_data, settings, plan_factory):
+    """Legacy <plan>.dummy.io with pattern *.dummy.io resolves the plan and redirects to <plan>.<country>.dummy.io."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    assert plans[0]['identifier'] == plan.identifier
+    assert plans[0]['domain']['redirectToHostname'] == f'{plan.identifier}.fi.dummy.io'
+
+
+def test_canonical_hostname_no_redirect_simple_wildcard(graphql_client_query_data, settings, plan_factory):
+    """Canonical <plan>.<country>.dummy.io with pattern *.dummy.io has no redirect."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.fi.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    domain = plans[0]['domain']
+    assert domain['redirectToHostname'] is None
+
+
+def test_wrong_region_redirect_simple_wildcard(graphql_client_query_data, settings, plan_factory):
+    """<plan>.<wrong_country>.dummy.io with pattern *.dummy.io redirects to correct country."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.de.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    domain = plans[0]['domain']
+    assert domain['redirectToHostname'] == f'{plan.identifier}.fi.dummy.io'
+
+
+def test_legacy_hostname_no_redirect_without_country(graphql_client_query_data, settings, plan_factory):
+    """Legacy <plan>.dummy.io with no country set on plan does not redirect."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    plan = plan_factory(country='')
+    hostname = f'{plan.identifier}.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    domain = plans[0]['domain']
+    assert domain['redirectToHostname'] is None
+
+
+def test_legacy_hostname_resolves_and_redirects_for_mid_wildcard(graphql_client_query_data, settings, plan_factory):
+    """Legacy <plan>.watch.dummy.io with pattern watch.*.dummy.io resolves the plan and redirects to <plan>.watch.fi.dummy.io."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    plan = plan_factory(country='FI')
+    hostname = f'{plan.identifier}.watch.dummy.io'
+    data = graphql_client_query_data(
+        GET_PLAN_DOMAIN_QUERY,
+        variables={'hostname': hostname},
+    )
+    plans = data['plansForHostname']
+    assert len(plans) == 1
+    assert plans[0]['identifier'] == plan.identifier
+    assert plans[0]['domain']['redirectToHostname'] == f'{plan.identifier}.watch.fi.dummy.io'

--- a/actions/tests/test_graphql_plans_for_hostname.py
+++ b/actions/tests/test_graphql_plans_for_hostname.py
@@ -146,9 +146,9 @@ def hostname_plan_domains_with_country_wildcard(request, settings):
     retval = {}
     settings.HOSTNAME_PLAN_DOMAINS = []
     if request.param in ('settings', 'both'):
-        settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+        settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     if request.param in ('header', 'both'):
-        retval.update({'headers': {'x-wildcard-domains': 'watch.*.dummy.io'}})
+        retval.update({'headers': {'x-wildcard-domains': 'watch.<country>.dummy.io'}})
     return retval
 
 
@@ -194,7 +194,7 @@ def test_plans_for_hostname_without_domains(
 
 
 def test_wildcard_pattern_resolves_plan(graphql_client_query_data, hostname_plan_domains_with_country_wildcard, plan_factory):
-    """Plan resolved via identifier.watch.fi.dummy.io when wildcard domain watch.*.dummy.io is configured."""
+    """Plan resolved via identifier.watch.fi.dummy.io when wildcard domain watch.<country>.dummy.io is configured."""
     plan = plan_factory(country='FI')
     hostname = f'{plan.identifier}.watch.fi.dummy.io'
     data = graphql_client_query_data(
@@ -307,8 +307,8 @@ def test_non_pattern_domain_no_redirect(
 
 
 def test_default_hostname_with_wildcard_pattern(settings, plan_factory):
-    """default_hostname() generates identifier.watch.fi.dummy.io for plan with country='FI' and pattern watch.*.dummy.io."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    """default_hostname() generates identifier.watch.fi.dummy.io when country='FI' and pattern watch.<country>.dummy.io."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     plan = plan_factory(country='FI')
     assert plan.default_hostname() == f'{plan.identifier}.watch.fi.dummy.io'
 
@@ -322,7 +322,7 @@ def test_default_hostname_with_exact_domain(settings, plan_factory):
 
 def test_default_hostname_pattern_no_country_raises(settings, plan_factory):
     """default_hostname() raises if plan has no country and domain is a pattern."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     plan = plan_factory(country='')
     with pytest.raises(Exception, match='no country set'):
         plan.default_hostname()
@@ -332,8 +332,8 @@ def test_default_hostname_pattern_no_country_raises(settings, plan_factory):
 
 
 def test_legacy_hostname_resolves_and_redirects(graphql_client_query_data, settings, plan_factory):
-    """Legacy <plan>.dummy.io with pattern *.dummy.io resolves the plan and redirects to <plan>.<country>.dummy.io."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    """Legacy <plan>.dummy.io with pattern <country>.dummy.io resolves the plan and redirects to <plan>.<country>.dummy.io."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
     plan = plan_factory(country='FI')
     hostname = f'{plan.identifier}.dummy.io'
     data = graphql_client_query_data(
@@ -347,8 +347,8 @@ def test_legacy_hostname_resolves_and_redirects(graphql_client_query_data, setti
 
 
 def test_canonical_hostname_no_redirect_simple_wildcard(graphql_client_query_data, settings, plan_factory):
-    """Canonical <plan>.<country>.dummy.io with pattern *.dummy.io has no redirect."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    """Canonical <plan>.<country>.dummy.io with pattern <country>.dummy.io has no redirect."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
     plan = plan_factory(country='FI')
     hostname = f'{plan.identifier}.fi.dummy.io'
     data = graphql_client_query_data(
@@ -362,8 +362,8 @@ def test_canonical_hostname_no_redirect_simple_wildcard(graphql_client_query_dat
 
 
 def test_wrong_region_redirect_simple_wildcard(graphql_client_query_data, settings, plan_factory):
-    """<plan>.<wrong_country>.dummy.io with pattern *.dummy.io redirects to correct country."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    """<plan>.<wrong_country>.dummy.io with pattern <country>.dummy.io redirects to correct country."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
     plan = plan_factory(country='FI')
     hostname = f'{plan.identifier}.de.dummy.io'
     data = graphql_client_query_data(
@@ -378,7 +378,7 @@ def test_wrong_region_redirect_simple_wildcard(graphql_client_query_data, settin
 
 def test_legacy_hostname_no_redirect_without_country(graphql_client_query_data, settings, plan_factory):
     """Legacy <plan>.dummy.io with no country set on plan does not redirect."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['*.dummy.io']
+    settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
     plan = plan_factory(country='')
     hostname = f'{plan.identifier}.dummy.io'
     data = graphql_client_query_data(
@@ -392,8 +392,8 @@ def test_legacy_hostname_no_redirect_without_country(graphql_client_query_data, 
 
 
 def test_legacy_hostname_resolves_and_redirects_for_mid_wildcard(graphql_client_query_data, settings, plan_factory):
-    """Legacy <plan>.watch.dummy.io with pattern watch.*.dummy.io resolves the plan and redirects to <plan>.watch.fi.dummy.io."""
-    settings.HOSTNAME_PLAN_DOMAINS = ['watch.*.dummy.io']
+    """Legacy <plan>.watch.dummy.io with pattern watch.<country>.dummy.io resolves plan, redirects to <plan>.watch.fi.dummy.io."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     plan = plan_factory(country='FI')
     hostname = f'{plan.identifier}.watch.dummy.io'
     data = graphql_client_query_data(

--- a/aplans/tests/test_hostname_pattern.py
+++ b/aplans/tests/test_hostname_pattern.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from aplans.utils import _matches_hostname_pattern, get_hostname_redirect_hostname
+
+
+class TestMatchesHostnamePatternLegacyShortened:
+    """
+    Tests for the behavior where hostname has one fewer part than pattern.
+
+    This handles the legacy case: <plan>.domain matching pattern *.domain,
+    allowing redirect to <plan>.<country>.domain.
+    Requires allow_shortened=True to activate.
+
+    """
+
+    def test_shortened_hostname_matches_simple_wildcard(self):
+        """dummy.io matches *.dummy.io with no captured region."""
+        is_match, region = _matches_hostname_pattern('dummy.io', '*.dummy.io', allow_shortened=True)
+        assert is_match is True
+        assert region is None
+
+    def test_shortened_hostname_matches_mid_wildcard(self):
+        """watch.dummy.io matches watch.*.dummy.io when allow_shortened=True."""
+        is_match, region = _matches_hostname_pattern('watch.dummy.io', 'watch.*.dummy.io', allow_shortened=True)
+        assert is_match is True
+        assert region is None
+
+    def test_shortened_hostname_does_not_match_mid_wildcard_without_flag(self):
+        """watch.dummy.io does NOT match watch.*.dummy.io without allow_shortened."""
+        is_match, _region = _matches_hostname_pattern('watch.dummy.io', 'watch.*.dummy.io')
+        assert is_match is False
+
+    def test_shortened_hostname_non_matching_domain(self):
+        """evil.io does not match *.dummy.io even though lengths align."""
+        is_match, _region = _matches_hostname_pattern('evil.io', '*.dummy.io', allow_shortened=True)
+        assert is_match is False
+
+    def test_shortened_hostname_single_part(self):
+        """Single-part hostname 'io' does not match *.dummy.io."""
+        is_match, _region = _matches_hostname_pattern('io', '*.dummy.io', allow_shortened=True)
+        assert is_match is False
+
+    def test_shortened_hostname_too_short(self):
+        """Hostname with two fewer parts than pattern does not match."""
+        is_match, _region = _matches_hostname_pattern('io', '*.example.dummy.io', allow_shortened=True)
+        assert is_match is False
+
+    def test_shortened_hostname_three_part_pattern(self):
+        """example.com matches *.example.com."""
+        is_match, region = _matches_hostname_pattern('example.com', '*.example.com', allow_shortened=True)
+        assert is_match is True
+        assert region is None
+
+    def test_normal_match_still_captures_region(self):
+        """fi.dummy.io matches *.dummy.io with captured region 'fi' (existing behavior)."""
+        is_match, region = _matches_hostname_pattern('fi.dummy.io', '*.dummy.io')
+        assert is_match is True
+        assert region == 'fi'
+
+    def test_shortened_not_enabled_by_default(self):
+        """Without allow_shortened, dummy.io does NOT match *.dummy.io."""
+        is_match, _region = _matches_hostname_pattern('dummy.io', '*.dummy.io')
+        assert is_match is False
+
+
+class TestRedirectHostnameSideEffect:
+    """
+    Test that the shortened-hostname matching doesn't cause unintended redirects.
+
+    get_hostname_redirect_hostname uses _matches_hostname_pattern without
+    allow_shortened, so bare domains without the wildcard part should NOT match.
+    """
+
+    def test_bare_domain_does_not_match_wildcard_redirect_pattern(self):
+        """watch.example.com does NOT match *.watch.example.com for redirects."""
+        result = get_hostname_redirect_hostname(
+            hostname='watch.example.com',
+            redirect_hostnames=[('*.watch.example.com', 'watch.example.dev')],
+            allowed_non_wildcard_hosts=set(),
+            preserve_subdomain=True,
+        )
+        assert result is None
+
+    def test_subdomain_redirect_still_works(self):
+        """Normal subdomain.watch.example.com still redirects correctly."""
+        result = get_hostname_redirect_hostname(
+            hostname='test.watch.example.com',
+            redirect_hostnames=[('*.watch.example.com', 'watch.example.dev')],
+            allowed_non_wildcard_hosts=set(),
+            preserve_subdomain=True,
+        )
+        assert result == 'test.watch.example.dev'

--- a/aplans/tests/test_hostname_pattern.py
+++ b/aplans/tests/test_hostname_pattern.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aplans.utils import _matches_hostname_pattern, get_hostname_redirect_hostname
+from aplans.utils import matches_hostname_pattern, get_hostname_redirect_hostname
 
 
 class TestMatchesHostnamePatternLegacyShortened:
@@ -15,51 +15,51 @@ class TestMatchesHostnamePatternLegacyShortened:
 
     def test_shortened_hostname_matches_simple_wildcard(self):
         """dummy.io matches *.dummy.io with no captured region."""
-        is_match, region = _matches_hostname_pattern('dummy.io', '*.dummy.io', allow_shortened=True)
+        is_match, region = matches_hostname_pattern('dummy.io', '*.dummy.io', allow_shortened=True)
         assert is_match is True
         assert region is None
 
     def test_shortened_hostname_matches_mid_wildcard(self):
         """watch.dummy.io matches watch.*.dummy.io when allow_shortened=True."""
-        is_match, region = _matches_hostname_pattern('watch.dummy.io', 'watch.*.dummy.io', allow_shortened=True)
+        is_match, region = matches_hostname_pattern('watch.dummy.io', 'watch.*.dummy.io', allow_shortened=True)
         assert is_match is True
         assert region is None
 
     def test_shortened_hostname_does_not_match_mid_wildcard_without_flag(self):
         """watch.dummy.io does NOT match watch.*.dummy.io without allow_shortened."""
-        is_match, _region = _matches_hostname_pattern('watch.dummy.io', 'watch.*.dummy.io')
+        is_match, _region = matches_hostname_pattern('watch.dummy.io', 'watch.*.dummy.io')
         assert is_match is False
 
     def test_shortened_hostname_non_matching_domain(self):
         """evil.io does not match *.dummy.io even though lengths align."""
-        is_match, _region = _matches_hostname_pattern('evil.io', '*.dummy.io', allow_shortened=True)
+        is_match, _region = matches_hostname_pattern('evil.io', '*.dummy.io', allow_shortened=True)
         assert is_match is False
 
     def test_shortened_hostname_single_part(self):
         """Single-part hostname 'io' does not match *.dummy.io."""
-        is_match, _region = _matches_hostname_pattern('io', '*.dummy.io', allow_shortened=True)
+        is_match, _region = matches_hostname_pattern('io', '*.dummy.io', allow_shortened=True)
         assert is_match is False
 
     def test_shortened_hostname_too_short(self):
         """Hostname with two fewer parts than pattern does not match."""
-        is_match, _region = _matches_hostname_pattern('io', '*.example.dummy.io', allow_shortened=True)
+        is_match, _region = matches_hostname_pattern('io', '*.example.dummy.io', allow_shortened=True)
         assert is_match is False
 
     def test_shortened_hostname_three_part_pattern(self):
         """example.com matches *.example.com."""
-        is_match, region = _matches_hostname_pattern('example.com', '*.example.com', allow_shortened=True)
+        is_match, region = matches_hostname_pattern('example.com', '*.example.com', allow_shortened=True)
         assert is_match is True
         assert region is None
 
     def test_normal_match_still_captures_region(self):
         """fi.dummy.io matches *.dummy.io with captured region 'fi' (existing behavior)."""
-        is_match, region = _matches_hostname_pattern('fi.dummy.io', '*.dummy.io')
+        is_match, region = matches_hostname_pattern('fi.dummy.io', '*.dummy.io')
         assert is_match is True
         assert region == 'fi'
 
     def test_shortened_not_enabled_by_default(self):
         """Without allow_shortened, dummy.io does NOT match *.dummy.io."""
-        is_match, _region = _matches_hostname_pattern('dummy.io', '*.dummy.io')
+        is_match, _region = matches_hostname_pattern('dummy.io', '*.dummy.io')
         assert is_match is False
 
 

--- a/aplans/tests/test_hostname_pattern.py
+++ b/aplans/tests/test_hostname_pattern.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aplans.utils import matches_hostname_pattern, get_hostname_redirect_hostname
+from aplans.utils import get_hostname_redirect_hostname, matches_hostname_pattern
 
 
 class TestMatchesHostnamePatternLegacyShortened:

--- a/aplans/tests/test_middleware.py
+++ b/aplans/tests/test_middleware.py
@@ -20,7 +20,7 @@ def request_factory():
     return RequestFactory()
 
 
-@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))
+@override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'admin.watch.example.com'),))
 def test_wildcard_hostname_redirect(request_factory):
     """Test wildcard pattern matching and redirect."""
     middleware = HostnameRedirectMiddleware(get_response_success)
@@ -29,7 +29,7 @@ def test_wildcard_hostname_redirect(request_factory):
     response = middleware(request)
 
     assert response.status_code == 301
-    assert response['Location'] == 'http://watch.example.com/'
+    assert response['Location'] == 'http://admin.watch.example.com/'
 
 
 @override_settings(REDIRECT_HOSTNAMES=(('*.watch.example.com', 'watch.example.com'),))

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -783,12 +783,18 @@ def matches_hostname_pattern(
 ) -> tuple[bool, str | None]:
     """
     Check if hostname matches pattern with strict wildcard rules.
+    This is called with the plan identifier stripped from the
+    beginning of the hostname.
 
     Wildcards (*) match only valid subdomain parts (no periods).
-    Example: '*.example.com' matches 'test.example.com' but not 'foo.bar.example.com'.
+
+    Wildcards are intended to be placeholders for country codes of
+    plans, not the plan identifiers which are simply prepended
+    to the hostname pattern to get the final hostname.
+    Example: '*.example.com' matches 'fi.example.com' but not 'foo.bar.example.com'.
 
     Args:
-        hostname: The hostname to check (e.g., 'test.example.com')
+        hostname: The hostname to check (e.g., 'de.example.com')
         pattern: The pattern with optional wildcards (e.g., '*.example.com')
         allow_shortened: If True, also match hostnames that have one fewer part
             than the pattern, where the wildcard part is missing.  This is used

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -776,10 +776,7 @@ class StaticBlockToStructBlockWorkaroundMixin(_StructBlock):
 
 
 def matches_hostname_pattern(
-    hostname: str,
-    pattern: str,
-    *,
-    allow_shortened: bool = False,
+    hostname: str, pattern: str, *, allow_shortened: bool = False, placeholder: str = '*'
 ) -> tuple[bool, str | None]:
     """
     Check if hostname matches pattern with strict wildcard rules.
@@ -787,20 +784,22 @@ def matches_hostname_pattern(
     This is called with the plan identifier stripped from the
     beginning of the hostname.
 
-    Wildcards (*) match only valid subdomain parts (no periods).
+    Wildcards ('*' or any placeholder) match only valid subdomain parts (no periods).
 
-    Wildcards are intended to be placeholders for country codes of
-    plans, not the plan identifiers which are simply prepended
+    Wildcards are intended to be placeholders, often for country codes of
+    plans, and not the plan identifiers which are simply prepended
     to the hostname pattern to get the final hostname.
-    Example: '*.example.com' matches 'fi.example.com' but not 'foo.bar.example.com'.
+    Example: '<country>.example.com' matches 'fi.example.com' but not 'foo.bar.example.com'
+             when the placeholder parameter is '<country>'
 
     Args:
         hostname: The hostname to check (e.g., 'de.example.com')
-        pattern: The pattern with optional wildcards (e.g., '*.example.com')
+        pattern: The pattern with optional wildcards (e.g., '<country>.example.com')
         allow_shortened: If True, also match hostnames that have one fewer part
             than the pattern, where the wildcard part is missing.  This is used
             in the plan-domain context to handle legacy hostnames like
             ``<plan>.domain`` that should redirect to ``<plan>.<country>.domain``.
+        placeholder: String to use as wildcard placeholder
 
     Returns:
         Tuple of:
@@ -813,7 +812,7 @@ def matches_hostname_pattern(
 
     if allow_shortened and len(hostname_parts) + 1 == len(pattern_parts):
         try:
-            wildcard_idx = pattern_parts.index('*')
+            wildcard_idx = pattern_parts.index(placeholder)
         except ValueError:
             return False, None
         remaining = pattern_parts[:wildcard_idx] + pattern_parts[wildcard_idx + 1 :]
@@ -828,7 +827,7 @@ def matches_hostname_pattern(
     match = None
 
     for hostname_part, pattern_part in zip(hostname_parts, pattern_parts, strict=True):
-        if pattern_part == '*':
+        if pattern_part == placeholder:
             # Wildcard matches any valid subdomain part
             # Valid: alphanumeric and hyphens, not starting/ending with hyphen
             if not hostname_part:

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -775,7 +775,12 @@ class StaticBlockToStructBlockWorkaroundMixin(_StructBlock):
         return super().bulk_to_python(values)
 
 
-def _matches_hostname_pattern(hostname: str, pattern: str) -> tuple[bool, str | None]:
+def _matches_hostname_pattern(
+    hostname: str,
+    pattern: str,
+    *,
+    allow_shortened: bool = False,
+) -> tuple[bool, str | None]:
     """
     Check if hostname matches pattern with strict wildcard rules.
 
@@ -785,6 +790,10 @@ def _matches_hostname_pattern(hostname: str, pattern: str) -> tuple[bool, str | 
     Args:
         hostname: The hostname to check (e.g., 'test.example.com')
         pattern: The pattern with optional wildcards (e.g., '*.example.com')
+        allow_shortened: If True, also match hostnames that have one fewer part
+            than the pattern, where the wildcard part is missing.  This is used
+            in the plan-domain context to handle legacy hostnames like
+            ``<plan>.domain`` that should redirect to ``<plan>.<country>.domain``.
 
     Returns:
         Tuple of:
@@ -794,6 +803,16 @@ def _matches_hostname_pattern(hostname: str, pattern: str) -> tuple[bool, str | 
     """
     hostname_parts = hostname.split('.')
     pattern_parts = pattern.split('.')
+
+    if allow_shortened and len(hostname_parts) + 1 == len(pattern_parts):
+        try:
+            wildcard_idx = pattern_parts.index('*')
+        except ValueError:
+            return False, None
+        remaining = pattern_parts[:wildcard_idx] + pattern_parts[wildcard_idx + 1 :]
+        if hostname_parts != remaining:
+            return False, None
+        return True, None
 
     # Must have same number of parts
     if len(hostname_parts) != len(pattern_parts):

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -775,7 +775,7 @@ class StaticBlockToStructBlockWorkaroundMixin(_StructBlock):
         return super().bulk_to_python(values)
 
 
-def _matches_hostname_pattern(
+def matches_hostname_pattern(
     hostname: str,
     pattern: str,
     *,
@@ -846,7 +846,7 @@ def get_hostname_redirect_hostname(
     for from_pattern, to_hostname in redirect_hostnames:
         if hostname == to_hostname or hostname in allowed_non_wildcard_hosts:
             continue
-        is_match, wildcard_subdomain_part = _matches_hostname_pattern(hostname, from_pattern)
+        is_match, wildcard_subdomain_part = matches_hostname_pattern(hostname, from_pattern)
         if not is_match:
             continue
 

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -783,6 +783,7 @@ def matches_hostname_pattern(
 ) -> tuple[bool, str | None]:
     """
     Check if hostname matches pattern with strict wildcard rules.
+
     This is called with the plan identifier stripped from the
     beginning of the hostname.
 


### PR DESCRIPTION
## Description
To make it as flexible as possible to choose which countries are served from which clusters, we want to always put the country code in the URL. Several countries will be served from a common cluster, but the cluster configuration might change over time.

This PR should be completely backwards compatible.

But when a plan wildcard hostname containing a `<country>` subdomain is configured -- either via Django settings or the wildcard domains custom HTTP header sent from the UI -- then the asterisk will match a country code which is derived from the country of the matching plan. The intention is for the country code to always be present in UI wildcard (non-production) URLs so that plans from different countries can flexibly be served from the same cluster or different clusters depending on the DNS and infrastructure routing configuration.

## Screenshots/Videos (if applicable)
N/A

## Related issue
https://app.asana.com/1/1201243246741462/project/1202854091946984/task/1212623057408317?focus=true

## Requirements, dependencies and related PRs
N/A

## Additional Notes
Should not result in any visible changes without changing ENV variables of either the backend or frontend.
------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Probably easiest to check with `portless`. https://portless.sh/ Or by prepending subdomains to localhost. Add a hostname such as `watch.<country>.localhost` to `settings.HOSTNAME_PLAN_DOMAINS` . Try to access various plans with hostnames containing the plans country.

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
