### PR TITLE
Skip avatar thumbnailing when image file is missing

### DIFF
--- a/people/models.py
+++ b/people/models.py
@@ -214,6 +214,9 @@ class Person(SearchableModel[PersonQuerySet], BasePerson, IndirectPlanRelatedMod
                 tn_args['focal_point'] = Rect(*[int(x) for x in self.image_cropping.split(',')])
                 tn_args['crop'] = 30
 
+            if not self.image.storage.exists(self.image.name):
+                return None
+
             try:
                 out_image = get_thumbnailer(self.image).get_thumbnail(tn_args)
             except Exception as e:

--- a/people/tests/test_models.py
+++ b/people/tests/test_models.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -157,6 +158,32 @@ def test_person_change_email_to_deactivated_users_email(plan_admin_user: User):
     assert old_user.is_active
     new_user.refresh_from_db()
     assert not new_user.is_active
+
+
+def test_get_avatar_url_returns_none_when_image_file_missing(rf):
+    """
+    Return None silently when the image field references a file that's not in storage.
+
+    Regression test for WATCH-BACKEND-3NR: InvalidImageFormatError used to be
+    raised and reported to Sentry on every PersonAdmin listing render when an
+    environment carried Person.image paths whose underlying files weren't
+    present in the storage backend (e.g. a CI DB snapshot without media).
+    """
+    person = PersonFactory.create()
+    # Bypass the field descriptor's auto-population of image_width/image_height,
+    # which would otherwise try to open the (nonexistent) file on assignment.
+    person.image.name = 'images/person/nonexistent.jpg'
+    person.image_width = 100
+    person.image_height = 100
+
+    assert person.image.storage.exists(person.image.name) is False
+
+    request = rf.get('/admin/people/person/')
+    with patch('people.models.capture_exception') as mock_capture:
+        result = person.get_avatar_url(request, size='50x50')
+
+    assert result is None
+    mock_capture.assert_not_called()
 
 
 @pytest.mark.parametrize('value', [None, True, False])


### PR DESCRIPTION
## Description
Person.get_avatar_url called get_thumbnailer unconditionally, which raised InvalidImageFormatError and reported to Sentry whenever Person.image pointed at a path missing from the storage backend (e.g. CI deployments with a restored DB but no media). Check storage.exists() first and return None quietly. Fixes WATCH-BACKEND-3NR.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
