### PR TITLE
Gate indicator factors formset on initial plan's feature flag. Indicator creation e2e test

### DIFF
--- a/e2e-tests/tests/indicators.spec.ts
+++ b/e2e-tests/tests/indicators.spec.ts
@@ -2,13 +2,40 @@ import {
   expect,
   test,
 } from '@playwright/test';
+import crypto from 'node:crypto';
+
+const listIndicatorsPath = '/admin/indicators/indicator/';
 
 test.describe('Test indicators', () => {
+  test.describe.configure({ mode: 'serial' });
+
   test('Open indicator list', async ({ page }) => {
     await page.goto('/admin/');
     await page.getByRole('button', { name: 'Indicators'}).click();
     await page.getByRole('button', { name: 'Indicators', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'Indicators' })).toBeVisible();
+  });
+
+  const indicatorName = `Test indicator ${crypto.randomUUID().slice(0, 8)}`;
+
+  test('Create a new indicator', async ({ page }, testInfo) => {
+    testInfo.setTimeout(15000);
+    await page.goto(listIndicatorsPath);
+    await page.getByRole('link', { name: 'Add indicator' }).first().click();
+    await page.waitForURL((url) => url.pathname.includes('/create'));
+
+    await page.getByRole('textbox', { name: 'Name' }).fill(indicatorName);
+    // Select a unit via the Select2 autocomplete dropdown:
+    // Click the combobox to open the dropdown, then type in the search input that appears.
+    const unitField = page.locator('[data-contentpath="unit"]');
+    await unitField.getByRole('combobox').last().click();
+    await page.locator('.select2-search__field').fill('t');
+    await page.locator('.select2-results__option').first().click();
+    // Save the indicator and wait for navigation away from the create page
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await page.waitForURL((url) => !url.pathname.includes('/create/'));
+    // Verify no validation errors on the resulting page
+    await expect(page.getByText('could not be created due to errors')).not.toBeVisible();
   });
 })
 

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -437,7 +437,8 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
 
         # Inject the metrics formset into self.formsets so that
         # IndicatorMetricsInlinePanel can pick it up via self.form.formsets['metrics'].
-        if self.plan.features.enable_indicator_factors:
+        effective_plan = Plan.objects.get(id=self.initial_plan_id) if self.initial_plan_id else self.plan
+        if effective_plan.features.enable_indicator_factors:
             schema = self.instance.dataset_schema if self.instance.pk else None
             indicator_unit_label = ''
             indicator_unit_short = ''
@@ -490,7 +491,8 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
                 # This may also affect CommonIndicatorForm.
                 raise ValidationError(_('Dimensions must be the same as in common indicator'))
 
-        if self.plan.features.enable_indicator_factors:
+        effective_plan = Plan.objects.get(id=self.initial_plan_id) if self.initial_plan_id else self.plan
+        if 'metrics' in self.formsets and effective_plan.features.enable_indicator_factors:
             if not self.formsets['metrics'].is_valid():
                 raise ValidationError(_('Please correct the errors in the factors section.'))
             self._validate_no_data_in_deleted_factors()


### PR DESCRIPTION
## Description
-Acknowledge review by codex in PR https://github.com/kausaltech/kausal-watch/pull/560,
Gating indicator factors formset on initial plan's feature flag.

-Added a simple e2e for indicator creation (aftermath of #560 , this test would have caught the original bug)

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
