### PR TITLE
Use best practise form of notifications from_email

### DIFF
--- a/notifications/models.py
+++ b/notifications/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import logging
 import typing
+from email.utils import formataddr
 from typing import TYPE_CHECKING, Any, cast
 
 import reversion
@@ -233,7 +234,7 @@ class BaseTemplate(ClusterableModel, PlanRelatedModelWithRevision):
     def get_from_email(self):
         from_address = self.from_address or settings.DEFAULT_FROM_EMAIL
         from_name = self.from_name or settings.DEFAULT_FROM_NAME
-        return f'{from_name} <{from_address}>'
+        return formataddr((from_name, from_address))
 
 
 class NotificationTemplateManager[M: NotificationTemplate](ModelManager[M, QuerySet['NotificationTemplate']]):


### PR DESCRIPTION
## Description
Should fix [this Sentry issue](https://sentry.kausal.tech/organizations/kausal/issues/14346).

According to Anymail docs the display name of a from email should be wrapped in double quotes
(https://anymail.dev/en/stable/sending/exceptions/#anymail.exceptions.AnymailInvalidAddress). Having no double quotes does not work when the display name has commas in it, which is the case with some of our customer's plan names, which are used as display names for the from email address.

Use built-in Python function email.utils.formataddr to build the email address and to ensure it is formatted according to best practise.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Sentry](https://sentry.kausal.tech/organizations/kausal/issues/14346)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
   \-

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)