### PR TITLE
Fix/action chooser

### DIFF
--- a/actions/chooser.py
+++ b/actions/chooser.py
@@ -146,7 +146,7 @@ class ActionChooserMixin(WatchModelChooserBase[Action]):
     def get_unfiltered_object_list(self):
         user = user_or_bust(self.request.user)
         plan = user.get_active_admin_plan()
-        related_plans = Plan.objects.filter(pk=plan.pk) | plan.related_plans.all()
+        related_plans = plan.get_all_related_plans(inclusive=True)
         objects = Action.objects.filter(plan__in=related_plans)
         return objects
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -1233,6 +1233,21 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         return f'{self.identifier}.{default_domain}'
 
     def get_all_related_plans(self, inclusive=False) -> PlanQuerySet:
+        """
+        Get all plans that are related to this plan.
+
+        A plan is considered related if it has this plan listed in its ``related_plans``
+        attribute, or if it is connected through an umbrella plan relationship — that
+        is, this plan's parent, its siblings (other children of the same parent), or
+        its own children.
+
+        Args:
+            inclusive (bool): Whether to include this plan in the returned queryset.
+
+        Returns:
+            A queryset of related plans.
+
+        """
         q = Q(related_plans=self)
         if self.parent_id:
             q |= Q(id=self.parent_id)


### PR DESCRIPTION
## Description
Fix returned actions in ActionChooser

ActionChooser used to return actions of plans in self.related_plans, but that doesn't necessarily include plans related through the umbrella plan structure. Use the more comprehensive get_all_related_plans method to determine the plans from which to search for the actions.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214031556575400?focus=true)

## Requirements, dependencies and related PRs
\-

## Additional Notes
`ActionChooser` is used in two locations, so choosable actions are affected in these places:
- `Actions -> <pick any action> -> Merged with action`
- `Actions -> <pick any action> -> Dependencies tab -> Dependent actions`

Are we okay with that? :slightly_smiling_face: 

------

## ✅ Pre-Merge Checklist

### Testing
- [-] **Built Unit tests** (unit tests added/updated)
- [-] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [-] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    See locations mentioned in Additional notes, see if the returned actions are correct / make sense.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [x] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
