### PR TITLE
Fix missing identifier uniqueness validation on CategoryType creation form

### DIFF
--- a/actions/category_admin.py
+++ b/actions/category_admin.py
@@ -293,6 +293,15 @@ class CategoryTypeForm(ActionListPageBlockFormMixin, AplansAdminModelForm[Catego
         self.initial_plan_id = kwargs.pop('initial_plan_id')
         super().__init__(*args, **kwargs)
 
+    def clean_identifier(self):
+        # Since plan is not a form field, `validate_unique()` will be called with `exclude` containing `plan`, in
+        # which case the unique_together constraint (plan, identifier) will not be checked. We do it manually here.
+        identifier = self.cleaned_data['identifier']
+        plan = self.instance.plan
+        if CategoryType.objects.filter(plan=plan, identifier=identifier).exclude(pk=self.instance.pk).exists():
+            raise ValidationError(_('There is already a category type with this identifier.'))
+        return identifier
+
     def save(self, commit=True):
         obj = super().save(commit)
         initial_plan_id = self.initial_plan_id


### PR DESCRIPTION
## Description
Fix missing identifier uniqueness validation on CategoryType creation form

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211672045493438

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
