### PR TITLE
Add --strip-media-references to destructively_trim_db

### DIFF
--- a/.github/workflows/admin-e2e-tests.yaml
+++ b/.github/workflows/admin-e2e-tests.yaml
@@ -72,7 +72,7 @@ jobs:
           CI: 1
           SECRET_KEY: abcd
           SENTRY_DSN: ${{ vars.SENTRY_DSN }}
-          TEST_DB_FILE: e2e-test-database.sql.gz
+          TEST_DB_FILE: e2e-test-database-180526.sql.gz
           TEST_DB_S3_BUCKET: ${{ inputs.s3_bucket }}
           TEST_DB_S3_ENDPOINT: ${{ inputs.s3_endpoint }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -20,6 +20,7 @@ from actions.models.plan import Plan
 from admin_site.models import Client
 from images.models import AplansRendition
 from orgs.models import Organization
+from people.models import Person
 from request_log.models import LoggedRequest
 from users.models import User
 
@@ -55,6 +56,16 @@ class Command(BaseCommand):
             help='Do not ask for confirmation but delete right away',
         )
         parser.add_argument('--thorough', action='store_true', help='Delete more data, including revision history and audit logs')
+        parser.add_argument(
+            '--strip-media-references',
+            action='store_true',
+            help=(
+                'Null out Person.image paths on surviving rows. Use when the resulting dump will be '
+                'restored into an environment whose media storage will not have the original files '
+                '(e.g. the e2e CI dump). Off by default; when migrating between environments that '
+                'share or sync media separately, leave this off.'
+            ),
+        )
 
     def handle(self, *args, **options):
         if not settings.DEBUG or settings.DEPLOYMENT_TYPE == 'production':
@@ -115,6 +126,8 @@ class Command(BaseCommand):
         #     self.stdout.write("- all entries of Wagtail's model log")
         self.stdout.write('- all thumbnails')
         self.stdout.write('- all sessions')
+        if options['strip_media_references']:
+            self.stdout.write('- avatar image references on remaining Person rows (--strip-media-references)')
         if not options['no_confirm']:
             confirmation = input('Do you want to proceed? [y/N] ').lower()
             if confirmation != 'y':
@@ -126,6 +139,7 @@ class Command(BaseCommand):
                 orgs_to_delete,
                 clients_to_keep=options['exclude_client'],
                 thorough=options['thorough'],
+                strip_media_references=options['strip_media_references'],
             )
         self.stdout.write("Rebuilding Wagtail's reference index...")
         call_command('rebuild_references_index')
@@ -181,6 +195,7 @@ class Command(BaseCommand):
         orgs_to_delete,
         clients_to_keep: list[int] | None = None,
         thorough: bool = False,
+        strip_media_references: bool = False,
     ):
         if clients_to_keep is None:
             clients_to_keep = []
@@ -225,6 +240,14 @@ class Command(BaseCommand):
 
         # Delete all renditions
         self.delete_all(AplansRendition)
+
+        # Optional: clear avatar references on surviving Person rows. The dump
+        # is a pure SQL export; it doesn't bundle the media bucket, so any
+        # Person.image path that survives the trim points at a missing file
+        # once restored into an environment with empty media storage.
+        if strip_media_references:
+            cleared = Person.objects.exclude(image='').update(image='', image_width=None, image_height=None, image_cropping='')
+            self.stdout.write(f'Cleared avatar references on {cleared} Person rows.')
 
         if thorough:
             self.delete_thoroughly()


### PR DESCRIPTION
## Description
The trim command dumps SQL but does not bundle the corresponding media, so any Person.image path that survives the trim points at a missing storage key once the dump is restored elsewhere (e.g. the e2e CI dump, which the backend container pulls from S3 every run and restores into empty FileSystemStorage: see WATCH-BACKEND-3NR).

Add an opt-in --strip-media-references flag that nulls out Person.image on surviving rows. Default off, because the script has been used for non-trim use cases (e.g. migrating to a localized server) where avatars should be preserved. The e2e dump pipeline can pass the flag explicitly.


## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/14376/?project=3&query=is%3Aunresolved%20assigned%3Ame&referrer=issue-stream

## Requirements, dependencies and related PRs
**Follow-up not in this PR:** re-upload the new dump to the S3 bucket referenced by `.github/workflows/admin-e2e-tests.yaml`. Until the dump is regenerated, CI keeps emitting the same Sentry events.


## Additional Notes
Only `Person.image` is stripped. Other `ImageField`s in the model graph (notably `AplansImage.file` via Wagtail's `AbstractImage`) have the same conceptual problem but aren't currently surfacing as errors. If they start to, the same treatment can be added behind the same flag..

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
