### PR TITLE
Fix action change history messages for plans with no moderation

### DIFF
--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -72,6 +72,7 @@ from people.models import Person
 from reports.views import MarkActionAsCompleteView
 
 from .action_admin_mixins import SnippetsEditViewCompatibilityMixin
+from .admin_utils import change_log_message_url_or_none
 from .models.action import Action, ActionContactPerson, ActionResponsibleParty, ActionTask
 
 if typing.TYPE_CHECKING:
@@ -705,16 +706,6 @@ class ActionEditHandler(
         return form_class
 
 
-def change_log_message_url_or_none(action: Action) -> str | None:
-    plan = action.plan
-    if plan.features.enable_change_log and not plan.features.moderation_workflow:
-        change_log_create_url = reverse('wagtailsnippets_actions_actionchangelogmessage:add')
-        revision = action.live_revision or action.latest_revision
-        revision_param = f'&revision={revision.pk}' if revision else ''
-        return f'{change_log_create_url}?action={action.pk}{revision_param}'
-    return None
-
-
 class ActionCreateView(InitializeFormWithInitialPlanMixin[Action], AplansCreateView[Action]):
     def initialize_instance(self, request):
         plan = request.user.get_active_admin_plan()
@@ -733,8 +724,10 @@ class ActionCreateView(InitializeFormWithInitialPlanMixin[Action], AplansCreateV
                 self.instance.primary_org = default_org
 
     def get_success_url(self):
-        url = change_log_message_url_or_none(self.instance)
-        return url or super().get_success_url()
+        if self.instance.plan.features.moderation_workflow is None:
+            url = change_log_message_url_or_none(self.instance, moderation_enabled=False)
+            return url or super().get_success_url()
+        return super().get_success_url()
 
 
 class ActionButtonHelper(AplansButtonHelper):
@@ -798,8 +791,10 @@ class ActionEditView(
     model: type[Action]
 
     def get_success_url(self):
-        url = change_log_message_url_or_none(self.instance)
-        return url or super().get_success_url()
+        if self.instance.plan.features.moderation_workflow is None:
+            url = change_log_message_url_or_none(self.instance, moderation_enabled=False)
+            return url or super().get_success_url()
+        return super().get_success_url()
 
     def get_context_data(self, **kwargs):  # type: ignore[override]
         context = super().get_context_data(**kwargs)

--- a/actions/action_admin.py
+++ b/actions/action_admin.py
@@ -709,7 +709,9 @@ def change_log_message_url_or_none(action: Action) -> str | None:
     plan = action.plan
     if plan.features.enable_change_log and not plan.features.moderation_workflow:
         change_log_create_url = reverse('wagtailsnippets_actions_actionchangelogmessage:add')
-        return f'{change_log_create_url}?action={action.pk}'
+        revision = action.live_revision or action.latest_revision
+        revision_param = f'&revision={revision.pk}' if revision else ''
+        return f'{change_log_create_url}?action={action.pk}{revision_param}'
     return None
 
 

--- a/actions/action_admin_mixins.py
+++ b/actions/action_admin_mixins.py
@@ -33,6 +33,7 @@ from wagtail.permissions import ModelPermissionPolicy
 
 from kausal_common.users import user_or_bust
 
+from actions.admin_utils import change_log_message_url_or_none
 from actions.models.action import Action
 
 if TYPE_CHECKING:
@@ -407,13 +408,12 @@ class CreateEditViewOptionalFeaturesMixin[M: Action, FormT: ModelForm[Any]](Crea
                 return redirect(self.get_edit_url())
 
         plan = self.object.plan
-        if plan.features.enable_change_log:
-            change_log_create_url = reverse('wagtailsnippets_actions_actionchangelogmessage:add')
-            # Get the revision that was just created for this submission
-            revision = self.object.latest_revision
-            revision_param = f'&revision={revision.pk}' if revision else ''
-            return redirect(f'{change_log_create_url}?action={self.object.pk}{revision_param}')
-        return None
+        if not plan.features.enable_change_log:
+            return None
+        url = change_log_message_url_or_none(self.object, moderation_enabled=True)
+        if url is None:
+            return None
+        return redirect(url)
 
     def restart_workflow_action(self):
         assert self.workflow_state is not None

--- a/actions/admin_utils.py
+++ b/actions/admin_utils.py
@@ -1,0 +1,21 @@
+import typing
+
+from django.urls import reverse
+
+if typing.TYPE_CHECKING:
+    from actions.models import Action
+
+
+def change_log_message_url_or_none(action: Action, moderation_enabled: bool = False) -> str | None:
+    plan = action.plan
+    if not plan.features.enable_change_log:
+        return None
+    change_log_create_url = reverse('wagtailsnippets_actions_actionchangelogmessage:add')
+    if moderation_enabled:
+        # Get the revision that was just created for this submission
+        revision = action.latest_revision
+    else:
+        # Get the live revision
+        revision = action.live_revision or action.latest_revision
+    revision_param = f'&revision={revision.pk}' if revision else ''
+    return f'{change_log_create_url}?action={action.pk}{revision_param}'

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -1334,9 +1334,14 @@ class Action(
         # When publishing, Wagtail creates a new revision, but the previous revision's id
         # is stored in the live revision. Currently the change history message is always
         # connected to that previous version, pre-publishing
-        previous_revision_to_published_revision = self.live_revision.content['latest_revision']
+        target_revision = self.live_revision.content['latest_revision']
+        if target_revision is None and self.get_workflow() is None:
+            # For newly created actions there only exists one revision, the live one
+            target_revision = self.live_revision
+        if target_revision is None:
+            return None
         try:
-            return ActionChangeLogMessage.objects.get(action=self, revision=previous_revision_to_published_revision)
+            return ActionChangeLogMessage.objects.get(action=self, revision=target_revision)
         except ActionChangeLogMessage.DoesNotExist:
             return None
 

--- a/actions/tests/test_change_log_graphql.py
+++ b/actions/tests/test_change_log_graphql.py
@@ -1,0 +1,270 @@
+import re
+
+from django.urls import reverse
+
+import pytest
+
+from actions.action_admin import ActionAdmin
+from actions.models.action import ActionChangeLogMessage
+from actions.tests.factories import PlanFactory
+from admin_site.tests.factories import ClientPlanFactory
+from people.tests.factories import PersonFactory
+from users.tests.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+CHANGE_LOG_QUERY = """
+  query ($id: ID!) {
+    action(id: $id) {
+      changeLogMessage {
+        content
+        createdAt
+      }
+    }
+  }
+"""
+
+
+def get_action_create_url():
+    admin = ActionAdmin()
+    return reverse(admin.url_helper.get_action_url_name('create'))
+
+
+def get_action_edit_url(action_pk):
+    admin = ActionAdmin()
+    return reverse(admin.url_helper.get_action_url_name('edit'), kwargs={'instance_pk': action_pk})
+
+
+def get_minimal_action_post_data(*, identifier='test-1', name='Test Action'):
+    return {
+        'identifier': identifier,
+        'name': name,
+        'visibility': 'public',
+        'responsible_parties_primary-TOTAL_FORMS': '0',
+        'responsible_parties_primary-INITIAL_FORMS': '0',
+        'responsible_parties_collaborator-TOTAL_FORMS': '0',
+        'responsible_parties_collaborator-INITIAL_FORMS': '0',
+        'tasks-TOTAL_FORMS': '0',
+        'tasks-INITIAL_FORMS': '0',
+        'links-TOTAL_FORMS': '0',
+        'links-INITIAL_FORMS': '0',
+        'contact_persons_editor-TOTAL_FORMS': '0',
+        'contact_persons_editor-INITIAL_FORMS': '0',
+        'contact_persons_moderator-TOTAL_FORMS': '0',
+        'contact_persons_moderator-INITIAL_FORMS': '0',
+    }
+
+
+def extract_hidden_fields(html):
+    """
+    Extract hidden input fields from the form HTML.
+
+    Returns a dict of {name: value} for all hidden inputs in the form_content block.
+    """
+    matches = re.findall(r'<input\s+type="hidden"\s+name="([^"]+)"\s+value="([^"]*)"', html)
+    return dict(matches)
+
+
+def submit_change_log_message(client, redirect_response, content):
+    """
+    Follow the redirect to the change log form, then POST it.
+
+    Simulates the real browser flow: GET the form page (which renders hidden
+    fields like 'action' and 'revision' via the template), then POST with
+    those hidden fields plus the user-provided content.
+    """
+    form_url = redirect_response['Location']
+    get_response = client.get(form_url)
+    assert get_response.status_code == 200
+
+    hidden_fields = extract_hidden_fields(get_response.content.decode())
+    post_data = {**hidden_fields, 'content': content}
+    change_log_url = reverse('wagtailsnippets_actions_actionchangelogmessage:add')
+    return client.post(change_log_url, data=post_data)
+
+
+def query_change_log_message(graphql_client_query_data, action_id):
+    data = graphql_client_query_data(CHANGE_LOG_QUERY, variables={'id': action_id})
+    return data['action']['changeLogMessage']
+
+
+def make_plan_admin(plan):
+    """Create a user who is a general admin for the given plan."""
+    user = UserFactory.create()
+    PersonFactory.create(user=user, general_admin_plans=[plan])
+    ClientPlanFactory.create(plan=plan)
+    return user
+
+
+class TestChangeLogWithoutModeration:
+    """
+    Test change log messages for plans without moderation workflow.
+
+    Without moderation, Action.save_revision() auto-publishes revisions.
+    The admin redirects to the change log form via get_success_url().
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, client):
+        self.plan = PlanFactory.create()
+        self.plan.features.enable_change_log = True
+        self.plan.features.save()
+        self.user = make_plan_admin(self.plan)
+        client.force_login(self.user)
+        self.client = client
+
+    def test_new_action_change_log_message_visible_via_graphql(
+        self,
+        graphql_client_query_data,
+    ):
+        # Create action via the admin form; save_revision() auto-publishes
+        post_data = get_minimal_action_post_data()
+        response = self.client.post(get_action_create_url(), data=post_data)
+        assert response.status_code == 302
+
+        # The redirect should point to the change log message form
+        assert 'actionchangelogmessage' in response['Location']
+
+        message_text = 'Created new action'
+        submit_change_log_message(self.client, response, message_text)
+
+        action = self.plan.actions.first()
+        assert action is not None
+        msg = ActionChangeLogMessage.objects.get(action=action)
+
+        # The message must be linked to the live revision, not left as NULL
+        assert msg.revision is not None
+        assert msg.revision == action.live_revision
+
+        result = query_change_log_message(graphql_client_query_data, action.id)
+        assert result is not None
+        assert result['content'] == message_text
+
+    def test_edited_action_change_log_message_visible_via_graphql(
+        self,
+        graphql_client_query_data,
+    ):
+        # First create an action via the form
+        post_data = get_minimal_action_post_data()
+        self.client.post(get_action_create_url(), data=post_data)
+        action = self.plan.actions.first()
+        assert action is not None
+
+        # Edit via the edit form (default action='edit', no explicit publish button)
+        edit_post_data = get_minimal_action_post_data(
+            identifier=action.identifier,
+            name='Updated Action Name',
+        )
+        response = self.client.post(get_action_edit_url(action.pk), data=edit_post_data)
+        assert response.status_code == 302
+
+        assert 'actionchangelogmessage' in response['Location']
+
+        message_text = 'Updated the action'
+        submit_change_log_message(self.client, response, message_text)
+
+        action.refresh_from_db()
+        result = query_change_log_message(graphql_client_query_data, action.id)
+        assert result is not None
+        assert result['content'] == message_text
+
+    def test_no_change_log_message_returns_null(
+        self,
+        graphql_client_query_data,
+    ):
+        post_data = get_minimal_action_post_data()
+        response = self.client.post(get_action_create_url(), data=post_data)
+        assert response.status_code == 302
+
+        # Skip the change log message form — don't submit it
+        action = self.plan.actions.first()
+        assert action is not None
+        result = query_change_log_message(graphql_client_query_data, action.id)
+        assert result is None
+
+
+class TestChangeLogWithModeration:
+    """
+    Test change log messages for plans with moderation workflow.
+
+    With moderation, the create view saves a draft. The user then submits
+    from the edit view (action-submit), which starts the workflow and
+    redirects to the change log form. Publishing happens via workflow approval.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, client, workflow_factory):
+        from django.contrib.auth.models import Group
+        from wagtail.models import GroupApprovalTask, WorkflowTask
+
+        self.plan = PlanFactory.create()
+        workflow = workflow_factory()
+        # Use GroupApprovalTask so the admin user can approve
+        group, _ = Group.objects.get_or_create(name='Moderators')
+        approval_task = GroupApprovalTask.objects.create(name='Approve action')
+        approval_task.groups.add(group)  # type: ignore[attr-defined]
+        WorkflowTask.objects.create(workflow=workflow, task=approval_task, sort_order=0)  # type: ignore[attr-defined]
+        self.plan.features.enable_change_log = True
+        self.plan.features.moderation_workflow = workflow
+        self.plan.features.save()
+        self.user = make_plan_admin(self.plan)
+        self.user.groups.add(group)
+        client.force_login(self.user)
+        self.client = client
+
+    def _create_action_and_submit_for_moderation(self, message_text):
+        """Create an action, then submit it for moderation with a change log message."""
+        # Step 1: Create the action (creates draft, no auto-publish)
+        post_data = get_minimal_action_post_data()
+        create_response = self.client.post(get_action_create_url(), data=post_data)
+        assert create_response.status_code == 302
+        action = self.plan.actions.first()
+        assert action is not None
+
+        # Step 2: Submit for moderation from the edit view
+        edit_post_data = get_minimal_action_post_data(
+            identifier=action.identifier,
+            name=action.name,
+        )
+        edit_post_data['action-submit'] = 'true'
+        submit_response = self.client.post(get_action_edit_url(action.pk), data=edit_post_data)
+        assert submit_response.status_code == 302
+        assert 'actionchangelogmessage' in submit_response['Location']
+
+        # Step 3: Submit the change log message
+        submit_change_log_message(self.client, submit_response, message_text)
+        return action
+
+    def test_new_action_message_not_visible_before_publish(
+        self,
+        graphql_client_query_data,
+    ):
+        message_text = 'Submitted new action for review'
+        action = self._create_action_and_submit_for_moderation(message_text)
+
+        # Before publish, the message should not be visible via GraphQL
+        result = query_change_log_message(graphql_client_query_data, action.id)
+        assert result is None
+
+    def test_new_action_message_visible_after_publish(
+        self,
+        graphql_client_query_data,
+    ):
+        message_text = 'Submitted new action for review'
+        action = self._create_action_and_submit_for_moderation(message_text)
+
+        # Approve and publish through the edit form (workflow action)
+        approve_post_data = get_minimal_action_post_data(
+            identifier=action.identifier,
+            name=action.name,
+        )
+        approve_post_data['action-workflow-action'] = 'true'
+        approve_post_data['workflow-action-name'] = 'approve'
+        approve_response = self.client.post(get_action_edit_url(action.pk), data=approve_post_data)
+        assert approve_response.status_code == 302
+
+        action.refresh_from_db()
+        result = query_change_log_message(graphql_client_query_data, action.id)
+        assert result is not None
+        assert result['content'] == message_text

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -37,6 +37,7 @@ from wagtail.admin.views.generic.permissions import PermissionCheckedMixin
 from wagtail.admin.widgets import Button
 from wagtail.admin.widgets.button import ButtonWithDropdown
 from wagtail.log_actions import log
+from wagtail.models import Revision
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import IndexView, SnippetViewSet
 
@@ -56,6 +57,7 @@ from aplans.context_vars import ctx_instance, ctx_request
 from actions.chooser import CategoryTypeChooser, PlanChooser
 from actions.models.action import ActionSchedule
 from admin_site.chooser import ClientChooser
+from admin_site.forms import WatchAdminModelForm
 from admin_site.menu import PlanSpecificSingletonModelMenuItem
 from admin_site.mixins import SuccessUrlEditPageMixin
 from admin_site.models import Client, ClientPlan
@@ -63,7 +65,6 @@ from admin_site.permissions import (
     PlanSpecificSingletonModelPermissionPolicy,
     PlanSpecificSingletonModelSuperuserPermissionPolicy,
 )
-from admin_site.forms import WatchAdminModelForm
 from admin_site.viewsets import (
     BaseChangeLogMessageCreateView,
     BaseChangeLogMessageDeleteView,
@@ -1132,20 +1133,28 @@ class ActionChangeLogMessageCreateView(
             return self.request.POST.get('revision')
         return self.request.GET.get('revision')
 
-    def get_form(self, *args, **kwargs):
-        form = super().get_form(*args, **kwargs)
+    def get_revision(self) -> Revision | None:
         revision_id = self.get_revision_id()
         if revision_id:
-            from wagtail.models import Revision
+            return Revision.objects.filter(pk=revision_id).first()
+        # For newly created actions, the revision wasn't available yet when
+        # the redirect URL was built, so fall back to the live revision.
+        related_obj = self.get_related_object()
+        if related_obj is not None:
+            return related_obj.live_revision
+        return None
 
-            revision = Revision.objects.filter(pk=revision_id).first()
-            if revision:
-                form.instance.revision = revision
+    def get_form(self, *args, **kwargs):
+        form = super().get_form(*args, **kwargs)
+        revision = self.get_revision()
+        if revision:
+            form.instance.revision = revision
         return form
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['revision_id'] = self.get_revision_id()
+        revision = self.get_revision()
+        context['revision_id'] = revision.pk if revision else None
         return context
 
     def check_related_object_permission(self, related_obj: Action | None) -> bool:


### PR DESCRIPTION
## Description
The action change history message feature only supported plans with moderation. Now it supports plans without moderation. And is tested.

## Screenshots/Videos (if applicable)
N/A

## Related issue
N/A

## Requirements, dependencies and related PRs
Kind of related to this https://github.com/kausaltech/kausal-watch/pull/575

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    The unit (integration) tests should be enough

### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented
- [X] **Umbrella plan structure** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
