### PR TITLE
Raise GraphQLError when plan identifier not found

### DIFF
--- a/aplans/cache.py
+++ b/aplans/cache.py
@@ -328,11 +328,12 @@ class WatchObjectCache:
             self.plan_caches[plan_id] = plan_cache
         return plan_cache
 
-    def for_plan_identifier(self, plan_identifier: str) -> PlanSpecificCache:
+    def for_plan_identifier(self, plan_identifier: str) -> PlanSpecificCache | None:
         plan_cache = self.plan_caches_by_identifier.get(plan_identifier)
         if plan_cache is None:
             plan_id = Plan.objects.filter(identifier=plan_identifier).values_list('id', flat=True).first()
-            assert plan_id is not None, 'Invalid plan identifier'
+            if plan_id is None:
+                return None
             if plan_id in self.plan_caches:
                 plan_cache = self.plan_caches[plan_id]
             else:

--- a/aplans/graphql_types.py
+++ b/aplans/graphql_types.py
@@ -63,6 +63,8 @@ def get_plan_from_context(info: GQLInfo, plan_identifier: str | None = None) -> 
         return plan
 
     plan_cache = info.context.cache.for_plan_identifier(plan_identifier=plan_identifier)
+    if plan_cache is None:
+        raise GraphQLError(f'Plan "{plan_identifier}" not found')
     plan = plan_cache.plan
     if not plan.is_visible_for_user(info.context.user):
         return None

--- a/aplans/tests/test_schema.py
+++ b/aplans/tests/test_schema.py
@@ -357,3 +357,19 @@ def test_site_general_content_node(graphql_client_query_data):
     }
     assert data == expected
 """
+
+
+def test_plan_page_invalid_plan_identifier_returns_graphql_error(graphql_client_query):
+    """A bogus plan identifier on planPage must return a structured GraphQL error, not an AssertionError."""
+    response = graphql_client_query(
+        """
+        query($plan: ID!, $path: String!) {
+          planPage(plan: $plan, path: $path) {
+            id
+          }
+        }
+        """,
+        variables={'plan': 'no-such-plan', 'path': '/'},
+    )
+    assert 'errors' in response
+    assert any('no-such-plan' in err['message'] for err in response['errors'])


### PR DESCRIPTION
## Description
Stops AssertionError noise from probing of the public GraphQL endpoint with bogus plan identifiers (e.g. plan='x'). The cache layer now returns None on lookup miss; get_plan_from_context turns that into a GraphQLError.

Fixes WATCH-BACKEND-4YD

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
