### PR TITLE
Fix StructBlock feature gate crash by also filtering formLayout

### DIFF
--- a/indicators/blocks/layout.py
+++ b/indicators/blocks/layout.py
@@ -8,7 +8,7 @@ from django.db.models.enums import TextChoices
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.admin.telepath import register as telepath_register
-from wagtail.blocks.struct_block import StructBlockAdapter, StructBlockValidationError
+from wagtail.blocks.struct_block import BlockGroup, StructBlockAdapter, StructBlockValidationError  # type: ignore[attr-defined]
 
 from grapple.helpers import register_streamfield_block
 from grapple.models import GraphQLBoolean, GraphQLField, GraphQLForeignKey, GraphQLInt
@@ -388,7 +388,17 @@ class _IndicatorVisualizationStructBlockAdapter(StructBlockAdapter):
         hidden = {f for f, flag in self.feature_gated_fields.items() if not getattr(features, flag, True)}
         if not hidden:
             return [name, children, meta]
-        return [name, tuple(c for c in children if c.name not in hidden), meta]
+        filtered_children = tuple(c for c in children if c.name not in hidden)
+        form_layout = meta.get('formLayout')
+        if form_layout is not None:
+            meta = {
+                **meta,
+                'formLayout': BlockGroup(
+                    [c for c in form_layout.children if not (isinstance(c, str) and c in hidden)],
+                    settings=[s for s in form_layout.settings if not (isinstance(s, str) and s in hidden)],
+                ),
+            }
+        return [name, filtered_children, meta]
 
 
 telepath_register(_IndicatorVisualizationStructBlockAdapter(), IndicatorVisualizationContentBlock)


### PR DESCRIPTION
The _IndicatorVisualizationStructBlockAdapter removed show_factor_values from telepath children but left a dangling reference in meta.formLayout. JS iterated formLayout, looked up the missing block def, got undefined, and crashed on undefined.meta.label.

Fixes WATCH-BACKEND-4DC

## Description
Brief description of the changes made in this PR.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
