### PR TITLE
Fix TypeError when planOrganizations is queried without plan arg

### DIFF
--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -127,11 +127,11 @@ class Query(
     def resolve_plan_organizations(
         self,
         info: GQLInfo,
-        plan: str | None,
-        with_ancestors: bool,
-        for_responsible_parties: bool,
-        for_contact_persons: bool,
-        include_related_plans: bool,
+        plan: str | None = None,
+        with_ancestors: bool = False,
+        for_responsible_parties: bool = True,
+        for_contact_persons: bool = False,
+        include_related_plans: bool = False,
     ) -> Iterable[Organization]:
         plan_obj: Plan | None = get_plan_from_context(info, plan)
         if plan_obj is None or not plan_obj.is_visible_for_user(info.context.user):


### PR DESCRIPTION
## Description
The resolver required `plan` (and other optional fields) as positional args, while the GraphQL schema declared them as optional. Graphene omitted them from the kwargs when clients didn't pass them, raising TypeError. Match the schema by giving each arg a default.

Fixes WATCH-BACKEND-36D

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/11738/?project=3&query=is%3Aunresolved&referrer=issue-stream

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
