### PR TITLE
Let plan contact persons read the orgs REST endpoint

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -1645,7 +1645,11 @@ class OrganizationViewSet(HandleProtectedErrorMixin, AuditLoggingBulkModelViewSe
         if plan is None:
             return context
         if not self.user_is_general_admin_for_plan(plan):
-            raise exceptions.PermissionDenied(detail='Not authorized')
+            # Non-admin reads are still permitted (get_queryset gates them via
+            # user_is_authorized_for_plan); writes are not.
+            if self.request.method not in permissions.SAFE_METHODS:
+                raise exceptions.PermissionDenied(detail='Not authorized')
+            return context
         context['plan'] = plan
         return context
 

--- a/actions/tests/test_api_organization_create.py
+++ b/actions/tests/test_api_organization_create.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 import pytest
 
-from actions.tests.factories import PlanFactory
+from actions.tests.factories import ActionContactFactory, ActionFactory, PlanFactory
 from orgs.models import Organization
 from orgs.tests.factories import OrganizationFactory
 from people.tests.factories import PersonFactory
@@ -55,6 +55,20 @@ def test_organization_list_authorized_user_for_plan_returns_200(api_client, orga
     )
 
     api_client.force_login(admin_person.user)
+    response = api_client.get(organization_list_url, data={'plan': plan.identifier})
+    assert response.status_code == 200
+
+
+def test_organization_list_contact_person_for_plan_returns_200(api_client, organization_list_url):
+    # Contact persons are not general admins but should still be able to read
+    # the plan's related organizations so the action grid can render its
+    # responsible-party columns for them.
+    plan = PlanFactory.create()
+    action = ActionFactory.create(plan=plan)
+    contact_person = PersonFactory.create(organization=plan.organization)
+    ActionContactFactory.create(action=action, person=contact_person)
+
+    api_client.force_login(contact_person.user)
     response = api_client.get(organization_list_url, data={'plan': plan.identifier})
     assert response.status_code == 200
 


### PR DESCRIPTION
## Description
OrganizationViewSet.get_serializer_context required general-admin status for the queried plan and raised PermissionDenied otherwise, firing on every GET that included ?plan=<id>. Contact persons and organization plan admins were allowed past get_queryset (the broader user_is_authorized_for_plan gate) but blocked here, so they saw a 403 even though the sibling PersonViewSet returned 200 for the same request shape.

Skip the raise on safe methods so reads behave like /v1/person/, and keep the strict check on writes so general-admin-of-plan-A posting with ?plan=B is still rejected (instead of silently falling back to plan A via OrganizationSerializer.create()).

This unblocks the action grid editor for contact persons, which previously crashed when restData.organizations came back as a 403.

Fixes WATCH-BACKEND-4WQ

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
related fix in kausal extensions https://github.com/kausaltech/kausal-extensions/compare/fix/action-grid-org-permission-crash?expand=1

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
