### PR TITLE
Fix default wagtail rich text features duplication in editor

### DIFF
--- a/images/apps.py
+++ b/images/apps.py
@@ -12,23 +12,11 @@ class ImagesConfig(AppConfig):
 
         from wagtail.images import permissions
 
-        # Register custom rich text image embed handler that injects
-        # data-image-credit attributes on <img> tags in rich text.
-        # We force a feature scan first so that Wagtail's default hooks
-        # have already run, then override the 'image' embed type with
-        # ours and clear the rewriter cache.
-        from wagtail.rich_text import features as rich_text_features, get_rewriter
-
         # Register graphql types overrides for grapple
         from . import schema  # noqa: F401
 
         # monkeypatch new permission policy
         from .permissions import permission_policy
-        from .rich_text import ImageEmbedHandler
-
-        rich_text_features.get_embed_types()  # ensure scan has completed
-        rich_text_features.register_embed_type(ImageEmbedHandler)
-        get_rewriter.cache_clear()
 
         permissions.permission_policy = permission_policy
 

--- a/images/tests/test_rich_text.py
+++ b/images/tests/test_rich_text.py
@@ -130,6 +130,13 @@ class TestImageEmbedHandlerRegistration:
         embed_types = features.get_embed_types()
         assert embed_types['image'] is ImageEmbedHandler
 
+    def test_no_duplicate_default_features(self):
+        from wagtail.rich_text import features
+
+        features.get_default_features()
+        duplicates = [f for f in features.default_features if features.default_features.count(f) > 1]  # type: ignore[attr-defined]
+        assert duplicates == [], f'Duplicate default features: {set(duplicates)}'
+
     def test_expand_db_html_uses_custom_handler(self):
         """End-to-end: expand_db_html should produce data-image-credit."""
         from wagtail.rich_text import expand_db_html

--- a/images/wagtail_hooks.py
+++ b/images/wagtail_hooks.py
@@ -6,9 +6,17 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import hooks
 
 from images.permissions import permission_policy
+from images.rich_text import ImageEmbedHandler
 
 if TYPE_CHECKING:
     from wagtail.log_actions import LogActionRegistry
+    from wagtail.rich_text.feature_registry import FeatureRegistry
+
+
+@hooks.register('register_rich_text_features', order=1)
+def register_custom_image_embed(features: FeatureRegistry):
+    """Replace Wagtail's default image embed handler with one that injects image credit."""
+    features.register_embed_type(ImageEmbedHandler)
 
 
 @hooks.register('construct_image_chooser_queryset')


### PR DESCRIPTION
Registering the feature in app.ready caused the default features to be registered twice.
Registering with the normal wagtail hook with order=1 (bigger than Wagtail's default 0) overrides the default handler.
The handler is registered based on the handler indentifier which is the same as the built-in handler's so the more recent one (order 1) will end up in the registry.
