### PR TITLE
Split pledge export into separate pledges and commitments downloads

### DIFF
--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -16,6 +16,7 @@ from wagtail.admin.panels import (
     ObjectList,
 )
 from wagtail.admin.ui.components import Component
+from wagtail.admin.ui.menus import MenuItem
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.views.mixins import Echo
 from wagtail.admin.widgets.button import Button
@@ -203,14 +204,11 @@ class PledgeEditView(PledgeViewMixin, WatchEditView[Pledge]):
     """Custom edit view for Pledge with dynamic attribute panels."""
 
 
-class _DropdownLabel(Component):
+class _DropdownLabel(MenuItem, Component):
     """Non-interactive group label rendered inside a dropdown."""
 
     def __init__(self, label: str, priority: int = 0) -> None:
-        self.label = label
-        self.priority = priority
-
-    __hash__ = None  # type: ignore[assignment]
+        super().__init__(label, '', icon_name = '', priority=priority)
 
     def render_html(self, parent_context=None) -> SafeString:
         from django.utils.html import format_html
@@ -220,33 +218,18 @@ class _DropdownLabel(Component):
             self.label,
         )
 
-    def __lt__(self, other): return (self.priority, self.label) < (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __le__(self, other): return (self.priority, self.label) <= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __gt__(self, other): return (self.priority, self.label) > (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __ge__(self, other): return (self.priority, self.label) >= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __eq__(self, other): return self.priority == getattr(other, 'priority', 0) and self.label == getattr(other, 'label', '')
 
-
-class _DropdownDivider(Component):
+class _DropdownDivider(MenuItem, Component):
     """Horizontal rule rendered inside a dropdown."""
 
     def __init__(self, priority: int = 0) -> None:
-        self.label = ''
-        self.priority = priority
-
-    __hash__ = None  # type: ignore[assignment]
+        super().__init__('', '', icon_name = '', priority=priority)
 
     def render_html(self, parent_context=None) -> SafeString:
         from django.utils.safestring import mark_safe
         return mark_safe(
             '<hr style="border: none; border-top: 1px solid var(--w-color-border-furniture); margin: 0.25rem 0;">'
         )
-
-    def __lt__(self, other): return (self.priority, self.label) < (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __le__(self, other): return (self.priority, self.label) <= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __gt__(self, other): return (self.priority, self.label) > (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __ge__(self, other): return (self.priority, self.label) >= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
-    def __eq__(self, other): return self.priority == getattr(other, 'priority', 0)
 
 
 class PledgeIndexView(WatchIndexView[Pledge]):

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -3,18 +3,22 @@ from __future__ import annotations
 import csv
 from collections import OrderedDict
 from functools import cached_property
+from io import BytesIO
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.db.models import Count
+from django.http import FileResponse, StreamingHttpResponse
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import (
     FieldPanel,
     MultiFieldPanel,
     ObjectList,
 )
+from wagtail.admin.ui.components import Component
 from wagtail.admin.ui.tables import Column
 from wagtail.admin.views.mixins import Echo
+from wagtail.admin.widgets.button import Button
 from wagtail.images.widgets import AdminImageChooser
 from wagtail.snippets.models import register_snippet
 
@@ -196,17 +200,59 @@ class PledgeEditView(PledgeViewMixin, WatchEditView[Pledge]):
     """Custom edit view for Pledge with dynamic attribute panels."""
 
 
+class _DropdownLabel(Component):
+    """Non-interactive group label rendered inside a dropdown."""
+
+    def __init__(self, label: str, priority: int = 0) -> None:
+        self.label = label
+        self.priority = priority
+
+    def render_html(self, parent_context=None):
+        from django.utils.html import format_html
+        return format_html(
+            '<div style="padding: 0.5rem 1.5rem 0.25rem; font-size: 0.75rem; font-weight: 600;'
+            ' text-transform: uppercase; color: var(--w-color-text-label-menus-default); opacity: 0.7;">{}</div>',
+            self.label,
+        )
+
+    def __lt__(self, other): return (self.priority, self.label) < (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __le__(self, other): return (self.priority, self.label) <= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __gt__(self, other): return (self.priority, self.label) > (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __ge__(self, other): return (self.priority, self.label) >= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __eq__(self, other): return self.priority == getattr(other, 'priority', 0) and self.label == getattr(other, 'label', '')
+
+
+class _DropdownDivider(Component):
+    """Horizontal rule rendered inside a dropdown."""
+
+    def __init__(self, priority: int = 0) -> None:
+        self.label = ''
+        self.priority = priority
+
+    def render_html(self, parent_context=None):
+        from django.utils.safestring import mark_safe
+        return mark_safe(
+            '<hr style="border: none; border-top: 1px solid var(--w-color-border-furniture); margin: 0.25rem 0;">'
+        )
+
+    def __lt__(self, other): return (self.priority, self.label) < (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __le__(self, other): return (self.priority, self.label) <= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __gt__(self, other): return (self.priority, self.label) > (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __ge__(self, other): return (self.priority, self.label) >= (getattr(other, 'priority', 0), getattr(other, 'label', ''))
+    def __eq__(self, other): return self.priority == getattr(other, 'priority', 0)
+
+
 class PledgeIndexView(WatchIndexView[Pledge]):
     """Custom index view for Pledge with spreadsheet export support."""
 
     export_headings = {
         'commitment_count': _('Number of commitments'),
     }
-    show_export_buttons = True
+    show_export_buttons = False
 
     @property
     def list_export(self) -> list[str]:
-        return ['id', 'name', 'slug', 'commitment_count'] + [f'user_data:{key}' for key in self._user_data_keys]
+        return ['id', 'name', 'slug', 'commitment_count']
 
     @list_export.setter
     def list_export(self, value: list[str]) -> None:
@@ -221,10 +267,23 @@ class PledgeIndexView(WatchIndexView[Pledge]):
     def export_filename(self, value: str) -> None:
         pass
 
-    def get_heading(self, queryset, field: str) -> str:
-        if field.startswith('user_data:'):
-            return field.removeprefix('user_data:')
-        return super().get_heading(queryset, field)
+    def get_header_more_buttons(self):
+        buttons = list(super().get_header_more_buttons())
+
+        def _url(export_type, fmt):
+            params = self.request.GET.copy()
+            params['export'] = fmt
+            params['export_type'] = export_type
+            return self.request.path + '?' + params.urlencode()
+
+        buttons += [
+            _DropdownLabel(str(_('Export')), priority=89),
+            Button(_('Export as Excel'),              url=self.get_export_url('xlsx'), icon_name='download', priority=90),
+            Button(_('Export pledges as CSV'),        url=_url('pledges',     'csv'),  icon_name='download', priority=91),
+            Button(_('Export commitments as CSV'),    url=_url('commitments', 'csv'),  icon_name='download', priority=92),
+            _DropdownDivider(priority=93),
+        ]
+        return sorted(buttons)
 
     @cached_property
     def _user_data_keys(self) -> list[str]:
@@ -251,21 +310,99 @@ class PledgeIndexView(WatchIndexView[Pledge]):
             yield self.write_csv_row(writer, self.to_row_dict(item))
 
     def to_row_dict(self, item: Pledge) -> OrderedDict[str, str]:
-        row: OrderedDict[str, str] = OrderedDict()
-        row['id'] = str(item.pk)
-        row['name'] = str(item.name)
-        row['slug'] = item.slug
-        row['commitment_count'] = str(getattr(item, 'commitment_count', item.commitments.count()))
+        return OrderedDict([
+            ('id', str(item.pk)),
+            ('name', str(item.name)),
+            ('slug', item.slug),
+            ('commitment_count', str(getattr(item, 'commitment_count', item.commitments.count()))),
+        ])
 
-        # Collect user_data values from all commitments for this pledge
-        commitments_user_data = list(
-            item.commitments.exclude(pledge_user__user_data={}).values_list('pledge_user__user_data', flat=True)
-        )
+    def render_to_response(self, context, **response_kwargs):
+        if self.is_export and self.request.GET.get('export_type') == 'commitments':
+            return self.write_commitments_csv_response(context['object_list'])
+        return super().render_to_response(context, **response_kwargs)
+
+    @property
+    def _commitment_export_fields(self) -> list[str]:
+        return ['pledge_id', 'pledge_name', 'commitment_created_at', 'user_id'] + [
+            f'user_data:{key}' for key in self._user_data_keys
+        ]
+
+    @property
+    def _commitment_export_headings(self) -> dict[str, str]:
+        headings: dict[str, str] = {
+            'pledge_id': str(_('Pledge ID')),
+            'pledge_name': str(_('Pledge name')),
+            'commitment_created_at': str(_('Commitment date')),
+            'user_id': str(_('User ID')),
+        }
         for key in self._user_data_keys:
-            values = [str(ud.get(key)) for ud in commitments_user_data if ud and key in ud]
-            row[f'user_data:{key}'] = ', '.join(values)
+            headings[f'user_data:{key}'] = key
+        return headings
 
-        return row
+    def _commitment_export_rows(self, queryset):
+        """Yield one dict per commitment across all pledges in the queryset."""
+        for pledge in queryset:
+            for commitment in pledge.commitments.select_related('pledge_user').order_by('created_at'):
+                user_data = commitment.pledge_user.user_data or {}
+                row: dict[str, str] = {
+                    'pledge_id': str(pledge.pk),
+                    'pledge_name': str(pledge.name),
+                    'commitment_created_at': commitment.created_at.isoformat(),
+                    'user_id': str(commitment.pledge_user.uuid),
+                }
+                for key in self._user_data_keys:
+                    row[f'user_data:{key}'] = str(user_data[key]) if key in user_data else ''
+                yield row
+
+    def _commitment_export_filename(self) -> str:
+        plan = user_or_bust(self.request.user).get_active_admin_plan()
+        return f'{_("Pledge Commitments")} - {plan}'
+
+    def write_commitments_csv_response(self, queryset) -> StreamingHttpResponse:
+        fields = self._commitment_export_fields
+        headings = self._commitment_export_headings
+
+        def _stream():
+            writer = csv.DictWriter(Echo(), fieldnames=fields, quoting=csv.QUOTE_ALL)
+            yield writer.writerow(headings)
+            for row in self._commitment_export_rows(queryset):
+                yield writer.writerow(row)
+
+        response = StreamingHttpResponse(_stream(), content_type='text/csv')
+        response['Content-Disposition'] = f'attachment; filename="{self._commitment_export_filename()}.csv"'
+        return response
+
+    def write_xlsx_response(self, queryset) -> FileResponse:
+        from openpyxl import Workbook
+
+        output = BytesIO()
+        workbook = Workbook(write_only=True, iso_dates=True)
+
+        # Pledges sheet
+        pledges_sheet = workbook.create_sheet(title=str(_('Pledges')))
+        pledges_sheet.append([self.get_heading(queryset, f) for f in self.list_export])
+        for item in queryset:
+            row = self.to_row_dict(item)
+            pledges_sheet.append([row[f] for f in self.list_export])
+
+        # Commitments sheet
+        commitment_fields = self._commitment_export_fields
+        commitment_headings = self._commitment_export_headings
+        commitments_sheet = workbook.create_sheet(title=str(_('Commitments')))
+        commitments_sheet.append([commitment_headings[f] for f in commitment_fields])
+        for row in self._commitment_export_rows(queryset):
+            commitments_sheet.append([row[f] for f in commitment_fields])
+
+        workbook.save(output)
+        output.seek(0)
+
+        return FileResponse(
+            output,
+            as_attachment=True,
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            filename=f'{self.export_filename}.xlsx',
+        )
 
 
 class PledgeViewSet(WatchViewSet[Pledge]):

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -38,9 +38,12 @@ from .models import Pledge
 from .models.pledge import PledgeCommitment
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from django.contrib.auth.base_user import AbstractBaseUser
     from django.contrib.auth.models import AnonymousUser
     from django.http import HttpRequest
+    from django.utils.safestring import SafeString
 
 
 class PledgePermissionPolicy(PlanRelatedPermissionPolicy):
@@ -207,7 +210,9 @@ class _DropdownLabel(Component):
         self.label = label
         self.priority = priority
 
-    def render_html(self, parent_context=None):
+    __hash__ = None  # type: ignore[assignment]
+
+    def render_html(self, parent_context=None) -> SafeString:
         from django.utils.html import format_html
         return format_html(
             '<div style="padding: 0.5rem 1.5rem 0.25rem; font-size: 0.75rem; font-weight: 600;'
@@ -229,7 +234,9 @@ class _DropdownDivider(Component):
         self.label = ''
         self.priority = priority
 
-    def render_html(self, parent_context=None):
+    __hash__ = None  # type: ignore[assignment]
+
+    def render_html(self, parent_context=None) -> SafeString:
         from django.utils.safestring import mark_safe
         return mark_safe(
             '<hr style="border: none; border-top: 1px solid var(--w-color-border-furniture); margin: 0.25rem 0;">'
@@ -270,7 +277,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
     def get_header_more_buttons(self):
         buttons = list(super().get_header_more_buttons())
 
-        def _url(export_type, fmt):
+        def _url(export_type: str, fmt: str) -> str:
             params = self.request.GET.copy()
             params['export'] = fmt
             params['export_type'] = export_type
@@ -318,7 +325,9 @@ class PledgeIndexView(WatchIndexView[Pledge]):
         ])
 
     def render_to_response(self, context, **response_kwargs):
-        if self.is_export and self.request.GET.get('export_type') == 'commitments':
+        if (self.is_export
+                and self.request.GET.get('export_type') == 'commitments'
+                and self.request.GET.get('export') == 'csv'):
             return self.write_commitments_csv_response(context['object_list'])
         return super().render_to_response(context, **response_kwargs)
 
@@ -340,7 +349,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
             headings[f'user_data:{key}'] = key
         return headings
 
-    def _commitment_export_rows(self, queryset):
+    def _commitment_export_rows(self, queryset) -> Generator[dict[str, str], None, None]:
         """Yield one dict per commitment across all pledges in the queryset."""
         for pledge in queryset:
             for commitment in pledge.commitments.select_related('pledge_user').order_by('created_at'):
@@ -363,7 +372,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
         fields = self._commitment_export_fields
         headings = self._commitment_export_headings
 
-        def _stream():
+        def _stream() -> Generator[bytes, None, None]:
             writer = csv.DictWriter(Echo(), fieldnames=fields, quoting=csv.QUOTE_ALL)
             yield writer.writerow(headings)
             for row in self._commitment_export_rows(queryset):

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -23,6 +23,8 @@ from wagtail.admin.widgets.button import Button
 from wagtail.images.widgets import AdminImageChooser
 from wagtail.snippets.models import register_snippet
 
+from openpyxl import Workbook
+
 from dal import autocomplete
 
 from kausal_common.users import user_or_bust
@@ -366,8 +368,6 @@ class PledgeIndexView(WatchIndexView[Pledge]):
         return response
 
     def write_xlsx_response(self, queryset) -> FileResponse:
-        from openpyxl import Workbook
-
         output = BytesIO()
         workbook = Workbook(write_only=True, iso_dates=True)
 

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -349,7 +349,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
             headings[f'user_data:{key}'] = key
         return headings
 
-    def _commitment_export_rows(self, queryset) -> Generator[dict[str, str], None, None]:
+    def _commitment_export_rows(self, queryset) -> Generator[dict[str, str]]:
         """Yield one dict per commitment across all pledges in the queryset."""
         for pledge in queryset:
             for commitment in pledge.commitments.select_related('pledge_user').order_by('created_at'):

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -23,9 +23,8 @@ from wagtail.admin.widgets.button import Button
 from wagtail.images.widgets import AdminImageChooser
 from wagtail.snippets.models import register_snippet
 
-from openpyxl import Workbook
-
 from dal import autocomplete
+from openpyxl import Workbook
 
 from kausal_common.users import user_or_bust
 

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -372,7 +372,7 @@ class PledgeIndexView(WatchIndexView[Pledge]):
         fields = self._commitment_export_fields
         headings = self._commitment_export_headings
 
-        def _stream() -> Generator[bytes, None, None]:
+        def _stream() -> Generator[bytes]:
             writer = csv.DictWriter(Echo(), fieldnames=fields, quoting=csv.QUOTE_ALL)
             yield writer.writerow(headings)
             for row in self._commitment_export_rows(queryset):

--- a/actions/tests/test_pledge_export.py
+++ b/actions/tests/test_pledge_export.py
@@ -20,14 +20,17 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.django_db
 
 
-def _get_view_and_queryset(rf: RequestFactory, user: User, plan):
+def _get_view_and_queryset(rf: RequestFactory, user: User, plan, extra_params: dict | None = None):
     """Set up a PledgeIndexView and build the queryset for the given plan."""
     view_set = PledgeViewSet()
     view = PledgeIndexView(
         **view_set.get_common_view_kwargs(),
         **view_set.get_index_view_kwargs(),
     )
-    request = rf.get('/admin/', {'export': 'csv'})
+    params = {'export': 'csv'}
+    if extra_params:
+        params.update(extra_params)
+    request = rf.get('/admin/', params)
     request.user = user
     view.setup(request)
     view.filterset_class = None  # type: ignore[assignment]
@@ -36,8 +39,16 @@ def _get_view_and_queryset(rf: RequestFactory, user: User, plan):
 
 
 def _parse_csv_rows(view: PledgeIndexView, queryset) -> list[dict[str, str]]:
-    """Stream CSV from the view and parse into a list of row dicts."""
+    """Stream pledges CSV from the view and parse into a list of row dicts."""
     raw = b''.join(view.stream_csv(queryset))
+    reader = csv.DictReader(io.StringIO(raw.decode('utf-8')))
+    return list(reader)
+
+
+def _parse_commitments_csv_rows(view: PledgeIndexView, queryset) -> list[dict[str, str]]:
+    """Stream commitments CSV from the view and parse into a list of row dicts."""
+    response = view.write_commitments_csv_response(queryset)
+    raw = b''.join(response.streaming_content)  # type: ignore[arg-type]
     reader = csv.DictReader(io.StringIO(raw.decode('utf-8')))
     return list(reader)
 
@@ -51,7 +62,7 @@ class TestPledgeExportCSV:
         self.plan.features.save()
 
     def test_basic_export_columns(self, rf):
-        """Export should contain the base columns: ID, Name, Slug, Number of commitments."""
+        """Pledge export should contain base columns; user_data columns should not appear."""
         PledgeFactory.create(plan=self.plan)
 
         view, qs = _get_view_and_queryset(rf, self.user, self.plan)
@@ -60,9 +71,10 @@ class TestPledgeExportCSV:
         assert len(rows) == 1
         row = rows[0]
         assert set(row.keys()) >= {'ID', 'Name', 'Slug', 'Number of commitments'}
+        assert not any(k in row for k in ('zip_code', 'city'))
 
     def test_commitment_count(self, rf):
-        """Export should reflect the correct number of commitments per pledge."""
+        """Pledge export should reflect the correct number of commitments per pledge."""
         pledge = PledgeFactory.create(plan=self.plan)
         for _ in range(3):
             PledgeCommitment.objects.create(
@@ -75,27 +87,23 @@ class TestPledgeExportCSV:
 
         assert rows[0]['Number of commitments'] == '3'
 
-    def test_user_data_columns(self, rf):
-        """User data keys from commitments should appear as extra columns."""
+    def test_user_data_columns_absent_from_pledge_export(self, rf):
+        """User data keys from commitments should NOT appear as columns in the pledge export."""
         pledge = PledgeFactory.create(plan=self.plan)
         PledgeCommitment.objects.create(
             pledge=pledge,
             pledge_user=PledgeUser.objects.create(user_data={'zip_code': '00100', 'city': 'Helsinki'}),
-        )
-        PledgeCommitment.objects.create(
-            pledge=pledge,
-            pledge_user=PledgeUser.objects.create(user_data={'zip_code': '00200'}),
         )
 
         view, qs = _get_view_and_queryset(rf, self.user, self.plan)
         rows = _parse_csv_rows(view, qs)
 
         row = rows[0]
-        assert row['zip_code'] == '00100, 00200'
-        assert row['city'] == 'Helsinki'
+        assert 'zip_code' not in row
+        assert 'city' not in row
 
     def test_multiple_pledges(self, rf):
-        """Export should include one row per pledge."""
+        """Pledge export should include one row per pledge."""
         PledgeFactory.create(plan=self.plan, name='First Pledge')
         PledgeFactory.create(plan=self.plan, name='Second Pledge')
 
@@ -106,7 +114,7 @@ class TestPledgeExportCSV:
         assert names == {'First Pledge', 'Second Pledge'}
 
     def test_only_own_plan_pledges(self, rf):
-        """Export should only include pledges from the user's active plan."""
+        """Pledge export should only include pledges from the user's active plan."""
         PledgeFactory.create(plan=self.plan, name='My Pledge')
 
         other_plan = PlanFactory.create()
@@ -121,15 +129,104 @@ class TestPledgeExportCSV:
         assert 'My Pledge' in names
         assert 'Other Pledge' not in names
 
-    def test_comma_in_user_data_value(self, rf):
-        """Values containing commas should be properly handled in CSV."""
+
+class TestCommitmentsExportCSV:
+    @pytest.fixture(autouse=True)
+    def setup(self, plan_admin_user):
+        self.user = plan_admin_user
+        self.plan = self.user.get_active_admin_plan()
+        self.plan.features.enable_community_engagement = True
+        self.plan.features.save()
+
+    def test_commitments_export_columns(self, rf):
+        """Commitments export should contain the expected base column headers."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        PledgeCommitment.objects.create(pledge=pledge, pledge_user=PledgeUser.objects.create())
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export_type': 'commitments'})
+        rows = _parse_commitments_csv_rows(view, qs)
+
+        assert len(rows) == 1
+        assert set(rows[0].keys()) >= {'Pledge ID', 'Pledge name', 'Commitment date', 'User ID'}
+
+    def test_commitments_one_row_per_commitment(self, rf):
+        """Commitments export should yield one row per commitment, not per pledge."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        for _ in range(3):
+            PledgeCommitment.objects.create(
+                pledge=pledge,
+                pledge_user=PledgeUser.objects.create(),
+            )
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export_type': 'commitments'})
+        rows = _parse_commitments_csv_rows(view, qs)
+
+        assert len(rows) == 3
+
+    def test_commitments_user_data_in_own_cells(self, rf):
+        """Each commitment's user_data values should appear in their own cells, not comma-joined."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        PledgeCommitment.objects.create(
+            pledge=pledge,
+            pledge_user=PledgeUser.objects.create(user_data={'zip_code': '00100', 'city': 'Helsinki'}),
+        )
+        PledgeCommitment.objects.create(
+            pledge=pledge,
+            pledge_user=PledgeUser.objects.create(user_data={'zip_code': '00200'}),
+        )
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export_type': 'commitments'})
+        rows = _parse_commitments_csv_rows(view, qs)
+
+        assert len(rows) == 2
+        zip_codes = {row['zip_code'] for row in rows}
+        assert zip_codes == {'00100', '00200'}
+        # Each cell contains a single value, not a comma-joined list
+        for row in rows:
+            assert ',' not in row['zip_code']
+
+    def test_commitments_includes_timestamp_and_user_id(self, rf):
+        """Each commitment row should include a timestamp and the pledge user's UUID."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        pu = PledgeUser.objects.create()
+        PledgeCommitment.objects.create(pledge=pledge, pledge_user=pu)
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export_type': 'commitments'})
+        rows = _parse_commitments_csv_rows(view, qs)
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row['User ID'] == str(pu.uuid)
+        # Timestamp should be an ISO 8601 string
+        assert 'T' in row['Commitment date'] or '-' in row['Commitment date']
+
+    def test_commitments_only_own_plan(self, rf):
+        """Commitments export should only include commitments from the user's active plan."""
+        pledge = PledgeFactory.create(plan=self.plan, name='My Pledge')
+        PledgeCommitment.objects.create(pledge=pledge, pledge_user=PledgeUser.objects.create())
+
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+        other_pledge = PledgeFactory.create(plan=other_plan, name='Other Pledge')
+        PledgeCommitment.objects.create(pledge=other_pledge, pledge_user=PledgeUser.objects.create())
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export_type': 'commitments'})
+        rows = _parse_commitments_csv_rows(view, qs)
+
+        pledge_names = {row['Pledge name'] for row in rows}
+        assert 'My Pledge' in pledge_names
+        assert 'Other Pledge' not in pledge_names
+
+    def test_commitments_comma_in_user_data_value(self, rf):
+        """User data values containing commas should be properly handled in the commitments CSV."""
         pledge = PledgeFactory.create(plan=self.plan)
         PledgeCommitment.objects.create(
             pledge=pledge,
             pledge_user=PledgeUser.objects.create(user_data={'location': 'City, State'}),
         )
 
-        view, qs = _get_view_and_queryset(rf, self.user, self.plan)
-        rows = _parse_csv_rows(view, qs)
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export_type': 'commitments'})
+        rows = _parse_commitments_csv_rows(view, qs)
 
         assert rows[0]['location'] == 'City, State'

--- a/actions/tests/test_pledge_export.py
+++ b/actions/tests/test_pledge_export.py
@@ -298,7 +298,7 @@ class TestCombinedXlsxExport:
         assert 'zip_code' in header
         assert 'city' in header
         zip_idx = header.index('zip_code')
-        data_row = list(ws.iter_rows(min_row=2, max_row=2, values_only=True))[0]
+        data_row = next(iter(ws.iter_rows(min_row=2, max_row=2, values_only=True)))
         assert data_row[zip_idx] == '00100'
 
     def test_render_to_response_routes_commitments_csv(self, rf):

--- a/actions/tests/test_pledge_export.py
+++ b/actions/tests/test_pledge_export.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import csv
 import io
+from io import BytesIO
 from typing import TYPE_CHECKING
 
 from django.db.models import Count
+from django.http import StreamingHttpResponse
 
 import pytest
 
@@ -230,3 +232,84 @@ class TestCommitmentsExportCSV:
         rows = _parse_commitments_csv_rows(view, qs)
 
         assert rows[0]['location'] == 'City, State'
+
+
+def _parse_xlsx_workbook(view: PledgeIndexView, queryset):
+    """Call write_xlsx_response and return an openpyxl Workbook for inspection."""
+    import openpyxl  # type: ignore[import-untyped]
+
+    response = view.write_xlsx_response(queryset)
+    raw = b''.join(response.streaming_content)  # type: ignore[arg-type]
+    return openpyxl.load_workbook(BytesIO(raw))
+
+
+class TestCombinedXlsxExport:
+    @pytest.fixture(autouse=True)
+    def setup(self, plan_admin_user):
+        self.user = plan_admin_user
+        self.plan = self.user.get_active_admin_plan()
+        self.plan.features.enable_community_engagement = True
+        self.plan.features.save()
+
+    def test_xlsx_sheet_names(self, rf):
+        """XLSX export should contain 'Pledges' and 'Commitments' sheets."""
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export': 'xlsx'})
+        wb = _parse_xlsx_workbook(view, qs)
+
+        assert 'Pledges' in wb.sheetnames
+        assert 'Commitments' in wb.sheetnames
+
+    def test_xlsx_pledges_sheet_one_row_per_pledge(self, rf):
+        """Pledges sheet should have one data row per pledge."""
+        PledgeFactory.create(plan=self.plan, name='Alpha')
+        PledgeFactory.create(plan=self.plan, name='Beta')
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export': 'xlsx'})
+        wb = _parse_xlsx_workbook(view, qs)
+
+        data_rows = list(wb['Pledges'].iter_rows(min_row=2, values_only=True))
+        assert len(data_rows) == 2
+
+    def test_xlsx_commitments_sheet_one_row_per_commitment(self, rf):
+        """Commitments sheet should have one data row per commitment."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        for _ in range(3):
+            PledgeCommitment.objects.create(pledge=pledge, pledge_user=PledgeUser.objects.create())
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export': 'xlsx'})
+        wb = _parse_xlsx_workbook(view, qs)
+
+        data_rows = list(wb['Commitments'].iter_rows(min_row=2, values_only=True))
+        assert len(data_rows) == 3
+
+    def test_xlsx_user_data_in_own_columns(self, rf):
+        """User data values should appear in separate named columns in the Commitments sheet."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        PledgeCommitment.objects.create(
+            pledge=pledge,
+            pledge_user=PledgeUser.objects.create(user_data={'zip_code': '00100', 'city': 'Helsinki'}),
+        )
+
+        view, qs = _get_view_and_queryset(rf, self.user, self.plan, {'export': 'xlsx'})
+        wb = _parse_xlsx_workbook(view, qs)
+
+        ws = wb['Commitments']
+        header = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        assert 'zip_code' in header
+        assert 'city' in header
+        zip_idx = header.index('zip_code')
+        data_row = list(ws.iter_rows(min_row=2, max_row=2, values_only=True))[0]
+        assert data_row[zip_idx] == '00100'
+
+    def test_render_to_response_routes_commitments_csv(self, rf):
+        """render_to_response with export_type=commitments and export=csv returns a streaming CSV."""
+        pledge = PledgeFactory.create(plan=self.plan)
+        PledgeCommitment.objects.create(pledge=pledge, pledge_user=PledgeUser.objects.create())
+
+        view, qs = _get_view_and_queryset(
+            rf, self.user, self.plan, {'export': 'csv', 'export_type': 'commitments'}
+        )
+        response = view.render_to_response({'object_list': qs})
+
+        assert isinstance(response, StreamingHttpResponse)
+        assert 'text/csv' in response['Content-Type']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ dependencies = [
   "tinycss2",
   "treelib",
   "tzdata",
+  "types-openpyxl",
   "unidecode",
   "uritemplate",
   "uuid-utils",

--- a/uv.lock
+++ b/uv.lock
@@ -1861,6 +1861,7 @@ dependencies = [
     { name = "strawberry-graphql-django", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tinycss2", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "treelib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "types-openpyxl", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "tzdata", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "unidecode", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "uritemplate", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2021,6 +2022,7 @@ requires-dist = [
     { name = "strawberry-graphql-django" },
     { name = "tinycss2" },
     { name = "treelib" },
+    { name = "types-openpyxl" },
     { name = "tzdata" },
     { name = "unidecode" },
     { name = "uritemplate" },
@@ -3875,6 +3877,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/6e/d08033f562053c459322333c46baa8cf8d2d8c18f30d46dd898c8fd8df77/types_oauthlib-3.3.0.20250822.tar.gz", hash = "sha256:2cd41587dd80c199e4230e3f086777e9ae525e89579c64afe5e0039ab09be9de", size = 25700, upload-time = "2025-08-22T03:02:41.378Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/4b/00593b8b5d055550e1fcb9af2c42fa11b0a90bf16a94759a77bc1c3c0c72/types_oauthlib-3.3.0.20250822-py3-none-any.whl", hash = "sha256:b7f4c9b9eed0e020f454e0af800b10e93dd2efd196da65744b76910cce7e70d6", size = 48800, upload-time = "2025-08-22T03:02:40.427Z" },
+]
+
+[[package]]
+name = "types-openpyxl"
+version = "3.1.5.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/c9/24f03f9d9fedd164de699c1418869bef9b819f59f75e7f647f5788c02d98/types_openpyxl-3.1.5.20260408.tar.gz", hash = "sha256:b49274d086fbb6e6bcd2a67d161dd1161d4d380488e4cce546d647d45eadcac2", size = 101361, upload-time = "2026-04-08T04:30:37.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/e8/64db0c32c6fda4b198aff84329ceeea00a93d16c28f05e9fe0404ddb8b8c/types_openpyxl-3.1.5.20260408-py3-none-any.whl", hash = "sha256:7ab7586796aed017cde50b81bd67ba024120c39b99c102320b57dd91390c317f", size = 166044, upload-time = "2026-04-08T04:30:36.449Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Previously the pledge export feature included commitment metadata (user zip codes) in a single cell, which is hard to digest or filter. This change adds a separate CSV export a separate Excel sheet for commitments, allowing admins to see when a commitment was made along with the user's ID and zip code.

## Screenshots/Videos (if applicable)

<img width="855" height="339" alt="image" src="https://github.com/user-attachments/assets/45e79346-5f6a-408d-bb7f-86eb410f5daf" />

### Exported Excel

<img width="1512" height="948" alt="image" src="https://github.com/user-attachments/assets/e1042397-e4dc-4a24-8e25-4cefca1f6686" />

<img width="1512" height="946" alt="image" src="https://github.com/user-attachments/assets/ae197f96-518b-47fa-96cb-ac2e0b7ec8da" />

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213357385251683?focus=true

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)