### PR TITLE
Log AplansImage form saves even when commit=False

### DIFF
--- a/images/apps.py
+++ b/images/apps.py
@@ -10,17 +10,18 @@ class ImagesConfig(AppConfig):
 
         monkeypatch_chooser()
 
-        from wagtail.images import permissions
 
+        from wagtail.images import permissions
+        from wagtail.images.forms import BaseImageForm
+
+        # Register post_save signal handler for audit logging.
         # Register graphql types overrides for grapple
-        from . import schema  # noqa: F401
+        from . import schema, signals  # noqa: F401
 
         # monkeypatch new permission policy
         from .permissions import permission_policy
 
         permissions.permission_policy = permission_policy
-
-        from wagtail.images.forms import BaseImageForm
 
         BaseImageForm.permission_policy = permission_policy
 

--- a/images/forms.py
+++ b/images/forms.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 from wagtail.images.forms import BaseImageForm
-from wagtail.log_actions import log
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -13,6 +12,9 @@ if TYPE_CHECKING:
     from django.db.models.fields.files import FieldFile
 
     from images.models import AplansImage
+
+
+_FORM_USER_ATTR = '_aplans_image_form_user'
 
 
 class _OldFileDeleteGuard:
@@ -60,6 +62,11 @@ class AplansImageForm(BaseImageForm):
         super().__init__(*args, **kwargs)
 
     def save(self, commit=True):
+        # Tag the instance so the post_save signal can log the save regardless
+        # of whether commit=True (model saved here) or commit=False (Wagtail's
+        # multi-upload AddView saves the model itself afterwards).
+        setattr(self.instance, _FORM_USER_ATTR, self.user)
+
         instance: AplansImage
         if 'file' in self.changed_data and self.original_file:
             with _guarded_storage(self.original_file, self.instance):
@@ -67,12 +74,4 @@ class AplansImageForm(BaseImageForm):
         else:
             instance = super().save(commit=commit)
 
-        if commit is False:
-            return instance
-
-        log(
-            instance=instance,
-            action='file.created_or_updated',
-            user=self.user,
-        )
         return instance

--- a/images/signals.py
+++ b/images/signals.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from wagtail.log_actions import log
+
+from images.forms import _FORM_USER_ATTR
+from images.models import AplansImage
+
+_UNSET = object()
+
+
+@receiver(post_save, sender=AplansImage)
+def log_form_save(sender, instance, **kwargs):
+    """
+    Log a file.created_or_updated audit entry whenever an AplansImage is saved through AplansImageForm.
+
+    AplansImageForm tags the instance with the form's user before delegating to
+    super().save(); when the model is then saved (either by the form itself or
+    by Wagtail's multi-upload AddView via instance.save() after form.save(commit=False)),
+    this handler picks up the tag and writes the log entry exactly once.
+    """
+    user = getattr(instance, _FORM_USER_ATTR, _UNSET)
+    if user is _UNSET:
+        return
+    delattr(instance, _FORM_USER_ATTR)
+    log(instance=instance, action='file.created_or_updated', user=user)

--- a/images/tests/test_form_audit_log.py
+++ b/images/tests/test_form_audit_log.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.files.images import ImageFile
+from django.core.files.uploadedfile import SimpleUploadedFile
+from wagtail.images.forms import get_image_form
+
+import PIL.Image
+import pytest
+
+from audit_logging.models import PlanScopedModelLogEntry
+from images.models import AplansImage
+from images.tests.factories import AplansImageFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    PIL.Image.new('RGBA', (8, 8), 'white').save(buf, 'PNG')
+    return buf.getvalue()
+
+
+def _png_upload(filename: str) -> SimpleUploadedFile:
+    return SimpleUploadedFile(filename, _png_bytes(), content_type='image/png')
+
+
+def _png_image_file(filename: str) -> ImageFile:
+    return ImageFile(BytesIO(_png_bytes()), name=filename)
+
+
+def _log_entries_for(image: AplansImage):
+    return PlanScopedModelLogEntry.objects.filter(
+        content_type=ContentType.objects.get_for_model(AplansImage),
+        object_id=str(image.pk),
+        action='file.created_or_updated',
+    )
+
+
+class TestAplansImageFormAuditLog:
+    def test_multi_upload_pattern_creates_log_entry(self, superuser, plan):
+        """
+        Regression test for the multi-upload log skip.
+
+        Wagtail's multi-upload AddView calls form.save(commit=False) and then
+        saves the instance itself. Before the fix, AplansImageForm.save's
+        early-return on commit=False meant log() was never called for these
+        creations — so the multi-upload code path produced rows with no
+        audit-log entries at all.
+        """
+        form_class = get_image_form(AplansImage)
+        form = form_class(
+            data={'title': 'new image', 'collection': plan.root_collection.id},
+            files={'file': _png_upload('test.png')},
+            user=superuser,
+        )
+        assert form.is_valid(), form.errors
+
+        image = form.save(commit=False)
+        image.uploaded_by_user = superuser
+        image.save()
+
+        assert _log_entries_for(image).count() == 1
+
+    def test_standard_form_save_creates_one_log_entry(self, superuser, plan):
+        """
+        Standard edit path (commit=True).
+
+        Must still produce exactly one log entry — the fix moves logging into a post_save signal handler, so we guard
+        against accidental double-logging or no-logging.
+        """
+        image = AplansImageFactory.create(
+            collection=plan.root_collection,
+            file=_png_image_file('orig.png'),
+        )
+        entries_before = _log_entries_for(image).count()
+
+        form_class = get_image_form(AplansImage)
+        form = form_class(
+            data={'title': 'renamed', 'collection': image.collection_id},
+            instance=image,
+            user=superuser,
+        )
+        assert form.is_valid(), form.errors
+        form.save()
+
+        assert _log_entries_for(image).count() == entries_before + 1
+
+    def test_direct_save_does_not_log(self, plan):
+        """
+        Save that bypasses the form.
+
+        A save that bypasses the form (e.g. from a management command, signal,
+        or factory) must not emit a file.created_or_updated entry — only form
+        saves should.
+        """
+        image = AplansImageFactory.create(
+            collection=plan.root_collection,
+            file=_png_image_file('direct.png'),
+        )
+        entries_before = _log_entries_for(image).count()
+
+        image.title = 'renamed by code'
+        image.save()
+
+        assert _log_entries_for(image).count() == entries_before

--- a/images/tests/test_forms.py
+++ b/images/tests/test_forms.py
@@ -141,14 +141,11 @@ class TestAplansImageFormSave:
             'cleaned up — the guard should only suppress same-path deletes.'
         )
 
-    def test_create_without_original_file_works(self):
+    def test_create_without_original_file_works(self, plan):
         # Building a form without an existing image (no original_file) must
         # still work — the save() override guards against original_file being
         # empty.
-        from wagtail.models import Collection
-
-        collection = Collection.get_first_root_node()
-        assert collection is not None
+        collection = plan.root_collection
 
         ImageForm = get_image_form(AplansImage)
         form = ImageForm(


### PR DESCRIPTION
`AplansImageForm.save` returned early on `commit=False` before calling `log()`, which meant every image created through Wagtail's multi-upload `AddView` (it always uses `form.save(commit=False)` then saves the instance itself) had no `file.created_or_updated` audit-log entry -- leaving these rows invisible in `PlanScopedModelLogEntry`.

Tag the instance with the form's user in `save()` and emit the log entry from a `post_save` signal handler. The log now fires exactly once on the next save of the form-bound instance, whether the form saves it or the caller does.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
