### PR TITLE
Fix Action revisions left in has_unpublished_changes=True, latest_revision=None state

### DIFF
--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -13,7 +13,7 @@ from django.db import ProgrammingError, connection, transaction
 from django.db.models import Exists, OuterRef
 from django.db.models.functions import Cast
 from django.db.models.signals import post_delete, post_save
-from reversion.models import Revision as ReversionRevision, Version
+from reversion.models import Revision as ReversionRevision
 from wagtail.models import DraftStateMixin, ModelLogEntry, PageLogEntry, Revision as WagtailRevision
 
 import factory
@@ -28,7 +28,7 @@ from request_log.models import LoggedRequest
 from users.models import User
 
 if TYPE_CHECKING:
-    from django.db.models import Field, Model, QuerySet
+    from django.db.models import Field, Model
 
 
 class Command(BaseCommand):
@@ -153,41 +153,6 @@ class Command(BaseCommand):
             target_field = getattr(pk_field, 'target_field', None)
         return pk_field.clone()
 
-    def _get_live_reversion_revision_ids_for_content_type(self, content_type_id: int) -> QuerySet[int]:
-        model = ContentType.objects.get_for_id(content_type_id).model_class()
-        if model is None:
-            return Version.objects.none().values_list('revision_id', flat=True)
-
-        existing_object_subquery = model._default_manager.filter(
-            pk=Cast(OuterRef('object_id'), output_field=self._get_object_id_cast_field(model))
-        )
-        return (
-            Version.objects.filter(revision__user__isnull=True, content_type_id=content_type_id)
-            .annotate(has_live_object=Exists(existing_object_subquery))
-            .filter(has_live_object=True)
-            .values_list('revision_id', flat=True)
-        )
-
-    def delete_userless_reversion_revisions(self) -> None:
-        queryset = ReversionRevision.objects.filter(user__isnull=True)
-        live_revision_ids: set[int] = set()
-        for content_type_id in Version.objects.filter(revision__user__isnull=True).values_list(
-            'content_type_id', flat=True
-        ).distinct():
-            if content_type_id is None:
-                continue
-            live_revision_ids.update(
-                self._get_live_reversion_revision_ids_for_content_type(content_type_id).iterator(chunk_size=10_000)
-            )
-
-        if not live_revision_ids:
-            _, by_type = queryset.delete()
-            self.print_deleted_instances_by_model(by_type)
-            return
-
-        _, by_type = queryset.exclude(id__in=live_revision_ids).delete()
-        self.print_deleted_instances_by_model(by_type)
-
     def delete_userless_wagtail_revisions(self) -> None:
         # Per content type with a NOT EXISTS subquery, so we never materialise the live-revision
         # ID set in Python memory or pass it as a giant IN predicate on production-sized dumps.
@@ -285,9 +250,7 @@ class Command(BaseCommand):
         # Delete clients without plans unless excluded
         _, by_type = Client.objects.filter(plans__isnull=True).exclude(id__in=clients_to_keep).delete()
         self.print_deleted_instances_by_model(by_type)
-        # Reversion orphan cleanup is intentionally left to thorough mode. Determining
-        # it safely for surviving objects is expensive on large production-sized dumps,
-        # and it is not needed for fixing Wagtail draft-state inconsistencies.
+        # Reversion cleanup is intentionally omitted here — thorough mode handles it with a full purge.
         # Delete Wagtail revisions without users
         self.delete_userless_wagtail_revisions()
         self.repair_has_unpublished_changes()

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -5,12 +5,13 @@ from typing import TYPE_CHECKING
 
 from django.apps import apps
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.sessions.models import Session
 from django.core.management import CommandError, call_command
 from django.core.management.base import BaseCommand
 from django.db import ProgrammingError, connection, transaction
 from django.db.models.signals import post_delete, post_save
-from reversion.models import Revision as ReversionRevision
+from reversion.models import Revision as ReversionRevision, Version
 from wagtail.models import DraftStateMixin, ModelLogEntry, PageLogEntry, Revision as WagtailRevision
 
 import factory
@@ -136,6 +137,46 @@ class Command(BaseCommand):
         _, by_type = model._default_manager.all().delete()
         self.print_deleted_instances_by_model(by_type)
 
