### PR TITLE
Include ancestor orgs in person admin's org lookup map

### DIFF
--- a/people/wagtail_admin.py
+++ b/people/wagtail_admin.py
@@ -467,6 +467,17 @@ class PersonAdmin(AplansModelAdmin[Person]):
             return display_for_value(value=False, empty_value_display='', boolean=True)
         return super().get_empty_value_display(field)
 
+    @staticmethod
+    def _get_orgs_for_listing(plan) -> list[Organization]:
+        all_orgs = list(Organization.objects.get_queryset().available_for_plan(plan))
+        ancestor_paths: set[str] = set()
+        for org in all_orgs:
+            ancestor_paths.update(org.path[:pos] for pos in range(org.steplen, len(org.path), org.steplen))
+        if ancestor_paths:
+            seen = {o.pk for o in all_orgs}
+            all_orgs.extend(Organization.objects.filter(path__in=ancestor_paths).exclude(pk__in=seen))
+        return all_orgs
+
     def get_list_display(self, request: HttpRequest):  # noqa: C901
         # get_list_display() gets called a lot, so we cache the results
         if hasattr(request, '_person_list_display'):
@@ -476,8 +487,10 @@ class PersonAdmin(AplansModelAdmin[Person]):
         plan = user.get_active_admin_plan()
 
         # We use a cached and path-indexed version of all organizations to reduce
-        # SQL queries.
-        all_orgs = list(Organization.objects.get_queryset().available_for_plan(plan))
+        # SQL queries. Ancestors are pulled in so get_fully_qualified_name can
+        # resolve parent paths even when an ancestor isn't itself in
+        # `available_for_plan` (e.g., a suborg is plan-related but its parent isn't).
+        all_orgs = self._get_orgs_for_listing(plan)
         orgs_by_path = Organization.make_orgs_by_path(all_orgs)
         orgs_by_id = {org.id: org for org in all_orgs}
 


### PR DESCRIPTION
## Description
The org column built `orgs_by_path` from `available_for_plan(plan)`, which doesn't include ancestors. If a suborg was plan-related but its parent wasn't, `get_fully_qualified_name` returned just the suborg name (no parent prefix) and `_validate_orgs_by_path` emitted a Sentry warning. Pull in the ancestors so the renderer can climb up and the validator sees a complete map.

Also prevents WATCH-BACKEND-3NS

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/14375/?project=3&query=is%3Aunresolved%20assigned%3Ame&referrer=issue-stream

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
