### PR TITLE
Validate request parameters for report export view

### DIFF
--- a/reports/tests/test_views.py
+++ b/reports/tests/test_views.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.http import Http404
+
 import pytest
+
+from actions.tests.factories import PlanFactory
 
 
 def test_mark_action_as_complete_view_accepts_as_view_kwargs():
@@ -59,3 +66,69 @@ def test_mark_report_as_complete_view_accepts_as_view_kwargs():
         if 'invalid keyword' in str(e):
             pytest.fail(f'as_view() rejected a keyword argument: {e}')
         raise
+
+
+@pytest.fixture
+def mock_export():
+    with patch('reports.views.export_dashboard_report_for_plan', return_value=(b'data', 'report.xlsx')) as m:
+        yield m
+
+
+@pytest.mark.django_db
+class TestExportReportView:
+    def _get(self, rf, plan_identifier, **params):
+        from reports.views import export_report_view
+
+        request = rf.get(f'/report_export/{plan_identifier}/', params)
+        request.user = AnonymousUser()
+        return export_report_view(request, plan_identifier=plan_identifier)
+
+    @pytest.mark.parametrize('format', ['pdf', 'json', 'xml'])
+    def test_invalid_format_returns_400(self, rf, plan, format):
+        response = self._get(rf, plan.identifier, format=format)
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        'actions',
+        [
+            "1,2'",  # trailing quote
+            '1,foo,3',  # non-integer token
+            'abc',  # entirely non-numeric
+        ],
+    )
+    def test_invalid_actions_returns_400(self, rf, plan, actions):
+        response = self._get(rf, plan.identifier, actions=actions)
+        assert response.status_code == 400
+
+    def test_nonexistent_plan_raises_404(self, rf):
+        with pytest.raises(Http404):
+            self._get(rf, 'does-not-exist')
+
+    def test_non_live_plan_raises_404(self, rf):
+        plan = PlanFactory.create(published_at=None)
+        with pytest.raises(Http404):
+            self._get(rf, plan.identifier)
+
+    @pytest.mark.parametrize(
+        ('format', 'expected_content_type'),
+        [
+            ('xlsx', 'spreadsheetml'),
+            ('csv', 'text/csv'),
+            (None, 'spreadsheetml'),  # default format is xlsx
+        ],
+    )
+    def test_valid_format_returns_200_with_correct_content_type(self, rf, plan, mock_export, format, expected_content_type):
+        params = {'format': format} if format is not None else {}
+        response = self._get(rf, plan.identifier, **params)
+        assert response.status_code == 200
+        assert expected_content_type in response['Content-Type']
+
+    def test_valid_actions_filter_passes_ids_to_exporter(self, rf, plan, mock_export):
+        response = self._get(rf, plan.identifier, actions='1,2,3')
+        assert response.status_code == 200
+        assert mock_export.call_args[0][3] == [1, 2, 3]
+
+    def test_no_actions_param_passes_none_to_exporter(self, rf, plan, mock_export):
+        response = self._get(rf, plan.identifier)
+        assert response.status_code == 200
+        assert mock_export.call_args[0][3] is None

--- a/reports/views.py
+++ b/reports/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.db.models import IntegerField
 from django.db.models.functions import Cast
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
@@ -19,6 +19,8 @@ from actions.models import Action, Plan
 
 from .export import export_dashboard_report_for_plan
 from .models import ActionSnapshot, Report
+
+ALLOWED_EXPORT_FORMATS = {'xlsx', 'csv'}
 
 
 class MarkActionAsCompleteView(WMABaseView[Action]):
@@ -148,16 +150,25 @@ class MarkReportAsCompleteView(WMABaseView[Report]):
 
 def export_report_view(request, plan_identifier):
     format = request.GET.get('format', 'xlsx')
-    user = request.user
-    plan = Plan.objects.get(identifier=plan_identifier)
+    if format not in ALLOWED_EXPORT_FORMATS:
+        return HttpResponseBadRequest(f'Invalid format. Allowed values: {", ".join(sorted(ALLOWED_EXPORT_FORMATS))}.')
+
+    plan = get_object_or_404(Plan, identifier=plan_identifier)
     if not plan.is_live():
         # TODO: authorization relative to user once plan visibility is merged
         raise Http404
+
     # Possibly restrict which actions are included
-    action_ids = request.GET.get('actions')
-    if action_ids is not None:
-        action_ids = [int(id) for id in action_ids.split(',') if id]  # `if id` is there to handle [] correctly
-    output, filename = export_dashboard_report_for_plan(plan, format, user, action_ids)
+    action_ids_param = request.GET.get('actions')
+    action_ids: list[int] | None = None
+    if action_ids_param is not None:
+        try:
+            # `if id` is there to handle [] correctly
+            action_ids = [int(id) for id in action_ids_param.split(',') if id]
+        except ValueError:
+            return HttpResponseBadRequest('Invalid actions parameter. Must be a comma-separated list of integers.')
+
+    output, filename = export_dashboard_report_for_plan(plan, format, request.user, action_ids)
     content_type = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' if format == 'xlsx' else 'text/csv'
     response = HttpResponse(
         output,


### PR DESCRIPTION
## Description
At the moment client errors, in particular invalid request parameters crash the backend and are reported to Sentry. Validate the parameters and return suitable HTTP statuses explaining the issues.

This is an attempt to address [a Sentry issue](https://sentry.kausal.tech/organizations/kausal/issues/10732), where a trailing `'` in the given action ids crash the backend. While this doesn't solve the root cause, I think this is how backend should work, and hopefully next time we run into the bug we get more relevant info from Sentry to solve the bug.

## Screenshots/Videos (if applicable)
\-

## Related issue
 [Sentry issue](https://sentry.kausal.tech/organizations/kausal/issues/10732)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    \-

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)