### PR TITLE
Prevent AplansImageForm from deleting just-uploaded file

### DIFF
--- a/images/forms.py
+++ b/images/forms.py
@@ -1,12 +1,37 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from wagtail.images.forms import BaseImageForm
 from wagtail.log_actions import log
 
 if TYPE_CHECKING:
+    from django.core.files.storage import Storage
+
     from images.models import AplansImage
+
+
+class _OldFileDeleteGuard:
+    """
+    Storage proxy that suppresses delete() when the targeted path matches the form instance's current file path.
+
+    Used to neutralise BaseImageForm.save's commit branch, which unconditionally
+    deletes the original file from storage after upload. If storage.get_available_name
+    reused the original path for the new upload (because the original was missing
+    on storage), that delete destroys the just-uploaded file.
+    """
+
+    def __init__(self, wrapped: Storage, instance: AplansImage) -> None:
+        self._wrapped = wrapped
+        self._instance = instance
+
+    def delete(self, name: str) -> None:
+        if name == self._instance.file.name:
+            return
+        self._wrapped.delete(name)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
 
 
 class AplansImageForm(BaseImageForm):
@@ -16,7 +41,17 @@ class AplansImageForm(BaseImageForm):
         super().__init__(*args, **kwargs)
 
     def save(self, commit=True):
-        instance: AplansImage = super().save(commit=commit)
+        original_file = self.original_file
+        if original_file is None:
+            instance: AplansImage = super().save(commit=commit)
+        else:
+            unwrapped_storage = original_file.storage
+            original_file.storage = _OldFileDeleteGuard(unwrapped_storage, self.instance)
+            try:
+                instance = super().save(commit=commit)
+            finally:
+                original_file.storage = unwrapped_storage
+
         if commit is False:
             return instance
 