+    def _get_existing_object_ids_by_content_type(self, content_type_id: int, object_ids: list[str]) -> set[str]:
+        model = ContentType.objects.get_for_id(content_type_id).model_class()
+        if model is None:
+            return set()
+        return {str(pk) for pk in model._default_manager.filter(pk__in=object_ids).values_list('pk', flat=True)}
+
+    def delete_userless_reversion_revisions(self) -> None:
+        queryset = ReversionRevision.objects.filter(user__isnull=True)
+        referenced_revision_ids: set[int] = set()
+        for content_type_id in queryset.values_list('version__content_type_id', flat=True).distinct():
+            if content_type_id is None:
+                continue
+            version_queryset = Version.objects.filter(revision__user__isnull=True, content_type_id=content_type_id)
+            object_ids = list(version_queryset.values_list('object_id', flat=True).distinct())
+            existing_object_ids = self._get_existing_object_ids_by_content_type(content_type_id, object_ids)
+            if not existing_object_ids:
+                continue
+            referenced_revision_ids.update(
+                version_queryset.filter(object_id__in=existing_object_ids).values_list('revision_id', flat=True)
+            )
+
+        _, by_type = queryset.exclude(id__in=referenced_revision_ids).delete()
+        self.print_deleted_instances_by_model(by_type)
+
+    def delete_userless_wagtail_revisions(self) -> None:
+        queryset = WagtailRevision.objects.filter(user__isnull=True)
+        revision_ids_to_keep: set[int] = set()
+        for content_type_id in queryset.values_list('content_type_id', flat=True).distinct():
+            content_type_queryset = queryset.filter(content_type_id=content_type_id)
+            object_ids = list(content_type_queryset.values_list('object_id', flat=True).distinct())
+            existing_object_ids = self._get_existing_object_ids_by_content_type(content_type_id, object_ids)
+            if not existing_object_ids:
+                continue
+            revision_ids_to_keep.update(
+                content_type_queryset.filter(object_id__in=existing_object_ids).values_list('id', flat=True)
+            )
+
+        _, by_type = queryset.exclude(id__in=revision_ids_to_keep).delete()
+        self.print_deleted_instances_by_model(by_type)
+
     def delete_thoroughly(self):
         from django.contrib.admin.models import LogEntry
 
@@ -151,9 +192,9 @@ class Command(BaseCommand):
             AuthIDToken = None  # type: ignore[misc,assignment]
 
         # Delete Reversion revisions without users
-        self.delete_all(ReversionRevision)
+        self.delete_userless_reversion_revisions()
         # Delete Wagtail revisions without users
-        self.delete_all(WagtailRevision)
+        self.delete_userless_wagtail_revisions()
         self.repair_has_unpublished_changes()
         # Delete Wagtail model log entries without users
         self.delete_all(ModelLogEntry)
@@ -205,11 +246,9 @@ class Command(BaseCommand):
         _, by_type = Client.objects.filter(plans__isnull=True).exclude(id__in=clients_to_keep).delete()
         self.print_deleted_instances_by_model(by_type)
         # Delete Reversion revisions without users
-        _, by_type = ReversionRevision.objects.filter(user__isnull=True).delete()
-        self.print_deleted_instances_by_model(by_type)
+        self.delete_userless_reversion_revisions()
         # Delete Wagtail revisions without users
-        _, by_type = WagtailRevision.objects.filter(user__isnull=True).delete()
-        self.print_deleted_instances_by_model(by_type)
+        self.delete_userless_wagtail_revisions()
         self.repair_has_unpublished_changes()
         # Delete Wagtail model log entries without users
         _, by_type = ModelLogEntry.objects.filter(user__isnull=True).delete()

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -168,21 +168,6 @@ class Command(BaseCommand):
             .values_list('revision_id', flat=True)
         )
 
-    def _get_live_wagtail_revision_ids_for_content_type(self, content_type_id: int) -> QuerySet[int]:
-        model = ContentType.objects.get_for_id(content_type_id).model_class()
-        if model is None:
-            return WagtailRevision.objects.none().values_list('id', flat=True)
-
-        existing_object_subquery = model._default_manager.filter(
-            pk=Cast(OuterRef('object_id'), output_field=self._get_object_id_cast_field(model))
-        )
-        return (
-            WagtailRevision.objects.filter(user__isnull=True, content_type_id=content_type_id)
-            .annotate(has_live_object=Exists(existing_object_subquery))
-            .filter(has_live_object=True)
-            .values_list('id', flat=True)
-        )
-
     def delete_userless_reversion_revisions(self) -> None:
         queryset = ReversionRevision.objects.filter(user__isnull=True)
         live_revision_ids: set[int] = set()
