### PR TITLE
Port workflow state directive to Strawberry

### DIFF
--- a/actions/schema.py
+++ b/actions/schema.py
@@ -1440,9 +1440,12 @@ def _get_visible_action(root, field_name: str, user: User | None) -> Action | No
         return None
 
 
-def _get_visible_actions(root, field_name: str, user: User | None) -> QuerySet[Action]:
-    actions = getattr(root, field_name)
-    return actions.visible_for_user(user)
+def _get_visible_actions(root, field_name: str, user: User | None) -> QuerySet[Action] | Iterable[Action]:
+    qs = getattr(root, field_name).all()
+    # Draft revision objects have FakeQuerySets without custom manager methods
+    if hasattr(qs, 'visible_for_user'):
+        return qs.visible_for_user(user)
+    return qs
 
 
 class RevisionNode(DjangoNode[Revision[Any]]):
@@ -1646,7 +1649,7 @@ class ActionNode(ModelAdminAdminButtonsMixin, AttributesMixin, DjangoNode[Action
         return _get_visible_actions(root, 'superseded_actions', user_or_none(info.context.user))
 
     @staticmethod
-    def resolve_copies(root: Action, info: GQLInfo) -> QuerySet[Action]:
+    def resolve_copies(root: Action, info: GQLInfo) -> QuerySet[Action] | Iterable[Action]:
         return _get_visible_actions(root, 'copies', user_or_none(info.context.user))
 
     @staticmethod

--- a/actions/tests/test_workflow_directive.py
+++ b/actions/tests/test_workflow_directive.py
@@ -1,0 +1,206 @@
+import pytest
+
+from actions.attributes import DraftAttributes
+
+pytestmark = pytest.mark.django_db
+
+DRAFT_ACTION_NAME = 'Draft Action Name'
+
+
+@pytest.fixture
+def query_single_action_draft():
+    return """
+      query ($id: ID!, $lang: String!) @locale(lang: $lang) @workflow(state: DRAFT) {
+        action(id: $id) {
+          name
+        }
+      }
+    """
+
+
+@pytest.fixture
+def query_single_action_variable_state():
+    return """
+      query ($id: ID!, $lang: String!, $state: WorkflowState!) @locale(lang: $lang) @workflow(state: $state) {
+        action(id: $id) {
+          name
+        }
+      }
+    """
+
+
+@pytest.fixture
+def query_single_action_no_directive():
+    return """
+      query ($id: ID!, $lang: String!) @locale(lang: $lang) {
+        action(id: $id) {
+          name
+        }
+      }
+    """
+
+
+@pytest.fixture
+def query_plan_actions():
+    return """
+      query ($plan: ID!, $lang: String!) @locale(lang: $lang) @workflow(state: DRAFT) {
+        planActions(plan: $plan) {
+          name
+        }
+      }
+    """
+
+
+@pytest.fixture
+def action_with_draft(plan_factory, workflow_factory, workflow_task_factory, action_factory, person):
+    plan = plan_factory()
+    workflow = workflow_factory()
+    workflow_task_factory(workflow=workflow)
+    plan.features.moderation_workflow = workflow
+    plan.features.save(update_fields=['moderation_workflow'])
+    action = action_factory(plan=plan)
+    published_name = action.name
+    user = person.user
+
+    # Modify the action name in memory and save a draft revision
+    action.name = DRAFT_ACTION_NAME
+    action.draft_attributes = DraftAttributes()
+    action.save_revision(user=user)
+
+    # Start the moderation workflow so the draft is in progress
+    workflow.start(action, user=user)
+
+    # Restore the published name on the live DB record
+    action.name = published_name
+    action.save(update_fields=['name'])
+
+    return action, published_name
+
+
+def test_single_action_draft_for_authenticated_admin(
+    graphql_client_query_data,
+    query_single_action_draft,
+    action_with_draft,
+    person,
+    client,
+):
+    action, _published_name = action_with_draft
+    plan = action.plan
+    person.general_admin_plans.add(plan)
+    person.save()
+    client.force_login(person.user)
+
+    data = graphql_client_query_data(
+        query_single_action_draft,
+        variables={'id': action.id, 'lang': 'en'},
+    )
+    assert data['action']['name'] == DRAFT_ACTION_NAME
+
+
+def test_single_action_published_for_unauthenticated_despite_draft_directive(
+    graphql_client_query_data,
+    query_single_action_draft,
+    action_with_draft,
+):
+    action, published_name = action_with_draft
+
+    data = graphql_client_query_data(
+        query_single_action_draft,
+        variables={'id': action.id, 'lang': 'en'},
+    )
+    assert data['action']['name'] == published_name
+
+
+def test_plan_actions_draft_for_authenticated_admin(
+    graphql_client_query_data,
+    query_plan_actions,
+    action_with_draft,
+    person,
+    client,
+):
+    action, _published_name = action_with_draft
+    plan = action.plan
+    person.general_admin_plans.add(plan)
+    person.save()
+    client.force_login(person.user)
+
+    data = graphql_client_query_data(
+        query_plan_actions,
+        variables={'plan': plan.identifier, 'lang': 'en'},
+    )
+    actions = data['planActions']
+    assert len(actions) == 1
+    assert actions[0]['name'] == DRAFT_ACTION_NAME
+
+
+def test_single_action_draft_via_variable_for_authenticated_admin(
+    graphql_client_query_data,
+    query_single_action_variable_state,
+    action_with_draft,
+    person,
+    client,
+):
+    action, _published_name = action_with_draft
+    plan = action.plan
+    person.general_admin_plans.add(plan)
+    person.save()
+    client.force_login(person.user)
+
+    data = graphql_client_query_data(
+        query_single_action_variable_state,
+        variables={'id': action.id, 'lang': 'en', 'state': 'DRAFT'},
+    )
+    assert data['action']['name'] == DRAFT_ACTION_NAME
+
+
+def test_single_action_draft_with_related_actions(
+    graphql_client_query_data,
+    action_with_draft,
+    action_factory,
+    person,
+    client,
+):
+    """Querying a draft action with relatedActions should not crash on FakeQuerySet."""
+    action, _published_name = action_with_draft
+    plan = action.plan
+    other_action = action_factory(plan=plan)
+    action.related_actions.add(other_action)
+    person.general_admin_plans.add(plan)
+    person.save()
+    client.force_login(person.user)
+
+    query = """
+      query ($id: ID!, $lang: String!) @locale(lang: $lang) @workflow(state: DRAFT) {
+        action(id: $id) {
+          name
+          relatedActions {
+            id
+          }
+        }
+      }
+    """
+    data = graphql_client_query_data(
+        query,
+        variables={'id': action.id, 'lang': 'en'},
+    )
+    assert data['action']['name'] == DRAFT_ACTION_NAME
+
+
+def test_no_directive_returns_published(
+    graphql_client_query_data,
+    query_single_action_no_directive,
+    action_with_draft,
+    person,
+    client,
+):
+    action, published_name = action_with_draft
+    plan = action.plan
+    person.general_admin_plans.add(plan)
+    person.save()
+    client.force_login(person.user)
+
+    data = graphql_client_query_data(
+        query_single_action_no_directive,
+        variables={'id': action.id, 'lang': 'en'},
+    )
+    assert data['action']['name'] == published_name

--- a/aplans/schema.py
+++ b/aplans/schema.py
@@ -7,10 +7,6 @@ import strawberry as sb
 from django.db.models import Count, Q
 from graphql import DirectiveLocation
 from graphql.error import GraphQLError
-from graphql.type import (
-    GraphQLArgument,
-    GraphQLDirective,
-)
 from strawberry.schema import Schema as StrawberrySchema
 from strawberry.tools import merge_types
 from strawberry.types import has_object_definition
@@ -29,7 +25,6 @@ from kausal_common.users.schema import UserNode
 
 from aplans import gql
 from aplans.cache import OrganizationActionCountCache
-from aplans.graphql_types import WorkflowStateGrapheneEnum
 from aplans.schema_context import WatchGraphQLContext
 from aplans.utils import public_fields
 
@@ -261,31 +256,6 @@ def auth_directive(info: gql.Info, uuid: str, token: str):  # pyright: ignore[re
     return
 
 
-graphene_enum_type = graphene.types.schema.TypeMap.create_enum(WorkflowStateGrapheneEnum)
-
-
-class WorkflowStateDirective(GraphQLDirective):
-    def __init__(self):
-        super().__init__(
-            name='workflow',
-            description=(
-                'Let the client request retrieving approved/unapproved '
-                'drafts or published versions of plan data (currently individual actions). '
-                'The actual response is dependent on user access rights, for example '
-                'a published version is always returned to unauthenticated users '
-                'or when no draft exists.'
-            ),
-            args={
-                'state': GraphQLArgument(
-                    type_=graphene_enum_type,
-                    description='State of content to show',
-                    default_value=WorkflowStateEnum.PUBLISHED,
-                ),
-            },
-            locations=[DirectiveLocation.QUERY],
-        )
-
-
 @sb.input(name='InstanceContext')
 class InstanceContextInput:
     hostname: str | None
@@ -331,6 +301,7 @@ class WatchSchema(UnifiedSchema):
         from .schema_context import (
             ActivatePlanContextExtension,
             DeterminePlanContextExtension,
+            ProcessWorkflowDirectiveExtension,
             WatchAuthenticationExtension,
             WatchExecutionCacheExtension,
         )
@@ -339,6 +310,7 @@ class WatchSchema(UnifiedSchema):
         extensions.extend([
             LoggingTracingExtension(context_class=WatchGraphQLContext),
             DeterminePlanContextExtension,
+            ProcessWorkflowDirectiveExtension,
             WatchExecutionCacheExtension,
             ActivatePlanContextExtension,
             WatchAuthenticationExtension,

--- a/aplans/schema_context.py
+++ b/aplans/schema_context.py
@@ -26,6 +26,7 @@ from aplans.graphene_views import PLAN_DOMAIN_HEADER, PLAN_IDENTIFIER_HEADER
 from actions.models import Plan
 
 from .cache import WatchObjectCache
+from .graphql_types import WorkflowStateEnum
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -231,6 +232,49 @@ class DeterminePlanContextExtension(WatchSchemaExtension):
             return
 
         self.determine_plan_and_locale(op)
+        yield
+
+
+class ProcessWorkflowDirectiveExtension(WatchSchemaExtension):
+    def process_workflow_directive(self, directive: DirectiveNode) -> WorkflowStateEnum:
+        from .schema import workflow_directive  # noqa: PLC0415
+
+        assert workflow_directive.graphql_name is not None
+        exec_ctx = self.execution_context
+        directive_ast = exec_ctx.schema._schema.get_directive(workflow_directive.graphql_name)
+        assert directive_ast is not None
+        args = get_argument_values(directive_ast, directive, exec_ctx.variables)
+        state_raw = args.get('state')
+        if state_raw is None:
+            state = WorkflowStateEnum.PUBLISHED
+        elif isinstance(state_raw, WorkflowStateEnum):
+            state = state_raw
+        else:
+            state = WorkflowStateEnum(state_raw)
+
+        ctx = self.get_context()
+        user = user_or_none(ctx.get_user())
+        if user is None:
+            return WorkflowStateEnum.PUBLISHED
+        return state
+
+    def on_execute(self) -> Generator[None]:
+        doc = self.execution_context.graphql_document
+        if doc:
+            op = get_first_operation(doc)
+        else:
+            op = None
+
+        if not op or self.execution_context.result:
+            yield
+            return
+
+        for directive in op.directives or []:
+            if directive.name.value == 'workflow':
+                state = self.process_workflow_directive(directive)
+                self.get_context().cache.query_workflow_state = state
+                break
+
         yield
 
 

--- a/aplans/tests/test_workflow_directive_extension.py
+++ b/aplans/tests/test_workflow_directive_extension.py
@@ -1,0 +1,92 @@
+from unittest.mock import MagicMock
+
+from graphql import OperationDefinitionNode, parse
+
+import pytest
+
+from aplans.graphql_types import WorkflowStateEnum
+from aplans.schema import generate_strawberry_schema
+from aplans.schema_context import ProcessWorkflowDirectiveExtension
+
+
+def _get_directive_from_query(query_str: str):
+    """Parse a GraphQL query and return the 'workflow' directive from the first operation."""
+    doc = parse(query_str)
+    op = doc.definitions[0]
+    assert isinstance(op, OperationDefinitionNode)
+    for d in op.directives:
+        if d.name.value == 'workflow':
+            return d
+    return None
+
+
+@pytest.fixture
+def extension():
+    ext = ProcessWorkflowDirectiveExtension.__new__(ProcessWorkflowDirectiveExtension)
+    return ext
+
+
+@pytest.fixture
+def mock_schema():
+    """Create a mock schema that provides the workflow directive definition."""
+    schema = generate_strawberry_schema()
+    return schema
+
+
+def _setup_extension(ext, schema, user, variables=None):
+    """Wire up the extension with mocked execution_context and context."""
+    exec_ctx = MagicMock()
+    exec_ctx.schema._schema = schema._schema
+    exec_ctx.variables = variables or {}
+    ext.execution_context = exec_ctx
+
+    ctx = MagicMock()
+    ctx.get_user.return_value = user
+    ext.get_context = MagicMock(return_value=ctx)
+    return ctx
+
+
+class TestProcessWorkflowDirective:
+    def test_returns_draft_for_authenticated_user(self, extension, mock_schema):
+        directive = _get_directive_from_query('query @workflow(state: DRAFT) { __typename }')
+        user = MagicMock()
+        user.is_authenticated = True
+        _setup_extension(extension, mock_schema, user)
+
+        result = extension.process_workflow_directive(directive)
+        assert result == WorkflowStateEnum.DRAFT
+
+    def test_returns_approved_for_authenticated_user(self, extension, mock_schema):
+        directive = _get_directive_from_query('query @workflow(state: APPROVED) { __typename }')
+        user = MagicMock()
+        user.is_authenticated = True
+        _setup_extension(extension, mock_schema, user)
+
+        result = extension.process_workflow_directive(directive)
+        assert result == WorkflowStateEnum.APPROVED
+
+    def test_returns_published_for_unauthenticated_user(self, extension, mock_schema):
+        directive = _get_directive_from_query('query @workflow(state: DRAFT) { __typename }')
+        _setup_extension(extension, mock_schema, user=None)
+
+        result = extension.process_workflow_directive(directive)
+        assert result == WorkflowStateEnum.PUBLISHED
+
+    def test_defaults_to_published_when_no_state_arg(self, extension, mock_schema):
+        directive = _get_directive_from_query('query @workflow { __typename }')
+        user = MagicMock()
+        user.is_authenticated = True
+        _setup_extension(extension, mock_schema, user)
+
+        result = extension.process_workflow_directive(directive)
+        assert result == WorkflowStateEnum.PUBLISHED
+
+    def test_returns_draft_when_state_passed_as_variable(self, extension, mock_schema):
+        directive = _get_directive_from_query('query ($state: WorkflowState!) @workflow(state: $state) { __typename }')
+        user = MagicMock()
+        user.is_authenticated = True
+        _setup_extension(extension, mock_schema, user, variables={'state': 'DRAFT'})
+
+        result = extension.process_workflow_directive(directive)
+        assert result == WorkflowStateEnum.DRAFT
+        assert isinstance(result, WorkflowStateEnum)


### PR DESCRIPTION
## Description
When migrating from Grafene to Strawberry, the WorkflowState directive stopped working. It is used to allow authenticated users to see draft versions of actions instead of the published ones (when moderation in use).

Port the directive to Strawberry.

## Screenshots/Videos (if applicable)
N/A

## Related issue
N/A

## Requirements, dependencies and related PRs
N/A

## Additional Notes
N/A

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Load a plan with moderation, login to public ui, select action you know has a draft, select workflowstate from top left menu. Reviewer does not need to test this manually, it has been tested.
### Internationalization & Accessibility
- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [X] **Moderation** integration implemented
- [X] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented
- [X] **Umbrella plan structure** integration implemented

### Dependencies
- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
