### PR TITLE
Require id or identifier argument in resolve_action

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -2038,6 +2038,9 @@ def _resolve_published_action(
     plan_identifier: str | None,
     info: GQLInfo,
 ) -> Action | None:
+    if not obj_id and not identifier:
+        raise GraphQLError("You must supply either 'id' or 'identifier' as arguments to 'action'")
+
     qs = Action.objects.get_queryset().visible_for_user(info.context.user).all()
     if obj_id:
         qs = qs.filter(id=obj_id)


### PR DESCRIPTION
## Description
Without either selector, the resolver fell through to .get() on an unfiltered visible-actions queryset and raised MultipleObjectsReturned as soon as more than one action was visible to the caller. Reject the malformed request with a GraphQLError instead - same pattern already used by resolve_plan for the equivalent case.

Fixes WATCH-BACKEND-36E

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/11738/?project=3&query=issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
