### PR TITLE
Validate GraphQL ID args in actions and organization resolvers

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -572,7 +572,13 @@ class PlanNode(DjangoNode[Plan]):
             else:
                 qs = qs.user_has_staff_role_for(user, plan=root)
         if responsible_organization:
-            qs = qs.filter(responsible_organizations=responsible_organization)
+            try:
+                responsible_organization_id = int(responsible_organization)
+            except ValueError:
+                raise GraphQLError(
+                    f"Invalid 'responsibleOrganization' value: {responsible_organization!r}",
+                ) from None
+            qs = qs.filter(responsible_organizations=responsible_organization_id)
 
         if first is not None and first > 0:
             qs = qs[0:first]

--- a/actions/tests/test_schema.py
+++ b/actions/tests/test_schema.py
@@ -492,6 +492,24 @@ def test_plan_actions_responsible_organization(graphql_client_query_data):
     assert data == expected
 
 
+def test_plan_actions_responsible_organization_invalid_id_returns_graphql_error(graphql_client_query):
+    plan = PlanFactory.create()
+    response = graphql_client_query(
+        """
+        query($plan: ID!, $org: ID!) {
+          plan(id: $plan) {
+            actions(responsibleOrganization: $org) {
+              id
+            }
+          }
+        }
+        """,
+        variables={'plan': plan.identifier, 'org': 'null'},
+    )
+    assert 'errors' in response
+    assert any('responsibleOrganization' in err['message'] for err in response['errors'])
+
+
 def test_attribute_choice_node(
     graphql_client_query_data,
     plan,

--- a/orgs/schema.py
+++ b/orgs/schema.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 import graphene
 from django.db.models.query import Prefetch
+from graphql.error import GraphQLError
 
 import graphene_django_optimizer as gql_optimizer
 
@@ -131,7 +132,11 @@ class Query:
         plan_obj = get_plan_from_context(info, plan)
         if plan_obj is None:
             return None
-        return Organization.objects.qs.available_for_plan(plan_obj).filter(id=id).first()
+        try:
+            org_id = int(id)
+        except ValueError:
+            raise GraphQLError(f"Invalid 'id' value: {id!r}") from None
+        return Organization.objects.qs.available_for_plan(plan_obj).filter(id=org_id).first()
 
 
 def _get_organization_mutation_namespace() -> type:

--- a/orgs/tests/test_schema.py
+++ b/orgs/tests/test_schema.py
@@ -136,3 +136,14 @@ def test_resolve_organization_with_explicit_plan_arg_blocks_other_plan_orgs(grap
         variables={'id': str(org_a.id), 'plan': plan_b.identifier},
     )
     assert response == {'organization': None}
+
+
+def test_resolve_organization_invalid_id_returns_graphql_error(graphql_client_query):
+    """A non-numeric `id` (e.g., the literal string "null") must return a structured GraphQL error."""
+    plan = PlanFactory.create()
+    response = graphql_client_query(
+        ORGANIZATION_QUERY_WITH_PLAN,
+        variables={'id': 'null', 'plan': plan.identifier},
+    )
+    assert 'errors' in response
+    assert any("'id'" in err['message'] for err in response['errors'])


### PR DESCRIPTION
## Description
Reject non-numeric values (e.g. the literal string "null") with a GraphQLError instead of letting Django's ORM raise a ValueError, which surfaced as unhandled 500s in Sentry. `WATCH-BACKEND-36X` `WATCH-BACKEND-4Y6`

This doesn't silence the Sentry issues, but it handles them in a better way (structured GraphQL error instead of unhandled 500)

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/16476/events/d3842d10c3a34c0b88506d02f98fa100/?project=3&referrer=issue_details.related_trace_issue

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
