### PR TITLE
Fix rich text editor format buttons rendered double

### DIFF
--- a/actions/apps.py
+++ b/actions/apps.py
@@ -60,3 +60,13 @@ class ActionsConfig(AppConfig):
         from actions.attribute_type_admin import check_attribute_value_models
 
         check_attribute_value_models()
+
+        # Import pledge_admin late (after hook scanning and feature scanning
+        # have completed) and register its snippet.  Importing it during
+        # wagtail_hooks discovery would trigger re-entrant feature scanning
+        # because PledgeAdminForm's metaclass processes RichTextFields eagerly.
+        from wagtail.snippets.models import register_snippet
+
+        from actions.pledge_admin import PledgeViewSet
+
+        register_snippet(PledgeViewSet)

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -16,7 +16,6 @@ from wagtail.admin.panels import (
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.views.mixins import Echo
 from wagtail.images.widgets import AdminImageChooser
-from wagtail.snippets.models import register_snippet
 
 from dal import autocomplete
 
@@ -81,7 +80,7 @@ class PledgeAdminForm(WatchAdminModelForm[Pledge]):
             'actions': autocomplete.ModelSelect2Multiple(url='action-autocomplete'),
         }
 
-    def clean_slug(self):
+    def clean_slug(self) -> str:
         # Since the plan field is excluded from the form, `validate_unique()` won't check
         # the unique_together = [('plan', 'slug')] constraint. We validate it manually here.
         slug = self.cleaned_data['slug']
@@ -90,7 +89,7 @@ class PledgeAdminForm(WatchAdminModelForm[Pledge]):
             raise ValidationError(_('There is already a pledge with this slug.'))
         return slug
 
-    def save(self, commit=True):
+    def save(self, commit=True) -> Pledge:
         obj = super().save(commit)
         # Get user from the dynamically set _user attribute
         user = getattr(self, '_user', None)
@@ -344,4 +343,5 @@ class PledgeViewSet(WatchViewSet[Pledge]):
         return qs.filter(plan=plan).annotate(commitment_count=Count('commitments'))
 
 
-register_snippet(PledgeViewSet)
+# register_snippet(PledgeViewSet) is called in ActionsConfig.ready() instead
+# of here.  See the comment in actions/wagtail_admin.py for details.

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -56,6 +56,7 @@ from aplans.context_vars import ctx_instance, ctx_request
 from actions.chooser import CategoryTypeChooser, PlanChooser
 from actions.models.action import ActionSchedule
 from admin_site.chooser import ClientChooser
+from admin_site.forms import WatchAdminModelForm
 from admin_site.menu import PlanSpecificSingletonModelMenuItem
 from admin_site.mixins import SuccessUrlEditPageMixin
 from admin_site.models import Client, ClientPlan
@@ -63,7 +64,6 @@ from admin_site.permissions import (
     PlanSpecificSingletonModelPermissionPolicy,
     PlanSpecificSingletonModelSuperuserPermissionPolicy,
 )
-from admin_site.forms import WatchAdminModelForm
 from admin_site.viewsets import (
     BaseChangeLogMessageCreateView,
     BaseChangeLogMessageDeleteView,
@@ -93,8 +93,13 @@ from . import (
     action_admin,  # noqa: F401
     attribute_type_admin,  # noqa: F401
     category_admin,  # noqa: F401
-    pledge_admin,  # noqa: F401
 )
+
+# pledge_admin is intentionally NOT imported here.  It is imported in
+# ActionsConfig.ready() instead, because its module-level PledgeAdminForm
+# class triggers Wagtail feature scanning at import time (via RichTextField
+# formfield), and importing it during hook discovery causes a re-entrant
+# scan that doubles every default rich-text feature.
 from .models import (
     Action,
     ActionChangeLogMessage,

--- a/admin_site/tests/test_apps.py
+++ b/admin_site/tests/test_apps.py
@@ -13,3 +13,20 @@ def test_rich_text_default_features_include_superscript():
     default = features.get_default_features()  # type: ignore[attr-defined]
     assert 'superscript' in default
     assert 'subscript' in default
+
+
+def test_rich_text_default_features_not_duplicated():
+    """
+    Ensure no feature is registered more than once.
+
+    Module-level ModelForm classes whose model has RichTextFields can trigger
+    re-entrant feature scanning during Wagtail hook discovery, doubling every
+    default feature.  This test catches that regression.
+    """
+    from collections import Counter
+
+    from wagtail.rich_text import features
+
+    default = features.get_default_features()  # type: ignore[attr-defined]
+    duplicates = {f: n for f, n in Counter(default).items() if n > 1}
+    assert not duplicates, f'Duplicate default rich-text features: {duplicates}'


### PR DESCRIPTION
## Description
Move pledge_admin import from wagtail_hooks discovery to ActionsConfig.ready() to prevent re-entrant feature scanning.

When pledge_admin was imported during hook scanning, its module-level PledgeAdminForm class triggered Wagtail's _scan_for_features() re-entrantly (via RichTextField.formfield() -> get_default_features()), causing every default rich-text feature to be registered twice.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