--- a/images/tests/test_forms.py
+++ b/images/tests/test_forms.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+from django.core.files.images import ImageFile
+from django.core.files.uploadedfile import SimpleUploadedFile
+from wagtail.images.forms import get_image_form
+
+import PIL.Image
+import pytest
+
+from images.models import AplansImage
+from images.tests.factories import AplansImageFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _png_bytes() -> bytes:
+    buf = BytesIO()
+    PIL.Image.new('RGBA', (8, 8), 'white').save(buf, 'PNG')
+    return buf.getvalue()
+
+
+def _png_upload(filename: str) -> SimpleUploadedFile:
+    return SimpleUploadedFile(filename, _png_bytes(), content_type='image/png')
+
+
+def _png_image_file(filename: str) -> ImageFile:
+    return ImageFile(BytesIO(_png_bytes()), name=filename)
+
+
+class TestAplansImageFormSelfDeleteTrap:
+    def test_save_preserves_new_file_when_original_was_missing(self, plan_admin_user, plan):
+        """
+        Regression test for the self-delete trap.
+
+        When the original file is missing on storage at the time of re-upload
+        and the new upload uses the same basename, storage.get_available_name
+        will reuse the original path. BaseImageForm.save's commit branch would
+        then delete what was just uploaded. AplansImageForm.save must prevent
+        this.
+        """
+        image = AplansImageFactory.create(
+            collection=plan.root_collection,
+            file=_png_image_file('ace34991.png'),
+        )
+        storage = image.file.storage
+        original_path = image.file.name
+        assert storage.exists(original_path)
+
+        # Simulate external deletion of the original file.
+        storage.delete(original_path)
+        assert not storage.exists(original_path)
+
+        # Re-upload using the same basename. get_available_name reuses the path
+        # because the original is missing — so without the fix, BaseImageForm
+        # would delete the file it just uploaded.
+        basename = original_path.rsplit('/', 1)[-1]
+        form_class = get_image_form(AplansImage)
+        form = form_class(
+            data={'title': image.title, 'collection': image.collection_id},
+            files={'file': _png_upload(basename)},
+            instance=image,
+            user=plan_admin_user,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+
+        assert storage.exists(saved.file.name), (
+            'AplansImageForm.save deleted the file it just uploaded'
+        )
+
+    def test_save_deletes_old_file_when_path_changes(self, plan_admin_user, plan):
+        """
+        Normal-path behaviour.
+
+        When re-uploading a differently-named file, the old file is deleted
+        and the new file remains. The fix must not regress this.
+        """
+
+        image = AplansImageFactory.create(
+            collection=plan.root_collection,
+            file=_png_image_file('ace34991.png'),
+        )
+        storage = image.file.storage
+        original_path = image.file.name
+        assert storage.exists(original_path)
+
+        form_class = get_image_form(AplansImage)
+        form = form_class(
+            data={'title': image.title, 'collection': image.collection_id},
+            files={'file': _png_upload('different-name.png')},
+            instance=image,
+            user=plan_admin_user,
+        )
+        assert form.is_valid(), form.errors
+        saved = form.save()
+
+        assert saved.file.name != original_path
+        assert storage.exists(saved.file.name)
+        assert not storage.exists(original_path)


### PR DESCRIPTION
Suppose a user uploaded a file, but something external deletes the file on S3 storage. The DB object lives on but has an invalid reference now. However, our current code has an issue that prevents a user from repairing this situation by re-uploading. This PR fixes that.

When the original file is missing on storage at the moment of re-upload and the new upload has the same `basename`, `storage.get_available_name` reuses the original path. `BaseImageForm.save`'s commit branch would then delete the file it just uploaded, leaving the row pointing at a path that no longer exists. Wrap the `original_file`'s storage during super `save()` so the destructive delete is suppressed precisely in that case.

# Detailed explanation

## Setup

- An image row `Image(pk=42, file='original_images/2026-05/photo.png')` exists in the database.
- The PNG actually lives at that path on S3.
- Everything works.

## The trap, step by step

**T0 — Something external deletes the file**

Could be a manual deletion, a misconfigured lifecycle rule, a maintenance script — anything that removes the object from S3 without touching the database. After this:

- DB row: `file = 'original_images/2026-05/photo.png'` (unchanged)
- S3: that key doesn't exist anymore
- The site shows a broken image.

**T1 — Admin user notices and opens Image 42 in the Wagtail admin**

The edit form renders. The user drags in the same `photo.png` from their machine (or pastes the same image) and clicks Save.

**T2 — Form submission hits `BaseImageForm.save(commit=True)`**

What happens inside, in order:

1. `BaseImageForm.__init__` had already captured `self.original_file = self.instance.file`. This is a `FieldFile` pointing at `original_images/2026-05/photo.png`.

2. `super().save(commit=True)` runs ModelForm.save. ModelForm sees a new file in the form's cleaned_data and assigns it to `instance.file`. Then it calls `instance.save()`, which Django routes through `FieldFile.pre_save` → `storage.save(name, content)`.

3. Inside `storage.save`, Django calls `storage.get_available_name('original_images/2026-05/photo.png')`. **That function decides if the target path is free by asking `storage.exists(name)`. The file is missing from S3, so `exists()` returns `False`, so `get_available_name` happily hands back the same path unchanged.**

4. The new PNG is uploaded to `original_images/2026-05/photo.png`. `instance.file.name` is set to that same path. The row is saved. **At this moment the bug is undone — the file exists again, the row points at it, all is well.**

5. Control returns to `BaseImageForm.save()`. The commit branch runs:
   ```python
   if "file" in self.changed_data and self.original_file:
       self.original_file.storage.delete(self.original_file.name)
   ```
   `self.original_file.name` is still `original_images/2026-05/photo.png` — captured in step 1, never mutated. So the form tells storage to delete that path.

6. **Storage deletes the file we just uploaded one step earlier.** Renditions are also wiped.

**T3 — User sees the form submit successfully, no error, image still broken**

Refresh: broken image. They sigh, drag in `photo.png` again. Steps 1–6 repeat. Same outcome.

## Why "trap"

Three features turn this from a bug into a trap:

1. **The natural recovery action triggers it.** The obvious response to "image file is missing" is "re-upload the image." That's the exact action that ends with the file deleted.

2. **It's invisible.** The form returns success. No exception, no warning, no audit-log signal. The user has no way to know the system deleted what they just uploaded.

3. **It's self-perpetuating.** Each retry's pre-condition is satisfied by the previous retry. The first deletion is what *opens* the trap (it makes `exists()` return False); from there, every well-intentioned re-upload with the same filename keeps it shut.

A bug you can stumble out of with a different action isn't a trap. The thing that makes this one a trap is that *the only way the affected user knows to react* — the same flow that worked when uploading the image originally — is exactly the flow that keeps the file deleted. They have to do something counter-intuitive (rename the file before uploading, or delete and recreate the row) to escape.

---

## ✅ Pre-Merge Checklist

### Type of Change
- [ ] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