@@ -204,20 +189,34 @@ class Command(BaseCommand):
         self.print_deleted_instances_by_model(by_type)
 
     def delete_userless_wagtail_revisions(self) -> None:
-        queryset = WagtailRevision.objects.filter(user__isnull=True)
-        live_revision_ids: set[int] = set()
-        for content_type_id in queryset.values_list('content_type_id', flat=True).distinct():
-            live_revision_ids.update(
-                self._get_live_wagtail_revision_ids_for_content_type(content_type_id).iterator(chunk_size=10_000)
+        # Per content type with a NOT EXISTS subquery, so we never materialise the live-revision
+        # ID set in Python memory or pass it as a giant IN predicate on production-sized dumps.
+        base_queryset = WagtailRevision.objects.filter(user__isnull=True)
+        content_type_ids = list(base_queryset.values_list('content_type_id', flat=True).distinct())
+        aggregated: dict[str, int] = {}
+
+        for content_type_id in content_type_ids:
+            model = (
+                ContentType.objects.get_for_id(content_type_id).model_class()
+                if content_type_id is not None
+                else None
             )
+            queryset = base_queryset.filter(content_type_id=content_type_id)
+            if model is None:
+                _, by_type = queryset.delete()
+            else:
+                existing_object_subquery = model._default_manager.filter(
+                    pk=Cast(OuterRef('object_id'), output_field=self._get_object_id_cast_field(model))
+                )
+                _, by_type = (
+                    queryset.annotate(has_live_object=Exists(existing_object_subquery))
+                    .filter(has_live_object=False)
+                    .delete()
+                )
+            for model_name, n in by_type.items():
+                aggregated[model_name] = aggregated.get(model_name, 0) + n
 
-        if not live_revision_ids:
-            _, by_type = queryset.delete()
-            self.print_deleted_instances_by_model(by_type)
-            return
-
-        _, by_type = queryset.exclude(id__in=live_revision_ids).delete()
-        self.print_deleted_instances_by_model(by_type)
+        self.print_deleted_instances_by_model(aggregated)
 
     def delete_thoroughly(self):
         from django.contrib.admin.models import LogEntry

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -198,10 +198,9 @@ class Command(BaseCommand):
         except ImportError:
             AuthIDToken = None  # type: ignore[misc,assignment]
 
-        # Delete Reversion revisions without users
-        self.delete_userless_reversion_revisions()
-        # Delete Wagtail revisions without users
-        self.delete_userless_wagtail_revisions()
+        # Delete all revision history in thorough mode.
+        self.delete_all(ReversionRevision)
+        self.delete_all(WagtailRevision)
         self.repair_has_unpublished_changes()
         # Delete Wagtail model log entries without users
         self.delete_all(ModelLogEntry)

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.sessions.models import Session
 from django.core.management import CommandError, call_command
@@ -10,7 +11,7 @@ from django.core.management.base import BaseCommand
 from django.db import ProgrammingError, connection, transaction
 from django.db.models.signals import post_delete, post_save
 from reversion.models import Revision as ReversionRevision
-from wagtail.models import ModelLogEntry, PageLogEntry, Revision as WagtailRevision
+from wagtail.models import DraftStateMixin, ModelLogEntry, PageLogEntry, Revision as WagtailRevision
 
 import factory
 from easy_thumbnails.models import Source, Thumbnail
@@ -153,6 +154,7 @@ class Command(BaseCommand):
         self.delete_all(ReversionRevision)
         # Delete Wagtail revisions without users
         self.delete_all(WagtailRevision)
+        self.repair_has_unpublished_changes()
         # Delete Wagtail model log entries without users
         self.delete_all(ModelLogEntry)
         self.delete_all(PlanScopedModelLogEntry)
@@ -208,6 +210,7 @@ class Command(BaseCommand):
         # Delete Wagtail revisions without users
         _, by_type = WagtailRevision.objects.filter(user__isnull=True).delete()
         self.print_deleted_instances_by_model(by_type)
+        self.repair_has_unpublished_changes()
         # Delete Wagtail model log entries without users
         _, by_type = ModelLogEntry.objects.filter(user__isnull=True).delete()
         self.print_deleted_instances_by_model(by_type)
@@ -232,3 +235,20 @@ class Command(BaseCommand):
     def print_deleted_instances_by_model(self, by_type):
         for model_name, n in by_type.items():
             self.stdout.write(f'Deleted {n} instances of {model_name}.')
+
+    def repair_has_unpublished_changes(self) -> None:
+        # `latest_revision` is `on_delete=SET_NULL`, so deleting Revision rows leaves
+        # DraftStateMixin instances with `latest_revision=NULL` while `has_unpublished_changes`
+        # stays at whatever it was — possibly producing the impossible state
+        # `has_unpublished_changes=True AND latest_revision IS NULL`. Fix the discrepancy here.
+        for model in apps.get_models():
+            if not issubclass(model, DraftStateMixin):
+                continue
+            updated_count = model._default_manager.filter(
+                latest_revision__isnull=True,
+                has_unpublished_changes=True,
+            ).update(has_unpublished_changes=False)
+            if updated_count:
+                self.stdout.write(
+                    f'Reset has_unpublished_changes on {updated_count} {model.__name__} instances with no latest_revision.'
+                )

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -10,6 +10,8 @@ from django.contrib.sessions.models import Session
 from django.core.management import CommandError, call_command
 from django.core.management.base import BaseCommand
 from django.db import ProgrammingError, connection, transaction
+from django.db.models import Exists, OuterRef
+from django.db.models.functions import Cast
 from django.db.models.signals import post_delete, post_save
 from reversion.models import Revision as ReversionRevision, Version
 from wagtail.models import DraftStateMixin, ModelLogEntry, PageLogEntry, Revision as WagtailRevision
@@ -26,7 +28,7 @@ from request_log.models import LoggedRequest
 from users.models import User
 
 if TYPE_CHECKING:
-    from django.db.models import Model
+    from django.db.models import Field, Model, QuerySet
 
 
 class Command(BaseCommand):
@@ -114,7 +116,6 @@ class Command(BaseCommand):
             self.stdout.write('- all plan-scoped model/page log entries')
             self.stdout.write('- all Wagtail PageLogEntry instances')
         else:
-            self.stdout.write("- orphaned Reversion Revision instances without a corresponding User anymore")
             self.stdout.write("- orphaned Wagtail Revision instances without a corresponding User anymore")
             self.stdout.write("- all Wagtail ModelLogEntry instances that don't have a corresponding User anymore")
         self.stdout.write('- all logged requests')
@@ -144,44 +145,78 @@ class Command(BaseCommand):
         _, by_type = model._default_manager.all().delete()
         self.print_deleted_instances_by_model(by_type)
 
-    def _get_existing_object_ids_by_content_type(self, content_type_id: int, object_ids: list[str]) -> set[str]:
+    def _get_object_id_cast_field(self, model: type[Model]) -> Field:
+        pk_field: Field = model._meta.pk
+        target_field = getattr(pk_field, 'target_field', None)
+        while target_field is not None:
+            pk_field = target_field
+            target_field = getattr(pk_field, 'target_field', None)
+        return pk_field.clone()
+
+    def _get_live_reversion_revision_ids_for_content_type(self, content_type_id: int) -> QuerySet[int]:
         model = ContentType.objects.get_for_id(content_type_id).model_class()
         if model is None:
-            return set()
-        return {str(pk) for pk in model._default_manager.filter(pk__in=object_ids).values_list('pk', flat=True)}
+            return Version.objects.none().values_list('revision_id', flat=True)
+
+        existing_object_subquery = model._default_manager.filter(
+            pk=Cast(OuterRef('object_id'), output_field=self._get_object_id_cast_field(model))
+        )
+        return (
+            Version.objects.filter(revision__user__isnull=True, content_type_id=content_type_id)
+            .annotate(has_live_object=Exists(existing_object_subquery))
+            .filter(has_live_object=True)
+            .values_list('revision_id', flat=True)
+        )
+
+    def _get_live_wagtail_revision_ids_for_content_type(self, content_type_id: int) -> QuerySet[int]:
+        model = ContentType.objects.get_for_id(content_type_id).model_class()
+        if model is None:
+            return WagtailRevision.objects.none().values_list('id', flat=True)
+
+        existing_object_subquery = model._default_manager.filter(
+            pk=Cast(OuterRef('object_id'), output_field=self._get_object_id_cast_field(model))
+        )
+        return (
+            WagtailRevision.objects.filter(user__isnull=True, content_type_id=content_type_id)
+            .annotate(has_live_object=Exists(existing_object_subquery))
+            .filter(has_live_object=True)
+            .values_list('id', flat=True)
+        )
 
     def delete_userless_reversion_revisions(self) -> None:
         queryset = ReversionRevision.objects.filter(user__isnull=True)
-        referenced_revision_ids: set[int] = set()
-        for content_type_id in queryset.values_list('version__content_type_id', flat=True).distinct():
+        live_revision_ids: set[int] = set()
+        for content_type_id in Version.objects.filter(revision__user__isnull=True).values_list(
+            'content_type_id', flat=True
+        ).distinct():
             if content_type_id is None:
                 continue
-            version_queryset = Version.objects.filter(revision__user__isnull=True, content_type_id=content_type_id)
-            object_ids = list(version_queryset.values_list('object_id', flat=True).distinct())
-            existing_object_ids = self._get_existing_object_ids_by_content_type(content_type_id, object_ids)
-            if not existing_object_ids:
-                continue
-            referenced_revision_ids.update(
-                version_queryset.filter(object_id__in=existing_object_ids).values_list('revision_id', flat=True)
+            live_revision_ids.update(
+                self._get_live_reversion_revision_ids_for_content_type(content_type_id).iterator(chunk_size=10_000)
             )
 
-        _, by_type = queryset.exclude(id__in=referenced_revision_ids).delete()
+        if not live_revision_ids:
+            _, by_type = queryset.delete()
+            self.print_deleted_instances_by_model(by_type)
+            return
+
+        _, by_type = queryset.exclude(id__in=live_revision_ids).delete()
         self.print_deleted_instances_by_model(by_type)
 
     def delete_userless_wagtail_revisions(self) -> None:
         queryset = WagtailRevision.objects.filter(user__isnull=True)
-        revision_ids_to_keep: set[int] = set()
+        live_revision_ids: set[int] = set()
         for content_type_id in queryset.values_list('content_type_id', flat=True).distinct():
-            content_type_queryset = queryset.filter(content_type_id=content_type_id)
-            object_ids = list(content_type_queryset.values_list('object_id', flat=True).distinct())
-            existing_object_ids = self._get_existing_object_ids_by_content_type(content_type_id, object_ids)
-            if not existing_object_ids:
-                continue
-            revision_ids_to_keep.update(
-                content_type_queryset.filter(object_id__in=existing_object_ids).values_list('id', flat=True)
+            live_revision_ids.update(
+                self._get_live_wagtail_revision_ids_for_content_type(content_type_id).iterator(chunk_size=10_000)
             )
 
-        _, by_type = queryset.exclude(id__in=revision_ids_to_keep).delete()
+        if not live_revision_ids:
+            _, by_type = queryset.delete()
+            self.print_deleted_instances_by_model(by_type)
+            return
+
+        _, by_type = queryset.exclude(id__in=live_revision_ids).delete()
         self.print_deleted_instances_by_model(by_type)
 
     def delete_thoroughly(self):
@@ -251,8 +286,9 @@ class Command(BaseCommand):
         # Delete clients without plans unless excluded
         _, by_type = Client.objects.filter(plans__isnull=True).exclude(id__in=clients_to_keep).delete()
         self.print_deleted_instances_by_model(by_type)
-        # Delete Reversion revisions without users
-        self.delete_userless_reversion_revisions()
+        # Reversion orphan cleanup is intentionally left to thorough mode. Determining
+        # it safely for surviving objects is expensive on large production-sized dumps,
+        # and it is not needed for fixing Wagtail draft-state inconsistencies.
         # Delete Wagtail revisions without users
         self.delete_userless_wagtail_revisions()
         self.repair_has_unpublished_changes()

--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -107,9 +107,16 @@ class Command(BaseCommand):
             client_names = Client.objects.filter(id__in=options['exclude_client']).values_list('name', flat=True)
             client_message += f' and are not among the following: {", ".join(client_names)}'
         self.stdout.write(client_message)
-        self.stdout.write("- all Reversion Revision instances that don't have a corresponding User anymore")
-        self.stdout.write("- all Wagtail Revision instances that don't have a corresponding User anymore")
-        self.stdout.write("- all Wagtail ModelLogEntry instances that don't have a corresponding User anymore")
+        if options['thorough']:
+            self.stdout.write('- all Reversion Revision instances')
+            self.stdout.write('- all Wagtail Revision instances')
+            self.stdout.write('- all Wagtail ModelLogEntry instances')
+            self.stdout.write('- all plan-scoped model/page log entries')
+            self.stdout.write('- all Wagtail PageLogEntry instances')
+        else:
+            self.stdout.write("- orphaned Reversion Revision instances without a corresponding User anymore")
+            self.stdout.write("- orphaned Wagtail Revision instances without a corresponding User anymore")
+            self.stdout.write("- all Wagtail ModelLogEntry instances that don't have a corresponding User anymore")
         self.stdout.write('- all logged requests')
         # if not options['keep_page_log']:
         #     self.stdout.write("- all entries of Wagtail's page log")

--- a/actions/tests/test_destructively_trim_db.py
+++ b/actions/tests/test_destructively_trim_db.py
@@ -1,0 +1,29 @@
+from wagtail.models import Revision
+
+import pytest
+
+from actions.management.commands.destructively_trim_db import Command
+from actions.tests.factories import ActionFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_delete_userless_wagtail_revisions_keeps_existing_drafts():
+    action = ActionFactory.create()
+    revision = action.save_revision(user=None)
+
+    Command().delete_userless_wagtail_revisions()
+
+    action.refresh_from_db()
+    assert action.latest_revision_id == revision.id
+    assert Revision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_userless_wagtail_revisions_deletes_orphaned_drafts():
+    action = ActionFactory.create()
+    revision = action.save_revision(user=None)
+    action.delete()
+
+    Command().delete_userless_wagtail_revisions()
+
+    assert not Revision.objects.filter(id=revision.id).exists()

--- a/actions/tests/test_destructively_trim_db.py
+++ b/actions/tests/test_destructively_trim_db.py
@@ -1,7 +1,6 @@
 from unittest.mock import call, patch
 
-import reversion
-from reversion.models import Revision as ReversionRevision, Version
+from reversion.models import Revision as ReversionRevision
 from wagtail.models import Revision
 
 import pytest
@@ -54,47 +53,6 @@ def test_delete_userless_wagtail_revisions_handles_multi_table_page_subclasses(p
     page.refresh_from_db()
     assert page.latest_revision_id == revision.id
     assert Revision.objects.filter(id=revision.id).exists()
-
-
-def test_delete_userless_reversion_revisions_keeps_existing_objects():
-    action = ActionFactory.create()
-    with reversion.create_revision():
-        reversion.add_to_revision(action)
-
-    revision = ReversionRevision.objects.get()
-
-    Command().delete_userless_reversion_revisions()
-
-    assert ReversionRevision.objects.filter(id=revision.id).exists()
-    assert Version.objects.filter(revision_id=revision.id, object_id=str(action.pk)).exists()
-
-
-def test_delete_userless_reversion_revisions_keeps_revision_if_any_version_still_exists():
-    kept_action = ActionFactory.create()
-    deleted_action = ActionFactory.create(plan=kept_action.plan)
-    with reversion.create_revision():
-        reversion.add_to_revision(kept_action)
-        reversion.add_to_revision(deleted_action)
-
-    revision = ReversionRevision.objects.get()
-    deleted_action.delete()
-
-    Command().delete_userless_reversion_revisions()
-
-    assert ReversionRevision.objects.filter(id=revision.id).exists()
-
-
-def test_delete_userless_reversion_revisions_deletes_orphaned_objects():
-    action = ActionFactory.create()
-    with reversion.create_revision():
-        reversion.add_to_revision(action)
-
-    revision = ReversionRevision.objects.get()
-    action.delete()
-
-    Command().delete_userless_reversion_revisions()
-
-    assert not ReversionRevision.objects.filter(id=revision.id).exists()
 
 
 def test_delete_thoroughly_deletes_all_revision_history():

--- a/actions/tests/test_destructively_trim_db.py
+++ b/actions/tests/test_destructively_trim_db.py
@@ -1,3 +1,6 @@
+from unittest.mock import call, patch
+
+from reversion.models import Revision as ReversionRevision
 from wagtail.models import Revision
 
 import pytest
@@ -27,3 +30,13 @@ def test_delete_userless_wagtail_revisions_deletes_orphaned_drafts():
     Command().delete_userless_wagtail_revisions()
 
     assert not Revision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_thoroughly_deletes_all_revision_history():
+    with (
+        patch.object(Command, 'delete_all') as delete_all,
+        patch.object(Command, 'repair_has_unpublished_changes'),
+    ):
+        Command().delete_thoroughly()
+
+    delete_all.assert_has_calls([call(ReversionRevision), call(Revision)], any_order=False)

--- a/actions/tests/test_destructively_trim_db.py
+++ b/actions/tests/test_destructively_trim_db.py
@@ -1,12 +1,14 @@
 from unittest.mock import call, patch
 
-from reversion.models import Revision as ReversionRevision
+import reversion
+from reversion.models import Revision as ReversionRevision, Version
 from wagtail.models import Revision
 
 import pytest
 
 from actions.management.commands.destructively_trim_db import Command
 from actions.tests.factories import ActionFactory
+from pages.tests.factories import CategoryTypePageFactory, StaticPageFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -30,6 +32,69 @@ def test_delete_userless_wagtail_revisions_deletes_orphaned_drafts():
     Command().delete_userless_wagtail_revisions()
 
     assert not Revision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_userless_wagtail_revisions_handles_page_subclasses(plan_with_pages):
+    page = StaticPageFactory.create(parent=plan_with_pages.root_page)
+    revision = page.save_revision(user=None)
+
+    Command().delete_userless_wagtail_revisions()
+
+    page.refresh_from_db()
+    assert page.latest_revision_id == revision.id
+    assert Revision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_userless_wagtail_revisions_handles_multi_table_page_subclasses(plan_with_pages, category_type):
+    page = CategoryTypePageFactory.create(parent=plan_with_pages.root_page, category_type=category_type)
+    revision = page.save_revision(user=None)
+
+    Command().delete_userless_wagtail_revisions()
+
+    page.refresh_from_db()
+    assert page.latest_revision_id == revision.id
+    assert Revision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_userless_reversion_revisions_keeps_existing_objects():
+    action = ActionFactory.create()
+    with reversion.create_revision():
+        reversion.add_to_revision(action)
+
+    revision = ReversionRevision.objects.get()
+
+    Command().delete_userless_reversion_revisions()
+
+    assert ReversionRevision.objects.filter(id=revision.id).exists()
+    assert Version.objects.filter(revision_id=revision.id, object_id=str(action.pk)).exists()
+
+
+def test_delete_userless_reversion_revisions_keeps_revision_if_any_version_still_exists():
+    kept_action = ActionFactory.create()
+    deleted_action = ActionFactory.create(plan=kept_action.plan)
+    with reversion.create_revision():
+        reversion.add_to_revision(kept_action)
+        reversion.add_to_revision(deleted_action)
+
+    revision = ReversionRevision.objects.get()
+    deleted_action.delete()
+
+    Command().delete_userless_reversion_revisions()
+
+    assert ReversionRevision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_userless_reversion_revisions_deletes_orphaned_objects():
+    action = ActionFactory.create()
+    with reversion.create_revision():
+        reversion.add_to_revision(action)
+
+    revision = ReversionRevision.objects.get()
+    action.delete()
+
+    Command().delete_userless_reversion_revisions()
+
+    assert not ReversionRevision.objects.filter(id=revision.id).exists()
 
 
 def test_delete_thoroughly_deletes_all_revision_history():

--- a/copying/main.py
+++ b/copying/main.py
@@ -991,6 +991,17 @@ def _copy_instance_revision(
     clone_visitor: CloneVisitor,
     update_references_visitor: UpdateReferencesVisitor,
 ) -> None:
+    def clear_impossible_draft_state() -> None:
+        update_fields = []
+        if instance.latest_revision is not None:
+            instance.latest_revision = None
+            update_fields.append('latest_revision')
+        if isinstance(instance, DraftStateMixin) and instance.has_unpublished_changes:
+            instance.has_unpublished_changes = False
+            update_fields.append('has_unpublished_changes')
+        if update_fields:
+            instance.save(update_fields=update_fields)
+
     try:
         if instance.latest_revision is None:
             return
@@ -1004,12 +1015,7 @@ def _copy_instance_revision(
         logger.opt(exception=True).warning(
             f'Failed to deserialize revision for {model_name} pk={instance.pk}, skipping ({type(exc).__name__}: {exc})'
         )
-        instance.latest_revision = None
-        if isinstance(instance, DraftStateMixin):
-            instance.has_unpublished_changes = False
-            instance.save(update_fields=['latest_revision', 'has_unpublished_changes'])
-        else:
-            instance.save(update_fields=['latest_revision'])
+        clear_impossible_draft_state()
         return
     # as_object() sets pk from the revision's content_object (the original), so fix it to the copy's pk
     rev_obj.pk = instance.pk
@@ -1043,6 +1049,9 @@ def copy_revisions(clone_visitor: CloneVisitor):
         if isinstance(instance, Page):
             continue  # Page revisions handled by UpdateReferencesVisitor.update_page_draft()
         if instance.latest_revision is None:
+            if isinstance(instance, DraftStateMixin) and instance.has_unpublished_changes:
+                instance.has_unpublished_changes = False
+                instance.save(update_fields=['has_unpublished_changes'])
             continue
         _copy_instance_revision(instance, clone_visitor, update_references_visitor)
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -19,7 +19,7 @@ from django.db.models import Field, ForeignKey, Manager, ManyToOneRel, Model, Q,
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel, get_all_child_relations
 from wagtail.fields import RichTextField, StreamField
-from wagtail.models import Page, Revision, RevisionMixin, Site
+from wagtail.models import DraftStateMixin, Page, Revision, RevisionMixin, Site
 from wagtail.models.i18n import Locale
 from wagtail.models.media import Collection
 from wagtail.models.reference_index import ReferenceIndex
@@ -1005,7 +1005,11 @@ def _copy_instance_revision(
             f'Failed to deserialize revision for {model_name} pk={instance.pk}, skipping ({type(exc).__name__}: {exc})'
         )
         instance.latest_revision = None
-        instance.save(update_fields=['latest_revision'])
+        if isinstance(instance, DraftStateMixin):
+            instance.has_unpublished_changes = False
+            instance.save(update_fields=['latest_revision', 'has_unpublished_changes'])
+        else:
+            instance.save(update_fields=['latest_revision'])
         return
     # as_object() sets pk from the revision's content_object (the original), so fix it to the copy's pk
     rev_obj.pk = instance.pk

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -585,6 +585,17 @@ def test_model_without_revision_is_not_affected(plan_with_pages, action):
     assert action_copy.latest_revision is None
 
 
+def test_copying_repairs_impossible_draft_state_without_revision(plan_with_pages, action):
+    action.has_unpublished_changes = True
+    action.save(update_fields=['has_unpublished_changes'])
+
+    plan_copy = copy_plan(plan_with_pages)
+    action_copy = plan_copy.actions.get()
+
+    assert action_copy.latest_revision is None
+    assert not action_copy.has_unpublished_changes
+
+
 def test_report_type_attribute_field_references_are_updated(plan_with_pages):
     """When copying a plan, attribute_type references in ReportType.fields are updated to the copy."""
     action_ct = ContentType.objects.get_for_model(Action)


### PR DESCRIPTION
## Description
Claude-conjured code.

<hr>

The `latest_revision` FK uses `on_delete=SET_NULL`, so deleting a Revision row leaves `has_unpublished_changes` untouched.

- `destructively_trim_db`: after bulk-deleting Wagtail revisions, walk all `DraftStateMixin` models and reset `has_unpublished_changes=False` where `latest_revision IS NULL`.
- `copying/main.py`: in the revision-deserialization exception branch of `_copy_instance_revision`, also clear `has_unpublished_changes` when clearing `latest_revision`, so the copy doesn't inherit the impossible state.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Slack](https://kausaltech.slack.com/archives/C07R954EV7D/p1778587230284149)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
##### Manual testing instructions
1. Find a plan that is using moderation
2. Edit an action and click `Save draft`
3. Delete the user (and maybe also corresponding person) that made the draft
4. Run destructively_trim_db excluding the plan: `python manage.py destructively_trim_db --exclude-plan <plan-identifier>`
5. The output should say somewhere in there that an Action's `has_unpublished_changes` has been reset:
```
[...]
Reset has_unpublished_changes on 1 Action instances with no latest_revision.
[...]
```

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
