### PR TITLE
Fix AttributeError when validating notification template formset

### DIFF
--- a/notifications/wagtail_admin.py
+++ b/notifications/wagtail_admin.py
@@ -52,18 +52,29 @@ class BaseTemplateForm(AplansAdminModelForm):
         super().__init__(*args, **kwargs)
 
     def _clean_manually_scheduled_notification_templates(self, formset: BaseFormSet) -> None:
-        for i, item in enumerate(formset.cleaned_data):
-            plan = self.instance.plan
-            new_date = item['date']
-            local_current_date = plan.now_in_local_timezone().date()
+        formset.is_valid()
+        plan = self.instance.plan
+        local_current_date = plan.now_in_local_timezone().date()
+        for form in formset.forms:
+            if not hasattr(form, 'cleaned_data'):
+                continue
+
+            item = form.cleaned_data
+            if item.get('DELETE'):
+                continue
+
+            new_date = item.get('date')
+            if new_date is None:
+                continue
+
             if item['id'] is None:
                 if new_date < local_current_date:
-                    formset[i].add_error('date', _('Cannot schedule a notification for the past'))
+                    form.add_error('date', _('Cannot schedule a notification for the past'))
                 continue
+
             instance = item['id']
             if new_date != instance.date and new_date < local_current_date:
-                # Rescheduling old notification
-                formset[i].add_error('date', _('Cannot reschedule a notification for the past'))
+                form.add_error('date', _('Cannot reschedule a notification for the past'))
 
     def clean(self):
         formset = self.formsets.get('manually_scheduled_notification_templates', None)


### PR DESCRIPTION
## Description
This is an attempt to address two Sentry issues:

- https://sentry.kausal.tech/organizations/kausal/issues/15961
- https://sentry.kausal.tech/organizations/kausal/issues/16214

Fully Claude-made solution, review accordingly. I reviewed the code pretty closely and it looked sensible to me, but I don't know all the intricacies of Django form cleaning and validation. Manually testing the one-off notification the validation seems to work correctly though.

<hr>

The clean() method accessed formset.cleaned_data, which raises AttributeError when any child form has validation errors. Iterate formset.forms instead, skipping invalid or deleted forms, and call formset.is_valid() to ensure the child forms have been cleaned (since ClusterForm validates the parent form before its formsets).

## Screenshots/Videos (if applicable)
\-

## Related issue
- https://sentry.kausal.tech/organizations/kausal/issues/15961
- https://sentry.kausal.tech/organizations/kausal/issues/16214

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
     Go to `Settings -> Notifications -> One-off notifications` and test if you can create manually scheduled notifications and they get validated correctly.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)