### PR TITLE
Raise GraphQLError when no plan in context

### DIFF
--- a/aplans/graphql_types.py
+++ b/aplans/graphql_types.py
@@ -10,6 +10,7 @@ import strawberry as sb
 from django.db.models import Model, QuerySet
 from django.utils.translation import gettext_lazy as _
 from graphene.utils.str_converters import to_camel_case, to_snake_case
+from graphql.error import GraphQLError
 
 from grapple.registry import registry as grapple_registry
 
@@ -57,7 +58,7 @@ def get_plan_from_context(info: GQLInfo, plan_identifier: str | None = None) -> 
     if plan_identifier is None:
         plan = info.context.active_plan
         if not plan:
-            raise Exception('No plan in context')
+            raise GraphQLError('No plan in context')
         assert plan.is_visible_for_user(info.context.user), 'Plan is not visible for user'
         return plan
 


### PR DESCRIPTION
## Description
Replaces a bare Exception with GraphQLError in get_plan_from_context so callers that don't supply a plan argument and don't set an active plan via directive get a structured GraphQL error instead of a generic internal server error. Also stops the condition from paging via Sentry (WATCH-BACKEND-4YW).


## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
