### PR TITLE
Fix resolve_workflow_states signature for optional plan argument

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -2142,7 +2142,7 @@ class Query:
         return PledgeUser.objects.filter(uuid=uuid).first()
 
     @staticmethod
-    def resolve_workflow_states(_root: Query, info: GQLInfo, plan: str | None):
+    def resolve_workflow_states(_root: Query, info: GQLInfo, plan: str | None = None):
         if plan is None:
             return []
         user = user_or_none(info.context.user)


### PR DESCRIPTION
## Description
The `plan` GraphQL argument is declared with `required=False` and the resolver body already handles `plan is None`, but the Python signature lacked a default, causing TypeError when the field was queried without a plan argument.

Fixes WATCH-BACKEND-36D

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/11738/?project=3&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=freq

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
