### PR TITLE
Return None from resolve_organization for missing IDs

### DIFF
--- a/orgs/schema.py
+++ b/orgs/schema.py
@@ -118,8 +118,8 @@ class Query:
     organization = graphene.Field(OrganizationNode, id=graphene.ID(required=True))
 
     @staticmethod
-    def resolve_organization(root, info: GQLInfo, id: str) -> Organization:
-        return Organization.objects.get(id=id)
+    def resolve_organization(root, info: GQLInfo, id: str) -> Organization | None:
+        return Organization.objects.filter(id=id).first()
 
 
 def _get_organization_mutation_namespace() -> type:


### PR DESCRIPTION
## Description
The public UI's /organizations/[id] page already handles a null response via Next.js notFound(), but the backend was raising Organization.DoesNotExist is just a stale link / 404. The graphene field is nullable, so returning None is a valid GraphQL response.

Fixes WATCH-BACKEND-35Z

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/11695/?project=3&query=is%3Aunresolved&referrer=issue-stream

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
