### PR TITLE
Fix action change log message never returning for public API

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1329,16 +1329,7 @@ class Action(
         return visible_contact_persons
 
     def get_public_change_log_message(self) -> BaseChangeLogMessage | None:
-        if not self.live_revision:
-            return None
-        # When publishing, Wagtail creates a new revision, but the previous revision's id
-        # is stored in the live revision. Currently the change history message is always
-        # connected to that previous version, pre-publishing
-        previous_revision_to_published_revision = self.live_revision.content['latest_revision']
-        try:
-            return ActionChangeLogMessage.objects.get(action=self, revision=previous_revision_to_published_revision)
-        except ActionChangeLogMessage.DoesNotExist:
-            return None
+        return ActionChangeLogMessage.objects.filter(action=self).order_by('-created_at').first()
 
     def get_workflow(self) -> Workflow | None:
         return self.plan.features.moderation_workflow


### PR DESCRIPTION
## Description
Claude Code assistance.
Fixes the public UI action change history block not being displayed after publishing an action with a change message.

The reason for the bug was that the UI received `null` for `action.changeLogMessage` from the backend, so it fell back to showing only the legacy updated-at line.
The `get_public_change_log_message` method looked up `ActionChangeLogMessage` by the revision ID from `live_revision.content['latest_revision']`. But the `revision` field on `ActionChangeLogMessage` is never set in the current create flow: the create URL only passes `?action=pk`, not `?revision=...`.
As a result, the lookup always raised `DoesNotExist` and returned `None`, causing the backend to return `null` for the latest change history message.

This change aligns actions with the same pattern used by Indicator, Category, and Page: return the most recently created message for the object.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214253552276819?focus=true)

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
The public UI expects action.changeLogMessage to return the latest message when the feature flag and layout block are enabled.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
  The admin setup is already configured for this action https://sunnydale.watch.fi.kausal.tech/actions/U1: the change log feature is enabled and the “Latest change history message” block is present in the action details page layout.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
