### PR TITLE
Skip copy of collection items whose source file is missing

### DIFF
--- a/copying/main.py
+++ b/copying/main.py
@@ -24,6 +24,7 @@ from wagtail.models.i18n import Locale
 from wagtail.models.media import Collection
 from wagtail.models.reference_index import ReferenceIndex
 
+import sentry_sdk
 from loguru import logger
 from relations_iterator import AbstractVisitor, ConfigurableRelationTree, RelationTreeIterator  # type: ignore
 
@@ -38,6 +39,8 @@ from content.apps import create_site_general_content
 from copying.utils import (
     get_foreign_keys,
     get_generic_foreign_keys,
+    remove_reference_from_streamfield_block,
+    remove_rich_text_reference_from_field,
     temp_disconnect_signal,
     update_rich_text_reference_in_field,
     update_streamfield_block,
@@ -322,6 +325,8 @@ class CloneVisitor(AbstractVisitor):
         self.copies = {}
         self._copy_keys: set[tuple[type[Model], Any]] = set()
         self._copy_to_original_pk: dict[tuple[type[Model], Any], Any] = {}
+        self._skipped_reference_targets: set[tuple[type[Model], Any]] = set()
+        self._reference_holders_to_drop: dict[tuple[type[Model], Any], Model] = {}
         self.removed_links = {}
         self._pledge_translation_keys: dict[Any, Any] = {}
         self.supersede_original_plan = supersede_original_plan
@@ -346,6 +351,44 @@ class CloneVisitor(AbstractVisitor):
         """Get the PK of the original instance for the given copy."""
         return self._copy_to_original_pk[(type(copy), copy.pk)]
 
+    def register_skipped_reference_target(self, instance: Model) -> None:
+        """Record that references to the given original instance should be removed from copies."""
+        self._skipped_reference_targets.add((type(instance), instance.pk))
+
+    def register_skipped_reference_target_key(self, model: type[Model], pk: Any) -> None:
+        """Record that references to the given original model and PK should be removed from copies."""
+        self._skipped_reference_targets.add((model, pk))
+
+    def is_skipped_reference_target(self, instance: Model) -> bool:
+        """Return true if references to the original instance should be removed from copies."""
+        return (type(instance), instance.pk) in self._skipped_reference_targets
+
+    def register_reference_holder_to_drop(self, instance: Model) -> None:
+        """Mark a copy for deletion because it holds a non-nullable reference to a skipped target."""
+        self._reference_holders_to_drop[(type(instance), instance.pk)] = instance
+
+    def drop_reference_holders(self) -> None:
+        """
+        Delete copies that hold non-nullable references to skipped targets.
+
+        Such copies cannot be made self-contained (the reference can neither be remapped to a copy nor cleared), so we
+        drop them entirely rather than leave them pointing at the source plan. This runs only after all references have
+        been updated, so that saving a holder's parent (e.g. a category owning a cluster of icons) cannot re-create the
+        row we are about to delete.
+        """
+        for (model, pk), instance in self._reference_holders_to_drop.items():
+            logger.warning(
+                f'Dropping copied {model.__name__} {pk}: it holds a non-nullable reference to an object whose source '
+                f'file was missing, so the copy cannot be made self-contained'
+            )
+            copy_key = (model, pk)
+            if copy_key in self._copy_to_original_pk:
+                original_pk = self._copy_to_original_pk.pop(copy_key)
+                self.copies.pop((model, original_pk), None)
+                self._copy_keys.discard(copy_key)
+            instance.delete()
+        self._reference_holders_to_drop.clear()
+
     def register_copy[M: Model](self, original: M, copy: M):
         """
         Store that `copy` is a copy of `original`.
@@ -360,6 +403,15 @@ class CloneVisitor(AbstractVisitor):
         self.copies[key] = copy
         self._copy_keys.add((type(copy), copy.pk))
         self._copy_to_original_pk[(type(copy), copy.pk)] = original.pk
+
+    def unregister_copy(self, copy: Model) -> None:
+        """Remove copy bookkeeping after a just-created copy row has been deleted."""
+        copy_key = (type(copy), copy.pk)
+        original_pk = self._copy_to_original_pk.pop(copy_key)
+        original_key = (type(copy), original_pk)
+        registered_copy = self.copies.pop(original_key)
+        assert registered_copy is copy
+        self._copy_keys.remove(copy_key)
 
     def visit(self, node: TreeNode):
         """
@@ -713,6 +765,44 @@ class UpdateReferencesVisitor(AbstractVisitor):
                 update_fields.add(field_name)
         return list(update_fields)
 
+    def _drop_or_report_unclearable_reference(self, holder: Model, field_name: str) -> None:
+        """
+        Handle a non-nullable reference from a copy to a skipped target that can be neither remapped nor cleared.
+
+        Persisted copies are registered to be dropped (see `CloneVisitor.drop_reference_holders()`), since a row that
+        cannot exist without the missing reference must not be left pointing at the source plan. Non-persisted holders
+        (e.g. revision drafts, which have no row to delete) keep the reference, which is logged and reported.
+        """
+        if holder.pk is not None and self.clone_visitor.is_copy(holder):
+            self.clone_visitor.register_reference_holder_to_drop(holder)
+            return
+        message = (
+            f"Cannot remove skipped reference in non-nullable field '{field_name}' of "
+            f'{type(holder).__name__} {holder.pk}; leaving cross-plan reference in place'
+        )
+        logger.warning(message)
+        sentry_sdk.capture_message(message, level='warning')
+
+    def _clear_skipped_foreign_key(self, instance: Model, fk: Field | GenericForeignKey) -> list[str]:
+        """
+        Clear a foreign key that points at a deliberately skipped copy target.
+
+        Returns the names of the fields that were modified (empty if the key could not be cleared). A generic foreign
+        key can always be set to None; a plain foreign key only if it is nullable. A non-nullable foreign key cannot be
+        cleared, so the holding copy is dropped instead.
+        """
+        if isinstance(fk, GenericForeignKey):
+            setattr(instance, fk.name, None)
+            logger.trace(f"Cleared skipped generic foreign key '{fk.name}' of {type(instance).__name__} {instance.pk}")
+            return [fk.ct_field, fk.fk_field]
+        assert isinstance(fk, ForeignKey)
+        if fk.null:
+            setattr(instance, fk.name, None)
+            logger.trace(f"Cleared skipped foreign key '{fk.name}' of {type(instance).__name__} {instance.pk}")
+            return [fk.name]
+        self._drop_or_report_unclearable_reference(instance, fk.name)
+        return []
+
     def update_foreign_keys(self, instance: Model) -> list[str]:
         update_fields = []
         for fk in self.get_references(instance):
@@ -724,7 +814,9 @@ class UpdateReferencesVisitor(AbstractVisitor):
                 try:
                     copy = self.clone_visitor.get_copy(related_object)
                 except KeyError:
-                    if self.clone_visitor.is_copy(related_object):
+                    if self.clone_visitor.is_skipped_reference_target(related_object):
+                        update_fields += self._clear_skipped_foreign_key(instance, fk)
+                    elif self.clone_visitor.is_copy(related_object):
                         logger.trace(
                             f"Trying to update foreign key '{fk.name}' of {type(instance).__name__} {instance.pk} "
                             f'that is already a copy: {type(related_object).__name__} {related_object.pk}'
@@ -858,6 +950,91 @@ class UpdateReferencesVisitor(AbstractVisitor):
         )
         return True
 
+    def _remove_stream_field_reference(
+        self,
+        from_object: Model,
+        to_object: Model,
+        source_field: Field,
+        content_path: str,
+    ) -> bool:
+        field_name, *content_path_rest = content_path.split('.')
+        assert field_name == source_field.name
+        assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
+        remove_reference_from_streamfield_block(from_object, field_name, content_path_rest, to_object)
+        return True
+
+    def _remove_many_to_one_rel_reference(
+        self,
+        from_object: Model,
+        to_object: Model,
+        source_field: ManyToOneRel,
+        content_path: str,
+    ) -> bool:
+        if not isinstance(from_object, ClusterableModel):
+            return False
+        field_name, id, *content_path_rest = content_path.split('.')
+        assert field_name == source_field.name
+        assert field_name == source_field.related_name
+        manager = getattr(from_object, field_name)
+        assert isinstance(manager, Manager)
+        manager.get_object_list()  # type: ignore[attr-defined]
+        referencing_object = manager.get(id=id)
+        assert self.clone_visitor.is_copy(referencing_object)
+        child_field_name, *child_content_path = content_path_rest
+        child_field = referencing_object._meta.get_field(child_field_name)
+        if isinstance(child_field, StreamField):
+            remove_reference_from_streamfield_block(referencing_object, child_field_name, child_content_path, to_object)
+            return True
+        if isinstance(child_field, RichTextField):
+            assert child_content_path == ['']
+            remove_rich_text_reference_from_field(referencing_object, child_field_name, to_object)
+            return True
+        if isinstance(child_field, (ForeignKey, GenericForeignKey)):
+            # A GenericForeignKey has no `null` attribute, but it can always be cleared by setting it to None.
+            if isinstance(child_field, GenericForeignKey) or child_field.null:
+                setattr(referencing_object, child_field_name, None)
+                return True
+            self._drop_or_report_unclearable_reference(referencing_object, child_field_name)
+            return False
+        raise TypeError('Unexpected child field type')
+
+    def _remove_foreign_key_reference(
+        self,
+        from_object: Model,
+        source_field: ForeignKey,
+    ) -> bool:
+        if source_field.null:
+            setattr(from_object, source_field.name, None)
+            return True
+        self._drop_or_report_unclearable_reference(from_object, source_field.name)
+        return False
+
+    def _remove_rich_text_reference(
+        self,
+        from_object: Model,
+        to_object: Model,
+        source_field: RichTextField,
+        content_path: str,
+    ) -> bool:
+        field_name, *content_path_rest = content_path.split('.')
+        assert field_name == source_field.name
+        assert content_path_rest == ['']
+        assert from_object.pk is None or self.clone_visitor.is_copy(from_object)
+        remove_rich_text_reference_from_field(from_object, field_name, to_object)
+        return True
+
+    def remove_reference(self, from_object: Model, to_object: Model, source_field: Field, content_path: str) -> bool:
+        """Remove a reference to an object that was deliberately skipped during copying."""
+        if isinstance(source_field, StreamField):
+            return self._remove_stream_field_reference(from_object, to_object, source_field, content_path)
+        if isinstance(source_field, ManyToOneRel):
+            return self._remove_many_to_one_rel_reference(from_object, to_object, source_field, content_path)
+        if isinstance(source_field, ForeignKey):
+            return self._remove_foreign_key_reference(from_object, source_field)
+        if isinstance(source_field, RichTextField):
+            return self._remove_rich_text_reference(from_object, to_object, source_field, content_path)
+        raise TypeError('Unexpected source field type')
+
     def update_reference(self, from_object: Model, to_object: Model, source_field: Field, content_path: str) -> bool:
         """
         Update the reference to `to_object` in the field `source_field` of `from_object` at `content_path`.
@@ -870,6 +1047,8 @@ class UpdateReferencesVisitor(AbstractVisitor):
         try:
             copy = self.clone_visitor.get_copy(to_object)
         except KeyError:
+            if self.clone_visitor.is_skipped_reference_target(to_object):
+                return self.remove_reference(from_object, to_object, source_field, content_path)
             if self.clone_visitor.is_copy(to_object):
                 logger.trace(
                     f'Trying to update reference in {type(from_object).__name__} {from_object.pk} at path '
@@ -1058,10 +1237,12 @@ def copy_collection_with_contents(collection: Collection, clone_visitor: CloneVi
         # time bomb that would orphan both rows the next time either is deleted.
         if not file.storage.exists(file.name):
             logger.warning(
-                f'Skipping copy of collection item {image_or_document}: '
-                f'source file {file.name!r} does not exist on storage'
+                f'Skipping copy of collection item {image_or_document}: source file {file.name!r} does not exist on storage'
             )
+            clone_visitor.register_skipped_reference_target(image_or_document)
             continue
+        original_model = type(image_or_document)
+        original_pk = image_or_document.pk
         visit_tree(image_or_document, {}, clone_visitor)
         image_or_document.collection = collection
         try:
@@ -1073,6 +1254,8 @@ def copy_collection_with_contents(collection: Collection, clone_visitor: CloneVi
             # the read. Roll back the row that visit_tree just created so we
             # don't leave a duplicate-path time bomb behind.
             logger.warning(f'File copy failed for collection item {image_or_document}: {e}')
+            clone_visitor.unregister_copy(image_or_document)
+            clone_visitor.register_skipped_reference_target_key(original_model, original_pk)
             image_or_document.delete()
             continue
         image_or_document.save()
@@ -1385,6 +1568,9 @@ def update_references(
     for at in attribute_types:
         visit_tree(at, ATTRIBUTE_TYPE_CLONE_STRUCTURE, update_references_visitor)
     update_references_in_indicators(indicators, clone_visitor)
+    # Drop copies that hold non-nullable references to skipped targets only now that every reference has been updated,
+    # so that saving a holder's parent earlier in this function cannot re-create the row we are about to delete.
+    clone_visitor.drop_reference_holders()
 
 
 def update_references_in_page_tree_with_translations(root_page: Page, update_references_visitor: UpdateReferencesVisitor):

--- a/copying/main.py
+++ b/copying/main.py
@@ -1050,16 +1050,31 @@ def copy_collection_with_contents(collection: Collection, clone_visitor: CloneVi
     )
     visit_tree(collection, {}, clone_visitor)
     for image_or_document in images_or_documents:
-        visit_tree(image_or_document, {}, clone_visitor)
-        image_or_document.collection = collection
         file = image_or_document.file
         assert file.name is not None
+        # If the source file is missing on storage, don't create a copy row.
+        # Otherwise the new row would point at the (still-missing) source path,
+        # which means source and copy share an S3 key — a duplicate-path
+        # time bomb that would orphan both rows the next time either is deleted.
+        if not file.storage.exists(file.name):
+            logger.warning(
+                f'Skipping copy of collection item {image_or_document}: '
+                f'source file {file.name!r} does not exist on storage'
+            )
+            continue
+        visit_tree(image_or_document, {}, clone_visitor)
+        image_or_document.collection = collection
         try:
             content_file = ContentFile(file.read(), name=file.name)
             filename = file.name.split('/')[-1]
             file.save(filename, content_file)
         except FileNotFoundError as e:
-            logger.warning(f'Could not copy file of collection item {image_or_document}: {e}')
+            # Race: source file disappeared between the existence check and
+            # the read. Roll back the row that visit_tree just created so we
+            # don't leave a duplicate-path time bomb behind.
+            logger.warning(f'File copy failed for collection item {image_or_document}: {e}')
+            image_or_document.delete()
+            continue
         image_or_document.save()
 
 

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
+from django.db.models.fields.files import FieldFile
 from wagtail.models import Page, Revision
 from wagtail.models.reference_index import ReferenceIndex
 from wagtail.rich_text import RichText
@@ -10,7 +11,7 @@ import pytest
 
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
-from actions.models.category import CategoryType
+from actions.models.category import Category, CategoryIcon, CategoryType
 from actions.models.plan import Plan
 from actions.tests.factories import (
     ActionContactFactory,
@@ -236,6 +237,91 @@ def test_image_with_missing_source_file_is_not_copied(plan_with_pages):
         collection=plan_copy.root_collection,
         title='image-with-missing-file',
     ).exists()
+
+
+def test_references_to_missing_source_file_are_removed_from_copied_content(plan_with_pages, action):
+    image = AplansImageFactory.create(
+        collection=plan_with_pages.root_collection,
+        title='image-with-missing-file',
+    )
+    doc = AplansDocumentFactory.create(
+        collection=plan_with_pages.root_collection,
+        title='document-with-missing-file',
+    )
+    action.description = html_with_references([image, doc])
+    action.save(update_fields=['description'])
+    image.file.storage.delete(image.file.name)
+    doc.file.storage.delete(doc.file.name)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    action_copy = plan_copy.actions.get()
+    assert action_copy.description == f'<p data-block-key="foo">{doc.title}</p>'
+    assert str(image.pk) not in action_copy.description
+    assert str(doc.pk) not in action_copy.description
+    assert not AplansImage.objects.filter(collection=plan_copy.root_collection, title=image.title).exists()
+    assert not AplansDocument.objects.filter(collection=plan_copy.root_collection, title=doc.title).exists()
+
+
+def test_copy_mapping_is_dropped_when_file_disappears_before_read(plan_with_pages, action, monkeypatch):
+    image = AplansImageFactory.create(
+        collection=plan_with_pages.root_collection,
+        title='image-with-racy-file',
+    )
+    action.description = html_with_references([image])
+    action.save(update_fields=['description'])
+    original_open = FieldFile.open
+
+    def raise_for_image(field_file, mode='rb'):
+        if field_file.name == image.file.name:
+            raise FileNotFoundError(image.file.name)
+        return original_open(field_file, mode)
+
+    monkeypatch.setattr(FieldFile, 'open', raise_for_image)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    action_copy = plan_copy.actions.get()
+    assert action_copy.description == '<p data-block-key="foo"></p>'
+    assert str(image.pk) not in action_copy.description
+    assert not AplansImage.objects.filter(collection=plan_copy.root_collection, title=image.title).exists()
+
+
+def test_plain_image_fk_to_missing_source_file_is_cleared(plan_with_pages, action):
+    image = AplansImageFactory.create(
+        collection=plan_with_pages.root_collection,
+        title='image-fk-with-missing-file',
+    )
+    action.image = image
+    action.save(update_fields=['image'])
+    image.file.storage.delete(image.file.name)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    # Re-fetch from the database: the `plan_copy` returned by `copy_plan` carries a relation cache populated during
+    # cloning, so `plan_copy.actions` would otherwise return stale pre-update instances.
+    action_copy = Action.objects.get(plan=plan_copy)
+    assert action_copy.image_id is None
+    assert not AplansImage.objects.filter(collection=plan_copy.root_collection, title=image.title).exists()
+
+
+def test_icon_with_non_nullable_image_fk_to_missing_source_file_is_dropped(plan_with_pages):
+    category_type = CategoryTypeFactory.create(plan=plan_with_pages)
+    category = Category.objects.create(type=category_type, identifier='cat-with-icon', name='Category with icon')
+    image = AplansImageFactory.create(
+        collection=plan_with_pages.root_collection,
+        title='icon-image-with-missing-file',
+    )
+    CategoryIcon.objects.create(category=category, image=image, language='en')
+    image.file.storage.delete(image.file.name)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    category_copy = Category.objects.get(type__plan=plan_copy, identifier='cat-with-icon')
+    # The icon's image FK is non-nullable, so the copied icon must be dropped rather than left pointing at the
+    # source plan's image (a CASCADE FK would otherwise couple the clone to the source plan).
+    assert not category_copy.icons.exists()
+    assert not CategoryIcon.objects.filter(image=image).exclude(category=category).exists()
 
 
 def test_document_copy_in_collection_copy(plan_with_pages):

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -213,6 +213,31 @@ def test_image_copy_in_collection_copy(plan_with_pages):
     assert image_copy.collection == plan_copy.root_collection
 
 
+def test_image_with_missing_source_file_is_not_copied(plan_with_pages):
+    """
+    Regression test for shared-path orphans.
+
+    If the source file is missing on storage, copying it would produce a new
+    row pointing at the still-missing source path — a duplicate-path time bomb
+    that orphans both rows the next time either is deleted. The copy must be
+    skipped entirely.
+    """
+    image = AplansImageFactory.create(
+        collection=plan_with_pages.root_collection,
+        title='image-with-missing-file',
+    )
+    # Simulate external deletion of the underlying file.
+    image.file.storage.delete(image.file.name)
+    assert not image.file.storage.exists(image.file.name)
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    assert not AplansImage.objects.filter(
+        collection=plan_copy.root_collection,
+        title='image-with-missing-file',
+    ).exists()
+
+
 def test_document_copy_in_collection_copy(plan_with_pages):
     doc = AplansDocumentFactory.create(collection=plan_with_pages.root_collection, title='doc')
     plan_copy = copy_plan(plan_with_pages)

--- a/copying/utils.py
+++ b/copying/utils.py
@@ -94,6 +94,44 @@ def update_reference_in_raw_data(
     return raw_data
 
 
+def remove_reference_from_raw_data(
+    raw_data: Any,
+    content_path: list[str],
+    old_object: Model,
+) -> Any:
+    """Remove a reference at a certain path in raw streamfield data."""
+    if not content_path:
+        if raw_data == old_object.pk:
+            return None
+        if isinstance(raw_data, str):
+            return remove_reference_from_html(raw_data, old_object)
+        return raw_data
+    path_element, *remaining_elements = content_path
+    if isinstance(raw_data, list):
+        for child in raw_data:
+            if child['id'] == path_element or child['type'] == path_element:
+                child['value'] = remove_reference_from_raw_data(child['value'], remaining_elements, old_object)
+    elif isinstance(raw_data, dict):
+        raw_data[path_element] = remove_reference_from_raw_data(raw_data[path_element], remaining_elements, old_object)
+    else:
+        raise TypeError(f'raw_data has unexpected type {type(raw_data)}')
+    return raw_data
+
+
+def remove_reference_from_streamfield_block(
+    instance: Model,
+    field_name: str,
+    content_path: list[str],
+    old_object: Model,
+) -> None:
+    """Remove a reference to an object at a certain path in a given streamfield."""
+    stream_value = getattr(instance, field_name)
+    raw_data = list(stream_value.raw_data)
+    remove_reference_from_raw_data(raw_data, content_path, old_object)
+    stream_value.raw_data = raw_data
+    setattr(instance, field_name, StreamValue(stream_value.stream_block, stream_value.raw_data, is_lazy=True))
+
+
 def update_streamfield_block(
     instance: Model,
     field_name: str,
@@ -120,6 +158,52 @@ def update_streamfield_block(
     # once the BoundBlock representation has been accessed, any changes to fields within raw data will not
     # propagate back to the BoundBlock
     setattr(instance, field_name, StreamValue(stream_value.stream_block, stream_value.raw_data, is_lazy=True))
+
+
+def _tag_references_object(tag: str, referenced_object: Model) -> bool:
+    return re.search(rf'\bid="{referenced_object.pk}"', tag) is not None
+
+
+def remove_reference_from_html(
+    html: str,
+    referenced_object: Model,
+) -> str:
+    """Remove a reference to an image, document, or indicator from a given HTML string."""
+    if isinstance(referenced_object, AplansDocument):
+        pattern = r'<a\s+[^>]*linktype="document"[^>]*>.*?</a>'
+
+        def replace_document_reference(match: re.Match) -> str:
+            tag = match.group(0)
+            if not _tag_references_object(tag, referenced_object):
+                return tag
+            inner_match = re.match(r'<a\s+[^>]*>(?P<inner>.*?)</a>', tag, flags=re.DOTALL)
+            assert inner_match is not None
+            return inner_match.group('inner')
+
+        return re.sub(pattern, replace_document_reference, html, flags=re.DOTALL)
+    if isinstance(referenced_object, AplansImage):
+        pattern = r'<embed\s+[^>]*embedtype="image"[^>]*/>'
+
+        def replace_image_reference(match: re.Match) -> str:
+            tag = match.group(0)
+            if not _tag_references_object(tag, referenced_object):
+                return tag
+            return ''
+
+        return re.sub(pattern, replace_image_reference, html)
+    if isinstance(referenced_object, Indicator):
+        pattern = r'<a\s+[^>]*linktype="indicator"[^>]*>.*?</a>'
+
+        def replace_indicator_reference(match: re.Match) -> str:
+            tag = match.group(0)
+            if not _tag_references_object(tag, referenced_object):
+                return tag
+            inner_match = re.match(r'<a\s+[^>]*>(?P<inner>.*?)</a>', tag, flags=re.DOTALL)
+            assert inner_match is not None
+            return inner_match.group('inner')
+
+        return re.sub(pattern, replace_indicator_reference, html, flags=re.DOTALL)
+    raise TypeError(f'referenced_object has unexpected type {type(referenced_object)}')
 
 
 def update_reference_in_html(
@@ -186,4 +270,15 @@ def update_rich_text_reference_in_field(
     """Update a reference to an image, document, or indicator in a given rich text field."""
     old_value: str = getattr(instance, field_name)
     new_value = update_reference_in_html(old_value, old_referenced_object, new_referenced_object)
+    setattr(instance, field_name, new_value)
+
+
+def remove_rich_text_reference_from_field(
+    instance: Model,
+    field_name: str,
+    referenced_object: Model,
+) -> None:
+    """Remove a reference to an image, document, or indicator from a given rich text field."""
+    old_value: str = getattr(instance, field_name)
+    new_value = remove_reference_from_html(old_value, referenced_object)
     setattr(instance, field_name, new_value)


### PR DESCRIPTION
When the source file is missing on storage, `copy_collection_with_contents` would still call `visit_tree` and save a new row pointing at the source's path, then catch the `FileNotFoundError` from `file.read()` and continue. The result was a new `AplansImage` row sharing its file path with the source — a duplicate-path "time bomb" that orphans both rows the next time either is deleted via standard admin (`post_delete_file_cleanup` deletes the underlying file).

Check `storage.exists` upfront and skip the row entirely. Keep the `FileNotFoundError` catch for the race where the file disappears between the check and the read; in that case delete the just-created row.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
