### PR TITLE
Validate duplicate email domain in client chooser

### DIFF
--- a/admin_site/chooser.py
+++ b/admin_site/chooser.py
@@ -33,6 +33,16 @@ class ClientForm(forms.ModelForm):
         validators=[HostnameValidator()],
     )
 
+    def clean_default_email_hostname(self):
+        hostname = self.cleaned_data['default_email_hostname']
+        if EmailDomains.objects.filter(domain=hostname).exists():
+            raise forms.ValidationError(
+                _('The email domain "%(domain)s" is already in use by another client.'),
+                params={'domain': hostname},
+                code='unique',
+            )
+        return hostname
+
     def save(self, commit=True):
         hostname = self.cleaned_data['default_email_hostname']
         result = super().save(commit=commit)

--- a/admin_site/tests/test_chooser.py
+++ b/admin_site/tests/test_chooser.py
@@ -1,0 +1,27 @@
+import pytest
+
+from admin_site.chooser import ClientForm
+from admin_site.tests.factories import EmailDomainsFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _form_data(name='New Client', hostname='example.com'):
+    return {
+        'name': name,
+        'auth_backend': 'azure_ad',
+        'default_email_hostname': hostname,
+    }
+
+
+def test_client_form_rejects_duplicate_email_domain():
+    EmailDomainsFactory.create(domain='taken.example')
+    form = ClientForm(data=_form_data(hostname='taken.example'))
+    assert not form.is_valid()
+    assert 'default_email_hostname' in form.errors
+    assert 'taken.example' in str(form.errors['default_email_hostname'])
+
+
+def test_client_form_accepts_unused_email_domain():
+    form = ClientForm(data=_form_data(hostname='fresh.example'))
+    assert form.is_valid(), form.errors


### PR DESCRIPTION
## Description
Show an inline form error when the entered hostname already exists in EmailDomains, instead of letting the unique constraint raise an IntegrityError on save.

Fixes WATCH-BACKEND-5VN

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
