### PR TITLE
Redirect to Relationships tab after saving indicator with factors

### DIFF
--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -1189,6 +1189,22 @@ class IndicatorChangeLogMessageCreateView(BaseChangeLogMessageCreateView[Indicat
     related_field_name = 'indicator'
     success_url_name = 'indicators_indicator_modeladmin_index'
 
+    def _get_indicator_edit_url(self) -> str | None:
+        """Redirect to the indicator edit page with the Relationships tab active, or None."""
+        active_tab = self.request.session.get('_active_tab', '')
+        if active_tab != 'tab-relationships':
+            return None
+        related_id = self.get_related_id()
+        if not related_id:
+            return None
+        return reverse('indicators_indicator_modeladmin_edit', args=[related_id]) + f'#{active_tab}'
+
+    def get_success_url(self):
+        return self._get_indicator_edit_url() or super().get_success_url()
+
+    def get_skip_url(self) -> str:
+        return self._get_indicator_edit_url() or super().get_skip_url()
+
     def get_related_object_by_pk(self, pk: str) -> Indicator | None:
         try:
             return Indicator.objects.get(pk=pk)

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -1190,14 +1190,14 @@ class IndicatorChangeLogMessageCreateView(BaseChangeLogMessageCreateView[Indicat
     success_url_name = 'indicators_indicator_modeladmin_index'
 
     def _get_indicator_edit_url(self) -> str | None:
-        """Redirect to the indicator edit page with the Relationships tab active, or None."""
+        """Redirect to the indicator edit page's factors panel, or None."""
         active_tab = self.request.session.get('_active_tab', '')
-        if active_tab != 'tab-relationships':
+        if active_tab not in ('tab-relationships', 'panel-child-relationships-factors-section'):
             return None
         related_id = self.get_related_id()
         if not related_id:
             return None
-        return reverse('indicators_indicator_modeladmin_edit', args=[related_id]) + f'#{active_tab}'
+        return reverse('indicators_indicator_modeladmin_edit', args=[related_id]) + '#panel-child-relationships-factors-section'
 
     def get_success_url(self):
         return self._get_indicator_edit_url() or super().get_success_url()

--- a/admin_site/wagtail_hooks.py
+++ b/admin_site/wagtail_hooks.py
@@ -352,6 +352,26 @@ def hack_wagtail_rich_text_fields():
         """)
 
 
+@hooks.register('insert_editor_js')
+def preserve_active_tab_on_save():
+    """Copy the active tab hash into a hidden field so the backend can redirect back to it."""
+    return mark_safe("""
+        <script>
+        $(function () {
+            $('form').each(function () {
+                var form = $(this);
+                if (!form.find('input[name="_active_tab"]').length) {
+                    form.append('<input type="hidden" name="_active_tab" value="">');
+                }
+                form.on('submit', function () {
+                    form.find('input[name="_active_tab"]').val(window.location.hash);
+                });
+            });
+        });
+        </script>
+        """)
+
+
 # Imported at the end because wagtail.snippets triggers re-entrant hook
 # discovery, and all hooks above must be registered before that happens.
 import admin_site.wagtail_admin  # noqa: E402, F401

--- a/e2e-tests/tests/indicators.spec.ts
+++ b/e2e-tests/tests/indicators.spec.ts
@@ -1,13 +1,45 @@
 import {
   expect,
   test,
+  type Page,
 } from '@playwright/test';
 import crypto from 'node:crypto';
 
 const listIndicatorsPath = '/admin/indicators/indicator/';
 
+async function setIndicatorFactorsFlag(page: Page, enabled: boolean) {
+  await page.goto('/admin/');
+  await page.getByRole('button', { name: 'Settings', exact: true }).click();
+  await page.getByRole('link', { name: 'Plan features', exact: true }).click();
+  const checkbox = page.getByLabel('Enable indicator factors');
+  if (enabled !== await checkbox.isChecked()) {
+    enabled ? await checkbox.check() : await checkbox.uncheck();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+  }
+}
+
+async function createIndicator(page: Page, name: string): Promise<string> {
+  await page.goto(listIndicatorsPath);
+  await page.getByRole('link', { name: 'Add indicator' }).first().click();
+  await page.waitForURL((url) => url.pathname.includes('/create'));
+  await page.getByRole('textbox', { name: 'Name' }).fill(name);
+  const unitField = page.locator('[data-contentpath="unit"]');
+  await unitField.getByRole('combobox').last().click();
+  await page.locator('.select2-search__field').fill('t');
+  await page.locator('.select2-results__option').first().click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.waitForURL((url) => !url.pathname.includes('/create/'));
+  // Verify no validation errors on the resulting page
+  await expect(page.getByText('could not be created due to errors')).not.toBeVisible();
+
+  // After create, Wagtail shows a success notification with an 'Edit' link to the new instance
+  await page.getByRole('alert').getByRole('link', { name: 'Edit' }).click();
+  await page.waitForURL(/\/edit\//);
+  return page.url().split('#')[0];
+}
+
 test.describe('Test indicators', () => {
-  test.describe.configure({ mode: 'serial' });
+  test.describe.configure({ mode: 'serial', timeout: 15000 });
 
   test('Open indicator list', async ({ page }) => {
     await page.goto('/admin/');
@@ -18,24 +50,8 @@ test.describe('Test indicators', () => {
 
   const indicatorName = `Test indicator ${crypto.randomUUID().slice(0, 8)}`;
 
-  test('Create a new indicator', async ({ page }, testInfo) => {
-    testInfo.setTimeout(15000);
-    await page.goto(listIndicatorsPath);
-    await page.getByRole('link', { name: 'Add indicator' }).first().click();
-    await page.waitForURL((url) => url.pathname.includes('/create'));
-
-    await page.getByRole('textbox', { name: 'Name' }).fill(indicatorName);
-    // Select a unit via the Select2 autocomplete dropdown:
-    // Click the combobox to open the dropdown, then type in the search input that appears.
-    const unitField = page.locator('[data-contentpath="unit"]');
-    await unitField.getByRole('combobox').last().click();
-    await page.locator('.select2-search__field').fill('t');
-    await page.locator('.select2-results__option').first().click();
-    // Save the indicator and wait for navigation away from the create page
-    await page.getByRole('button', { name: 'Save', exact: true }).click();
-    await page.waitForURL((url) => !url.pathname.includes('/create/'));
-    // Verify no validation errors on the resulting page
-    await expect(page.getByText('could not be created due to errors')).not.toBeVisible();
+  test('Create a new indicator', async ({ page }) => {
+    await createIndicator(page, indicatorName);
   });
 })
 
@@ -74,3 +90,46 @@ test.describe('Test quantities', () => {
     await expect(page.getByRole('heading', { name: 'Quantities' })).toBeVisible();
   });
 })
+
+const factorRedirectIndicatorName = `E2E factor redirect ${crypto.randomUUID().slice(0, 8)}`;
+let factorRedirectEditUrl = '';
+
+test.describe('Indicator factor redirect', () => {
+  test.describe.configure({ mode: 'serial', timeout: 30000 });
+
+  test('Saving with a new factor redirects to the factors panel', async ({ page }) => {
+    await setIndicatorFactorsFlag(page, true);
+    factorRedirectEditUrl = await createIndicator(page, factorRedirectIndicatorName);
+
+    await page.getByRole('tab', { name: 'Relationships' }).click();
+    await page.getByRole('button', { name: 'Add factor' }).click();
+    const factorsSection = page.getByRole('region', { name: 'Factors' });
+    await factorsSection.getByLabel('Name').last().fill('Test factor');
+    await factorsSection.getByLabel('Result').last().fill('Test result');
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await expect(page).toHaveURL(factorRedirectEditUrl + '#panel-child-relationships-factors-section');
+  });
+
+  test('Saving without new factors does not redirect to the factors panel', async ({ page }) => {
+    await page.goto(factorRedirectEditUrl);
+    await page.waitForURL(/\/edit\//);
+
+    await page.getByRole('tab', { name: 'Relationships' }).click();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await expect(page).toHaveURL(listIndicatorsPath);
+  });
+
+  test('Flag disabled: saving on Relationships tab does not redirect to the factors panel', async ({ page }) => {
+    await setIndicatorFactorsFlag(page, false);
+
+    await page.goto(factorRedirectEditUrl);
+    await page.waitForURL(/\/edit\//);
+
+    await page.getByRole('tab', { name: 'Relationships' }).click();
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    await expect(page).toHaveURL(listIndicatorsPath);
+  });
+});

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -770,11 +770,26 @@ class IndicatorCreateView(
 class IndicatorEditView(
     InitializeFormWithPlanMixin[Indicator], InitializeFormWithInitialPlanMixin[Indicator], AplansEditView[Indicator]
 ):
+    def _get_active_tab(self) -> str:
+        """Get the active tab hash from the form submission (e.g. 'tab-relationships')."""
+        raw = self.request.POST.get('_active_tab', '')
+        return raw.lstrip('#')
+
     def get_success_url(self):
+        active_tab = self._get_active_tab()
+        if active_tab:
+            self.request.session['_active_tab'] = active_tab
+        else:
+            self.request.session.pop('_active_tab', None)
         plan = user_or_bust(self.request.user).get_active_admin_plan()
         if plan.features.enable_change_log:
             change_log_create_url = reverse('wagtailsnippets_actions_indicatorchangelogmessage:add')
             return f'{change_log_create_url}?indicator={self.instance.pk}'
+        # When saving from the Relationships tab, redirect back to the edit page
+        # so the user can immediately access the factor data editor link that
+        # becomes available after saving new factors.
+        if active_tab == 'tab-relationships':
+            return self.url_helper.get_action_url('edit', self.instance.pk) + f'#{active_tab}'
         return super().get_success_url()
 
 
@@ -1088,6 +1103,10 @@ class IndicatorAdmin(AplansModelAdmin[Indicator]):
                 dataset_link_panel = self._get_dataset_editor_link_panel(instance)
                 if dataset_link_panel is not None:
                     factors_panels.append(dataset_link_panel)
+                else:
+                    factors_panels.append(
+                        HelpPanel(content=_('Save the indicator after adding a factor to enable the data editor.'))
+                    )
             panels.append(MultiFieldPanel(factors_panels, heading=_('Factors')))
 
         return ObjectList(panels, heading=_('Relationships'))

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -604,12 +604,6 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
             self._delete_result_metrics_for_removed_factors(obj.dataset_schema, metrics_formset)
 
         has_new = self._has_new_factors(metrics_formset)
-        # Track whether the user added new factor forms (beyond the pre-existing ones).
-        initial_count = metrics_formset.initial_form_count()
-        self._new_factors_were_added = any(
-            form.cleaned_data and not form.cleaned_data.get('DELETE') for form in metrics_formset.forms[initial_count:]
-        )
-
         if has_new:
             schema = self._ensure_dataset_schema(obj)
             metrics_formset.instance = schema
@@ -618,6 +612,9 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
             # Save deletions/edits even when no new factors
             metrics_formset.instance = obj.dataset_schema
             metrics_formset.save()
+
+        if len(getattr(metrics_formset, 'new_objects', [])):
+            self._new_factors_were_added = True
 
         # Auto-create/update computations for each factor
         if obj.dataset_schema is not None:
@@ -628,6 +625,10 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
             self._cleanup_empty_schema(obj)
 
         return obj
+
+    @property
+    def new_factors_were_added(self) -> bool:
+        return getattr(self, '_new_factors_were_added', False)
 
     @staticmethod
     def _delete_result_metrics_for_removed_factors(schema: DatasetSchema, metrics_formset) -> None:
@@ -777,7 +778,9 @@ class IndicatorCreateView(
 class IndicatorEditView(
     InitializeFormWithPlanMixin[Indicator], InitializeFormWithInitialPlanMixin[Indicator], AplansEditView[Indicator]
 ):
-    def form_valid(self, form, *args, **kwargs):
+    _form: IndicatorForm
+
+    def form_valid(self, form: IndicatorForm, *args, **kwargs):
         self._form = form
         return super().form_valid(form, *args, **kwargs)
 
@@ -788,9 +791,8 @@ class IndicatorEditView(
 
     def get_success_url(self):
         active_tab = self._get_active_tab()
-        new_factors = getattr(self._form, '_new_factors_were_added', False)
         on_relationships_tab = active_tab in ('tab-relationships', 'panel-child-relationships-factors-section')
-        redirect_to_factors = on_relationships_tab and new_factors
+        redirect_to_factors = on_relationships_tab and self._form.new_factors_were_added
         # Only persist the active tab in the session when we want the
         # changelog flow to redirect back to the factors panel too.
         if redirect_to_factors:

--- a/indicators/wagtail_admin.py
+++ b/indicators/wagtail_admin.py
@@ -603,7 +603,14 @@ class IndicatorForm(AplansAdminModelForm[Indicator]):
         if obj.dataset_schema is not None:
             self._delete_result_metrics_for_removed_factors(obj.dataset_schema, metrics_formset)
 
-        if self._has_new_factors(metrics_formset):
+        has_new = self._has_new_factors(metrics_formset)
+        # Track whether the user added new factor forms (beyond the pre-existing ones).
+        initial_count = metrics_formset.initial_form_count()
+        self._new_factors_were_added = any(
+            form.cleaned_data and not form.cleaned_data.get('DELETE') for form in metrics_formset.forms[initial_count:]
+        )
+
+        if has_new:
             schema = self._ensure_dataset_schema(obj)
             metrics_formset.instance = schema
             metrics_formset.save()
@@ -770,6 +777,10 @@ class IndicatorCreateView(
 class IndicatorEditView(
     InitializeFormWithPlanMixin[Indicator], InitializeFormWithInitialPlanMixin[Indicator], AplansEditView[Indicator]
 ):
+    def form_valid(self, form, *args, **kwargs):
+        self._form = form
+        return super().form_valid(form, *args, **kwargs)
+
     def _get_active_tab(self) -> str:
         """Get the active tab hash from the form submission (e.g. 'tab-relationships')."""
         raw = self.request.POST.get('_active_tab', '')
@@ -777,7 +788,12 @@ class IndicatorEditView(
 
     def get_success_url(self):
         active_tab = self._get_active_tab()
-        if active_tab:
+        new_factors = getattr(self._form, '_new_factors_were_added', False)
+        on_relationships_tab = active_tab in ('tab-relationships', 'panel-child-relationships-factors-section')
+        redirect_to_factors = on_relationships_tab and new_factors
+        # Only persist the active tab in the session when we want the
+        # changelog flow to redirect back to the factors panel too.
+        if redirect_to_factors:
             self.request.session['_active_tab'] = active_tab
         else:
             self.request.session.pop('_active_tab', None)
@@ -785,11 +801,9 @@ class IndicatorEditView(
         if plan.features.enable_change_log:
             change_log_create_url = reverse('wagtailsnippets_actions_indicatorchangelogmessage:add')
             return f'{change_log_create_url}?indicator={self.instance.pk}'
-        # When saving from the Relationships tab, redirect back to the edit page
-        # so the user can immediately access the factor data editor link that
-        # becomes available after saving new factors.
-        if active_tab == 'tab-relationships':
-            return self.url_helper.get_action_url('edit', self.instance.pk) + f'#{active_tab}'
+        # Redirect to the factors panel so the user can access the data editor link.
+        if redirect_to_factors:
+            return self.url_helper.get_action_url('edit', self.instance.pk) + '#panel-child-relationships-factors-section'
         return super().get_success_url()
 
 


### PR DESCRIPTION
## Description
When saving an indicator from the Relationships tab, redirect back to the edit page with the tab active instead of the index view. This lets users immediately access the factor data editor link that appears after saving new factors.

- Add JS hook to capture active tab hash into a hidden form field
- Store active tab in session so it survives the changelog form flow
- Changelog save/skip both redirect to the edit page with the tab hash
- Other tabs still redirect to the index view as before
- Show help text when the data editor is not yet available


## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214058225355801

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
