### PR TITLE
Scope organization query to plan

### DIFF
--- a/orgs/schema.py
+++ b/orgs/schema.py
@@ -118,8 +118,11 @@ class Query:
     organization = graphene.Field(OrganizationNode, id=graphene.ID(required=True))
 
     @staticmethod
-    def resolve_organization(root, info: GQLInfo, id: str) -> Organization | None:
-        return Organization.objects.filter(id=id).first()
+    def resolve_organization(_root, info: GQLInfo, id: str) -> Organization | None:
+        plan = info.context.request_plan
+        if plan is None:
+            return None
+        return Organization.objects.qs.available_for_plan(plan).filter(id=id).first()
 
 
 def _get_organization_mutation_namespace() -> type:

--- a/orgs/schema.py
+++ b/orgs/schema.py
@@ -15,7 +15,7 @@ from kausal_common.organizations.schema import (
 from aplans.graphql_helpers import (
     AdminButtonsMixin,
 )
-from aplans.graphql_types import DjangoNode, register_django_node
+from aplans.graphql_types import DjangoNode, get_plan_from_context, register_django_node
 from aplans.utils import public_fields
 
 from actions.models import Plan
@@ -115,14 +115,23 @@ class OrganizationNode(AdminButtonsMixin, BaseOrganizationNode, DjangoNode[Organ
 
 
 class Query:
-    organization = graphene.Field(OrganizationNode, id=graphene.ID(required=True))
+    organization = graphene.Field(
+        OrganizationNode,
+        id=graphene.ID(required=True),
+        plan=graphene.ID(required=False),
+    )
 
     @staticmethod
-    def resolve_organization(_root, info: GQLInfo, id: str) -> Organization | None:
-        plan = info.context.request_plan
+    def resolve_organization(_root, info: GQLInfo, id: str, plan: str | None = None) -> Organization | None:
         if plan is None:
+            request_plan = info.context.request_plan
+            if request_plan is None or not request_plan.is_visible_for_user(info.context.user):
+                return None
+            plan = request_plan.identifier
+        plan_obj = get_plan_from_context(info, plan)
+        if plan_obj is None:
             return None
-        return Organization.objects.qs.available_for_plan(plan).filter(id=id).first()
+        return Organization.objects.qs.available_for_plan(plan_obj).filter(id=id).first()
 
 
 def _get_organization_mutation_namespace() -> type:

--- a/orgs/tests/test_schema.py
+++ b/orgs/tests/test_schema.py
@@ -100,3 +100,39 @@ def test_resolve_organization_returns_org_in_current_plan(graphql_client_query_d
         headers={'X-Cache-Plan-Identifier': plan.identifier},
     )
     assert response == {'organization': {'id': str(org.id)}}
+
+
+ORGANIZATION_QUERY_WITH_PLAN = """
+    query($id: ID!, $plan: ID!) {
+      organization(id: $id, plan: $plan) {
+        id
+      }
+    }
+"""
+
+
+def test_resolve_organization_with_explicit_plan_arg(graphql_client_query_data):
+    """Passing the plan argument scopes the lookup without relying on the request header."""
+    plan = PlanFactory.create()
+    org = OrganizationFactory.create()
+    plan.related_organizations.add(org)
+
+    response = graphql_client_query_data(
+        ORGANIZATION_QUERY_WITH_PLAN,
+        variables={'id': str(org.id), 'plan': plan.identifier},
+    )
+    assert response == {'organization': {'id': str(org.id)}}
+
+
+def test_resolve_organization_with_explicit_plan_arg_blocks_other_plan_orgs(graphql_client_query_data):
+    """The plan argument enforces scoping even when the header is absent or different."""
+    plan_a = PlanFactory.create()
+    plan_b = PlanFactory.create()
+    org_a = OrganizationFactory.create()
+    plan_a.related_organizations.add(org_a)
+
+    response = graphql_client_query_data(
+        ORGANIZATION_QUERY_WITH_PLAN,
+        variables={'id': str(org_a.id), 'plan': plan_b.identifier},
+    )
+    assert response == {'organization': None}

--- a/orgs/tests/test_schema.py
+++ b/orgs/tests/test_schema.py
@@ -5,8 +5,17 @@ from django.utils import timezone
 import pytest
 
 from actions.tests.factories import PlanFactory
+from orgs.tests.factories import OrganizationFactory
 
 pytestmark = pytest.mark.django_db
+
+ORGANIZATION_QUERY = """
+    query($id: ID!) {
+      organization(id: $id) {
+        id
+      }
+    }
+"""
 
 
 @pytest.mark.parametrize(
@@ -53,3 +62,41 @@ def test_resolve_plans_with_action_responsibilities_visibility(
     }
 
     assert response == expected
+
+
+def test_resolve_organization_blocks_other_plans_orgs(graphql_client_query_data):
+    """An org from one plan must not be returned when queried from another plan's context."""
+    plan_a = PlanFactory.create()
+    plan_b = PlanFactory.create()
+    org_a = OrganizationFactory.create()
+    plan_a.related_organizations.add(org_a)
+
+    response = graphql_client_query_data(
+        ORGANIZATION_QUERY,
+        variables={'id': str(org_a.id)},
+        headers={'X-Cache-Plan-Identifier': plan_b.identifier},
+    )
+    assert response == {'organization': None}
+
+
+def test_resolve_organization_returns_none_without_plan_context(graphql_client_query_data, organization):
+    """Without a plan context (no header / directive), no organization should be returned."""
+    response = graphql_client_query_data(
+        ORGANIZATION_QUERY,
+        variables={'id': str(organization.id)},
+    )
+    assert response == {'organization': None}
+
+
+def test_resolve_organization_returns_org_in_current_plan(graphql_client_query_data):
+    """Within the current plan's context, its own organizations must still resolve."""
+    plan = PlanFactory.create()
+    org = OrganizationFactory.create()
+    plan.related_organizations.add(org)
+
+    response = graphql_client_query_data(
+        ORGANIZATION_QUERY,
+        variables={'id': str(org.id)},
+        headers={'X-Cache-Plan-Identifier': plan.identifier},
+    )
+    assert response == {'organization': {'id': str(org.id)}}

--- a/orgs/tests/test_schema.py
+++ b/orgs/tests/test_schema.py
@@ -22,7 +22,8 @@ def test_resolve_plans_with_action_responsibilities_visibility(
     published_at,
 ):
     """Test plan visibility for unauthenticated users based on publication status."""
-    plan = PlanFactory(published_at=published_at)
+    plan = PlanFactory.create(published_at=published_at)
+    plan.related_organizations.add(organization)
     organization.responsible_for_actions.create(plan=plan)
 
     response = graphql_client_query_data(
@@ -36,6 +37,7 @@ def test_resolve_plans_with_action_responsibilities_visibility(
         }
         """,
         variables={'id': str(organization.id)},
+        headers={'X-Cache-Plan-Identifier': plan.identifier},
     )
 
     expected = {


### PR DESCRIPTION
## Description
The public `organization(id:)` resolver returned any organization by id without plan filtering, so visiting another tenant's hostname with a foreign org id rendered that org's page and related actions. Filter by `available_for_plan` on the request's plan, and return None when no plan context is set.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
After the backend is live, UI should be deployed: https://github.com/kausaltech/kausal-watch-ui/pull/735
When UI is live, we can remove the fallback and make the plan id required.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
