### PR TITLE
Preserve validated form across Wagtail render_partials

### DIFF
--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -56,6 +56,18 @@ class WatchEditView[ModelT: Model, FormT: WagtailAdminModelForm = WagtailAdminMo
             'plan': admin_req(self.request).user.get_active_admin_plan(),
         }
 
+    def get_context_data(self, **kwargs):
+        # During a successful POST, Wagtail's save_action -> get_success_json calls
+        # render_partials, which invokes get_context_data() without passing a form. Django's
+        # FormMixin then constructs a fresh form via get_form(), and EditView.get_context_data
+        # overwrites self.form with it. The new form is bound but never validated, so its
+        # formset child forms have no cleaned_data, breaking the subsequent
+        # form.get_field_updates_for_resave() call (formset._should_delete_form reads
+        # form.cleaned_data).
+        if 'form' not in kwargs and getattr(self, 'form', None) is not None:
+            kwargs['form'] = self.form
+        return super().get_context_data(**kwargs)
+
     def form_valid(self, form, *args, **kwargs):
         try:
             form_valid_return = super().form_valid(form, *args, **kwargs)


### PR DESCRIPTION
## Description
[Sentry had a recurring issue about forms missing `cleaned_data`](https://sentry.kausal.tech/organizations/kausal/issues/14437/?project=3&query=assigned%3Ame&referrer=issue-stream). This was somehow caused by the recently added Wagtail feature that autosaves forms while still editing: the error was raised when the autosaving was first tried during editing certain specific objects. So, this can be solved also with setting the autosave off with `WAGTAIL_AUTOSAVE_INTERVAL = 0`.

However, Claude figured that there's a bug in Wagtail system that drops the form at some point and came up with this solution where the missing form kwarg is added back on if it's been lost somewhere in the Wagtail code. I managed to reproduce the bug, and it indeed goes away with this solution.

By the way, the only thing this bug does is that the autosaving is paused because Wagtail runs into the server error, but you can still keep on editing, probably without even noticing. Final save still works fine.

The following is Claude's explanation, which I'm taking at a face value word for word (as is the case with the code comments etc.) because I can't be bothered to go through the effort to figure out whether it is entirely correct in its explanation :sweat_smile: 

<hr>

Wagtail's EditView re-runs get_context_data from render_partials after a successful save, which lets FormMixin build a fresh, unvalidated form and overwrites self.form with it. The subsequent get_field_updates_for_resave then iterates formset children that never had cleaned_data set, raising AttributeError on inlines like OrganizationMetadataAdminForm.

## Screenshots/Videos (if applicable)
\-

## Related issue
[Sentry](https://sentry.kausal.tech/organizations/kausal/issues/14437/?project=3&query=assigned%3Ame&referrer=issue-stream)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

------

## ✅ Pre-Merge Checklist

### Testing
- [-] **Built Unit tests** (unit tests added/updated)
- [-] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    The bug happens e.g. with the plan `Klimastrategie Kanton Schaffhausen`, when trying to edit one-off notifications at `Notification -> One-off notifications tab`. 

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
