### PR TITLE
Soft-delete attribute type choice options

### DIFF
--- a/actions/api.py
+++ b/actions/api.py
@@ -39,7 +39,7 @@ from aplans.rest_api import PlanRelatedModelSerializer, get_plan_from_view
 from aplans.utils import generate_identifier, public_fields
 
 from actions.models.action import ActionContactPerson, ActionImplementationPhase, ContactPersonDict
-from actions.models.attributes import AttributeType, ModelWithAttributes
+from actions.models.attributes import AttributeType, AttributeTypeChoiceOption, ModelWithAttributes
 from admin_site.models import BuiltInFieldCustomization
 from audit_logging.models import PlanScopedModel, PlanScopedModelLogEntry
 from orgs.models import Organization
@@ -604,6 +604,78 @@ class AttributesSerializerMixin[InstanceT: Any](AttributesSerializerMixinBase[In
         raise NotImplementedError
 
 
+def _resolve_target_instance_for_archived_check(serializer) -> Any:
+    """
+    Find the model instance whose existing values to compare against.
+
+    Walks the parent chain so the same logic covers single-instance
+    requests (outer serializer's `instance`) and bulk requests (the
+    BulkSerializerValidationInstanceMixin's per-row `_instance`) without
+    bailing out if a list wrapper sits between the choice serializer and
+    the per-row child.
+    """
+    p = serializer.parent
+    while p is not None:
+        target = getattr(p, '_instance', None)
+        if target is not None and not isinstance(target, QuerySet):
+            return target
+        p = getattr(p, 'parent', None)
+    p = serializer.parent
+    while p is not None:
+        candidate = getattr(p, 'instance', None)
+        if candidate is not None and not isinstance(candidate, QuerySet):
+            return candidate
+        p = getattr(p, 'parent', None)
+    return None
+
+
+def _reject_unassignable_archived_choices(serializer, data, extract_choice) -> None:
+    """
+    Reject incoming choice attribute values that point at archived options.
+
+    Allowed: the serializer's target instance already has this exact option
+    as its current value (in-place re-save of an unchanged archived value).
+
+    Runs during DRF's `is_valid()`, before any save or downstream effect —
+    a fast-failing complement to the model-layer `set_attribute()` /
+    `save()` guards.
+    """
+    if not data:
+        return
+    proposed_pks = {extract_choice(value) for value in data.values()}
+    proposed_pks.discard(None)
+    if not proposed_pks:
+        return
+    archived = set(
+        AttributeTypeChoiceOption.objects.filter(
+            pk__in=proposed_pks,
+            is_active=False,
+        ).values_list('pk', flat=True),
+    )
+    if not archived:
+        return
+
+    target = _resolve_target_instance_for_archived_check(serializer)
+    existing_by_identifier: dict[str, int | None] = {}
+    if target is not None and target.pk is not None:
+        cached = serializer.get_cached_values(instance_pk=target.pk) or []
+        for av in cached:
+            existing_by_identifier[av.type.identifier] = av.choice_id
+
+    errors: dict[str, str] = {}
+    for identifier, value in data.items():
+        choice_id = extract_choice(value)
+        if choice_id is None or choice_id not in archived:
+            continue
+        if existing_by_identifier.get(identifier) == choice_id:
+            continue
+        errors[identifier] = str(
+            _('This choice option is archived and cannot be selected as a new value.'),
+        )
+    if errors:
+        raise serializers.ValidationError(errors)
+
+
 class ChoiceAttributesSerializer(AttributesSerializerMixin, serializers.Serializer):
     attribute_formats = (AttributeType.AttributeFormat.ORDERED_CHOICE, AttributeType.AttributeFormat.UNORDERED_CHOICE)
 
@@ -613,6 +685,10 @@ class ChoiceAttributesSerializer(AttributesSerializerMixin, serializers.Serializ
         return {v.type.identifier: v.choice_id for v in values if self.is_attribute_visible(v)}
 
     def to_internal_value(self, data):
+        return data
+
+    def validate(self, data):
+        _reject_unassignable_archived_choices(self, data, extract_choice=lambda v: v)
         return data
 
     def to_value_parameter(self, item):
@@ -631,6 +707,14 @@ class ChoiceWithTextAttributesSerializer(AttributesSerializerMixin, serializers.
         return {v.type.identifier: {'choice': v.choice_id, 'text': v.text} for v in values if self.is_attribute_visible(v)}
 
     def to_internal_value(self, data):
+        return data
+
+    def validate(self, data):
+        _reject_unassignable_archived_choices(
+            self,
+            data,
+            extract_choice=lambda v: v.get('choice') if isinstance(v, dict) else None,
+        )
         return data
 
     def to_value_parameter(self, item):

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib import messages
 from django.contrib.admin import SimpleListFilter
@@ -467,9 +467,9 @@ class ChoiceOptionArchivePanel(Panel):
 
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
-            option = self.instance
+            option = cast('AttributeTypeChoiceOption | None', self.instance)
             self.is_archived = bool(option and option.pk and not option.is_active)
-            if self.is_archived and option.type_id is not None:
+            if option is not None and self.is_archived and option.type_id is not None:
                 self.unarchive_url = reverse(
                     'actions_attributetype_modeladmin_unarchive_choice_option',
                     args=[option.type_id, option.pk],

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -4,15 +4,20 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from django.contrib import messages
 from django.contrib.admin import SimpleListFilter
 from django.contrib.admin.decorators import display
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.forms import ValidationError
-from django.urls import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import path, reverse
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from django.utils.translation import gettext_lazy as _, ngettext_lazy
+from django.views.decorators.http import require_POST
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.panels import FieldPanel, ObjectList, Panel
@@ -27,7 +32,7 @@ from wagtailorderable.modeladmin.mixins import OrderableMixin
 from kausal_common.users import user_or_bust
 
 from aplans.context_vars import ctx_instance, ctx_request
-from aplans.utils import OrderedModelChildFormSet, append_query_parameter
+from aplans.utils import ArchivableOrderedModelChildFormSet, append_query_parameter
 
 from actions.blocks.mixins import ActionListPageBlockFormMixin
 from actions.chooser import CategoryTypeChooser
@@ -683,7 +688,7 @@ class ActionAttributeTypeForm(ActionListPageBlockFormMixin, AttributeTypeForm):
 class AttributeTypeEditHandler(AplansTabbedInterface):
     def get_form_options(self):
         options = super().get_form_options()
-        options['formsets']['choice_options']['formset'] = OrderedModelChildFormSet
+        options['formsets']['choice_options']['formset'] = ArchivableOrderedModelChildFormSet
         return options
 
 
@@ -705,6 +710,30 @@ class AttributeTypeAdmin(OrderableMixin, AplansModelAdmin[AttributeType]):
     edit_view_class = AttributeTypeEditView
     delete_view_class = AttributeTypeDeleteView
     button_helper_class = AttributeTypeAdminButtonHelper
+
+    def unarchive_choice_option_view(self, request, attribute_type_pk, option_pk):
+        if not self.permission_helper.user_can_edit_obj(
+            request.user,
+            get_object_or_404(AttributeType, pk=attribute_type_pk),
+        ):
+            raise PermissionDenied
+        option = get_object_or_404(
+            AttributeTypeChoiceOption,
+            pk=option_pk,
+            type_id=attribute_type_pk,
+        )
+        option.unarchive()
+        messages.success(request, _("Choice option '%s' has been restored.") % option.name)
+        return HttpResponseRedirect(self.url_helper.get_action_url('edit', attribute_type_pk))
+
+    def get_admin_urls_for_registration(self):
+        urls = super().get_admin_urls_for_registration()
+        unarchive_url = path(
+            f'{self.opts.app_label}/{self.opts.model_name}/<int:attribute_type_pk>/unarchive-choice-option/<int:option_pk>/',
+            require_POST(self.unarchive_choice_option_view),
+            name=self.url_helper.get_action_url_name('unarchive_choice_option'),
+        )
+        return (*urls, unarchive_url)
 
     # Fix index_order method added by OrderableMixinMetaClass because the way Wagtail handles icons has changed and
     # wagtailorderable hasn't accounted for this.

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -459,6 +459,28 @@ def _get_attribute_type_usage(attribute_type: AttributeType) -> AttributeTypeUsa
     )
 
 
+class ChoiceOptionArchivePanel(Panel):
+    """Renders an 'Archived' badge and an unarchive button on archived choice options."""
+
+    class BoundPanel(Panel.BoundPanel):
+        template_name = 'aplans/panels/choice_option_archive_panel.html'
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            option = self.instance
+            self.is_archived = bool(option and option.pk and not option.is_active)
+            if self.is_archived and option.type_id is not None:
+                self.unarchive_url = reverse(
+                    'actions_attributetype_modeladmin_unarchive_choice_option',
+                    args=[option.type_id, option.pk],
+                )
+            else:
+                self.unarchive_url = ''
+
+        def is_shown(self):
+            return self.is_archived
+
+
 class ChoiceOptionUsagePanel(Panel):
     """Panel that warns admins about choice option usage in drafts and reports."""
 
@@ -750,12 +772,15 @@ class AttributeTypeAdmin(OrderableMixin, AplansModelAdmin[AttributeType]):
     def get_edit_handler(self):
         request = ctx_request.get()
         instance = ctx_instance.get_as_type(AttributeType)
-        choice_option_panels: list[Panel[Any]] = insert_model_translation_panels(
-            AttributeTypeChoiceOption,
-            self.choice_option_panels,
-            request,
-            instance,
-        )
+        choice_option_panels: list[Panel[Any]] = [
+            ChoiceOptionArchivePanel(),
+            *insert_model_translation_panels(
+                AttributeTypeChoiceOption,
+                self.choice_option_panels,
+                request,
+                instance,
+            ),
+        ]
 
         if instance.pk is not None:
             usage_by_option = _get_choice_option_usage(instance)

--- a/actions/attribute_type_admin.py
+++ b/actions/attribute_type_admin.py
@@ -628,7 +628,21 @@ class AttributeTypeEditView(
     InitializeFormWithPlanMixin,
     AplansEditView,
 ):
-    pass
+    def form_valid(self, form, *args, **kwargs):
+        response = super().form_valid(form, *args, **kwargs)
+        for formset in getattr(form, 'formsets', {}).values():
+            for archived in getattr(formset, 'archived_on_last_save', ()):
+                messages.warning(
+                    self.request,
+                    _(
+                        "Choice option '%(name)s' is still in use, so it was archived rather "
+                        'than deleted. Existing references continue to resolve; the option is '
+                        'hidden from new selections. Use the "Unarchive" button on the option to '
+                        'restore it.'
+                    )
+                    % {'name': archived.name},
+                )
+        return response
 
 
 class AttributeTypeDeleteView(ContentTypeQueryParameterMixin, DeleteView):

--- a/actions/attributes.py
+++ b/actions/attributes.py
@@ -8,7 +8,7 @@ from typing import Any, Generic, TypeVar, cast
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import ForeignKey
+from django.db.models import ForeignKey, Q
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, field_panel
@@ -616,7 +616,14 @@ class OrderedChoice(AttributeType[models.AttributeChoice]):
             if c:
                 initial_choice = c.choice
 
-        choice_options = self.instance.choice_options.all()
+        # Hide archived options from the picker, but if the current value
+        # points at an archived option, keep it in the dropdown for this form
+        # so existing data isn't silently lost.
+        choice_options = self.instance.choice_options.filter(is_active=True)
+        if initial_choice is not None and not initial_choice.is_active:
+            choice_options = self.instance.choice_options.filter(
+                Q(is_active=True) | Q(pk=initial_choice.pk),
+            )
         field = forms.ModelChoiceField(
             choice_options,
             initial=initial_choice,
@@ -773,7 +780,13 @@ class OptionalChoiceWithText(AttributeType[models.AttributeChoiceWithText]):
             initial_choice = draft_attribute.option
         elif committed_attribute:
             initial_choice = committed_attribute.choice
-        choice_options = self.instance.choice_options.all()
+        # Hide archived options from the picker; keep the current value if it
+        # happens to point at an archived option.
+        choice_options = self.instance.choice_options.filter(is_active=True)
+        if initial_choice is not None and not initial_choice.is_active:
+            choice_options = self.instance.choice_options.filter(
+                Q(is_active=True) | Q(pk=initial_choice.pk),
+            )
         choice_field = forms.ModelChoiceField(
             choice_options,
             initial=initial_choice,

--- a/actions/migrations/0175_attributetypechoiceoption_is_active.py
+++ b/actions/migrations/0175_attributetypechoiceoption_is_active.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('actions', '0174_alter_actionstatus_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='attributetypechoiceoption',
+            name='is_active',
+            field=models.BooleanField(default=True, verbose_name='active'),
+        ),
+    ]

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -373,18 +373,32 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
         return qs.filter(type=self.type)
 
     def archive(self) -> None:
-        """Mark this option as archived; existing references continue to resolve."""
+        """
+        Mark this option as archived; existing references continue to resolve.
+
+        Bumps `order` above all sibling rows so the inline editor's
+        renumbering of active options doesn't collide with this row under
+        the (type, order) unique constraint.
+        """
         if not self.is_active:
             return
+        max_order = type(self).objects.filter(type=self.type).aggregate(
+            m=models.Max('order'),
+        )['m']
         self.is_active = False
-        self.save(update_fields=['is_active'])
+        self.order = (max_order if max_order is not None else 0) + 1
+        self.save(update_fields=['is_active', 'order'])
 
     def unarchive(self) -> None:
-        """Restore this option to the active list."""
+        """Restore this option to the active list at the end of the order."""
         if self.is_active:
             return
+        max_order = type(self).objects.filter(type=self.type).aggregate(
+            m=models.Max('order'),
+        )['m']
         self.is_active = True
-        self.save(update_fields=['is_active'])
+        self.order = (max_order if max_order is not None else 0) + 1
+        self.save(update_fields=['is_active', 'order'])
 
     def is_referenced(self) -> bool:
         """

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -81,7 +81,7 @@ else:
 
 
 @reversion.register(follow=['choice_options'])
-class AttributeType(
+class AttributeType(  # type: ignore[django-manager-missing]
     InstancesEditableByMixin,
     InstancesVisibleForMixin,
     ReferenceIndexedModelMixin,
@@ -313,12 +313,15 @@ class AttributeTypeChoiceOptionQuerySet(MultilingualQuerySet['AttributeTypeChoic
 
 
 if TYPE_CHECKING:
+    _AttributeTypeChoiceOptionManager = models.Manager.from_queryset(AttributeTypeChoiceOptionQuerySet)
 
     class AttributeTypeChoiceOptionManager(
         MLModelManager['AttributeTypeChoiceOption', AttributeTypeChoiceOptionQuerySet],
+        _AttributeTypeChoiceOptionManager,
     ):
-        def active(self) -> AttributeTypeChoiceOptionQuerySet: ...
-        def archived(self) -> AttributeTypeChoiceOptionQuerySet: ...
+        pass
+
+    del _AttributeTypeChoiceOptionManager
 
 else:
     AttributeTypeChoiceOptionManager = MultilingualManager.from_queryset(AttributeTypeChoiceOptionQuerySet)
@@ -433,7 +436,7 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
             # nothing can reference it through the attribute machinery.
             return False
 
-        if attribute_model.objects.filter(choice=self).exists():
+        if cast('Any', attribute_model).objects.filter(choice=self).exists():
             return True
 
         target_ct = self.type.object_content_type
@@ -502,8 +505,7 @@ class AttributeCategoryChoice(Attribute, ClusterableModel):
 
 def _attribute_choice_is_in_parent_revisions(attribute) -> bool:
     """
-    Return True if a Wagtail revision of the attribute's parent references
-    this `(type, choice)` pair.
+    Return True if a Wagtail revision of the attribute's parent references this `(type, choice)` pair.
 
     Used to recognise the publish-from-draft path: a choice option was
     archived because `is_referenced()` found it in a draft of this very
@@ -558,9 +560,7 @@ def _validate_attribute_choice_is_assignable(attribute) -> None:
         # is still active — nothing to do.
         return
     if attribute.pk is not None:
-        previous_choice_id = (
-            type(attribute).objects.filter(pk=attribute.pk).values_list('choice_id', flat=True).first()
-        )
+        previous_choice_id = type(attribute).objects.filter(pk=attribute.pk).values_list('choice_id', flat=True).first()
         if previous_choice_id == attribute.choice_id:
             return
     if _attribute_choice_is_in_parent_revisions(attribute):

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, cast, override
 
 import reversion
@@ -14,7 +15,9 @@ from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
 from modeltrans.fields import TranslationField
 from modeltrans.manager import MultilingualManager, MultilingualQuerySet
+from reversion.models import Version
 from wagtail.fields import RichTextField
+from wagtail.models import Revision
 
 import sentry_sdk
 from autoslug.fields import AutoSlugField
@@ -301,6 +304,26 @@ class Attribute(models.Model):
         return self.type.is_instance_visible_for(user, plan, action)  # type: ignore[attr-defined]
 
 
+class AttributeTypeChoiceOptionQuerySet(MultilingualQuerySet['AttributeTypeChoiceOption']):
+    def active(self) -> Self:
+        return self.filter(is_active=True)
+
+    def archived(self) -> Self:
+        return self.filter(is_active=False)
+
+
+if TYPE_CHECKING:
+
+    class AttributeTypeChoiceOptionManager(
+        MLModelManager['AttributeTypeChoiceOption', AttributeTypeChoiceOptionQuerySet],
+    ):
+        def active(self) -> AttributeTypeChoiceOptionQuerySet: ...
+        def archived(self) -> AttributeTypeChoiceOptionQuerySet: ...
+
+else:
+    AttributeTypeChoiceOptionManager = MultilingualManager.from_queryset(AttributeTypeChoiceOptionQuerySet)
+
+
 @reversion.register()
 class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
     type: PK[AttributeType] = ParentalKey(AttributeType, on_delete=models.CASCADE, related_name='choice_options')
@@ -310,13 +333,14 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
         populate_from='name',
         unique_with='type',
     )
+    is_active = models.BooleanField(default=True, verbose_name=_('active'))
 
     i18n = TranslationField(
         fields=('name',),
         default_language_field='type__primary_language_lowercase',
     )
 
-    objects: models.Manager[AttributeTypeChoiceOption] = MultilingualManager()
+    objects: ClassVar[AttributeTypeChoiceOptionManager] = AttributeTypeChoiceOptionManager()
 
     public_fields: ClassVar = ['id', 'identifier', 'name']
 
@@ -326,6 +350,9 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
                 fields=['type', 'identifier'],
                 name='unique_identifier_per_type',
             ),
+            # Active rows start at order 0; archived rows are parked at
+            # distinct negative orders (see `archive()`), so they coexist
+            # under this single constraint.
             models.UniqueConstraint(
                 fields=['type', 'order'],
                 name='unique_order_per_type',
@@ -340,8 +367,96 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
         return self.name
 
     def filter_siblings(self, qs: models.QuerySet[Self]) -> models.QuerySet[Self]:
-        # Used by OrderedModel to make sure order starts at 0 for each attribute type
+        # Used by OrderedModel to make sure order starts at 0 for each
+        # attribute type. Archived rows participate so that their `order`
+        # slot is reserved and active inserts don't collide with them.
         return qs.filter(type=self.type)
+
+    def archive(self) -> None:
+        """Mark this option as archived; existing references continue to resolve."""
+        if not self.is_active:
+            return
+        self.is_active = False
+        self.save(update_fields=['is_active'])
+
+    def unarchive(self) -> None:
+        """Restore this option to the active list."""
+        if self.is_active:
+            return
+        self.is_active = True
+        self.save(update_fields=['is_active'])
+
+    def is_referenced(self) -> bool:
+        """
+        Return True if this option is referenced anywhere that should prevent hard deletion.
+
+        Covers:
+        - Live AttributeChoice / AttributeChoiceWithText rows.
+        - Wagtail revisions on the target model (drafts and historical revisions).
+        - django-reversion versions of AttributeChoice / AttributeChoiceWithText
+          (used by report snapshots).
+        """
+        fmt = self.type.format
+        if fmt == AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT:
+            attribute_model: type[Attribute] = AttributeChoiceWithText
+            attribute_model_name = 'attributechoicewithtext'
+        elif fmt in (
+            AttributeType.AttributeFormat.ORDERED_CHOICE,
+            AttributeType.AttributeFormat.UNORDERED_CHOICE,
+        ):
+            attribute_model = AttributeChoice
+            attribute_model_name = 'attributechoice'
+        else:
+            # A choice option on a non-choice AttributeType shouldn't exist —
+            # nothing can reference it through the attribute machinery.
+            return False
+
+        if attribute_model.objects.filter(choice=self).exists():
+            return True
+
+        target_ct = self.type.object_content_type
+        type_key = str(self.type_id)
+        pk = self.pk
+        # JSONB structural containment matches only the exact attribute slot,
+        # avoiding the substring false positives a `content__icontains` lookup
+        # would produce (e.g. `"order": 15020` matching PK 1502). A choice
+        # option belongs to one format, so only one containment shape applies.
+        if fmt == AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT:
+            contains_arg = {'attributes': {str(fmt): {type_key: {'choice': pk}}}}
+        else:
+            contains_arg = {'attributes': {str(fmt): {type_key: pk}}}
+        if Revision.objects.filter(content_type=target_ct, content__contains=contains_arg).exists():
+            return True
+
+        # `serialized_data` is plain text; anchor on `,` / `}` so PK 1502
+        # doesn't match `"choice": 15020`, and narrow by the owning
+        # AttributeType's id so candidates from other types' history are
+        # eliminated up-front. We then JSON-parse each candidate to confirm.
+        type_id = self.type_id
+        candidates = (
+            Version.objects.filter(
+                content_type__app_label='actions',
+                content_type__model=attribute_model_name,
+            )
+            .filter(
+                Q(serialized_data__contains=f'"choice": {pk},') | Q(serialized_data__contains=f'"choice": {pk}}}'),
+            )
+            .filter(
+                Q(serialized_data__contains=f'"type": {type_id},') | Q(serialized_data__contains=f'"type": {type_id}}}'),
+            )
+        )
+
+        for v in candidates.iterator():
+            try:
+                payload = json.loads(v.serialized_data)
+            except TypeError, ValueError:
+                continue
+            if not isinstance(payload, list) or not payload:
+                continue
+            fields = payload[0].get('fields', {})
+            if fields.get('choice') == pk and fields.get('type') == type_id:
+                return True
+        return False
 
 
 @reversion.register(follow=['categories'])

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -382,9 +382,13 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
         """
         if not self.is_active:
             return
-        max_order = type(self).objects.filter(type=self.type).aggregate(
-            m=models.Max('order'),
-        )['m']
+        max_order = (
+            type(self)
+            .objects.filter(type=self.type)
+            .aggregate(
+                m=models.Max('order'),
+            )['m']
+        )
         self.is_active = False
         self.order = (max_order if max_order is not None else 0) + 1
         self.save(update_fields=['is_active', 'order'])
@@ -393,9 +397,13 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
         """Restore this option to the active list at the end of the order."""
         if self.is_active:
             return
-        max_order = type(self).objects.filter(type=self.type).aggregate(
-            m=models.Max('order'),
-        )['m']
+        max_order = (
+            type(self)
+            .objects.filter(type=self.type)
+            .aggregate(
+                m=models.Max('order'),
+            )['m']
+        )
         self.is_active = True
         self.order = (max_order if max_order is not None else 0) + 1
         self.save(update_fields=['is_active', 'order'])
@@ -448,7 +456,8 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
         # eliminated up-front. We then JSON-parse each candidate to confirm.
         type_id = self.type_id
         candidates = (
-            Version.objects.filter(
+            Version.objects
+            .filter(
                 content_type__app_label='actions',
                 content_type__model=attribute_model_name,
             )

--- a/actions/models/attributes.py
+++ b/actions/models/attributes.py
@@ -17,7 +17,7 @@ from modeltrans.fields import TranslationField
 from modeltrans.manager import MultilingualManager, MultilingualQuerySet
 from reversion.models import Version
 from wagtail.fields import RichTextField
-from wagtail.models import Revision
+from wagtail.models import Revision, RevisionMixin
 
 import sentry_sdk
 from autoslug.fields import AutoSlugField
@@ -342,7 +342,7 @@ class AttributeTypeChoiceOption(ClusterableModel, OrderedModel):
 
     objects: ClassVar[AttributeTypeChoiceOptionManager] = AttributeTypeChoiceOptionManager()
 
-    public_fields: ClassVar = ['id', 'identifier', 'name']
+    public_fields: ClassVar = ['id', 'identifier', 'name', 'is_active']
 
     class Meta:
         constraints = [
@@ -477,6 +477,76 @@ class AttributeCategoryChoice(Attribute, ClusterableModel):
         return '; '.join([str(c) for c in self.categories.all()])
 
 
+def _attribute_choice_is_in_parent_revisions(attribute) -> bool:
+    """
+    Return True if a Wagtail revision of the attribute's parent references
+    this `(type, choice)` pair.
+
+    Used to recognise the publish-from-draft path: a choice option was
+    archived because `is_referenced()` found it in a draft of this very
+    action; publishing that draft now creates a new `AttributeChoice` with
+    the archived choice, and we must allow it instead of treating it as a
+    fresh selection.
+    """
+    content_object = attribute.content_object
+    if content_object is None or not isinstance(content_object, RevisionMixin):
+        return False
+    target_ct = ContentType.objects.get_for_model(type(content_object))
+    type_key = str(attribute.type_id)
+    pk = attribute.choice_id
+    fmt = attribute.type.format
+    if fmt == AttributeType.AttributeFormat.OPTIONAL_CHOICE_WITH_TEXT:
+        contains_arg = {'attributes': {str(fmt): {type_key: {'choice': pk}}}}
+    else:
+        contains_arg = {'attributes': {str(fmt): {type_key: pk}}}
+    return Revision.objects.filter(
+        content_type=target_ct,
+        object_id=str(content_object.pk),
+        content__contains=contains_arg,
+    ).exists()
+
+
+def _validate_attribute_choice_is_assignable(attribute) -> None:
+    """
+    Block writes that introduce an archived choice option as a new value.
+
+    Allowed:
+    - choice is None or active.
+    - choice is archived AND the row already has this exact choice (in-place
+      re-save of an unchanged archived value).
+    - choice is archived AND a Wagtail revision of the parent already
+      references this `(type, choice)` pair — the publish-from-draft path
+      legitimately materialises an option that was archived only because
+      it was kept around for the draft.
+
+    Rejected:
+    - choice is archived AND the row is new (and no draft reference exists),
+      or is changing to this option.
+
+    This enforces the "no new selections of archived options" policy at the
+    data layer, so any save path that runs `full_clean()` is covered — not
+    just the Strawberry mutation that explicitly checks up-front.
+    """
+    if attribute.choice_id is None:
+        return
+    is_active = AttributeTypeChoiceOption.objects.filter(pk=attribute.choice_id).values_list('is_active', flat=True).first()
+    if is_active is None or is_active:
+        # Either the option doesn't exist (let FK validation handle it) or it
+        # is still active — nothing to do.
+        return
+    if attribute.pk is not None:
+        previous_choice_id = (
+            type(attribute).objects.filter(pk=attribute.pk).values_list('choice_id', flat=True).first()
+        )
+        if previous_choice_id == attribute.choice_id:
+            return
+    if _attribute_choice_is_in_parent_revisions(attribute):
+        return
+    raise ValidationError(
+        {'choice': _('This choice option is archived and cannot be selected as a new value.')},
+    )
+
+
 @reversion.register(follow=['choice'])
 class AttributeChoice(Attribute):
     type: PK[AttributeType] = ParentalKey(AttributeType, on_delete=models.CASCADE, related_name='choice_attributes')
@@ -505,6 +575,16 @@ class AttributeChoice(Attribute):
             sentry_sdk.capture_exception(e)
             return gettext('Missing value')
         return str(choice)
+
+    def save(self, *args, **kwargs):
+        # DRF and other paths bypass full_clean() and call save() directly.
+        # Enforce the archived-choice rule here so every write is covered.
+        _validate_attribute_choice_is_assignable(self)
+        super().save(*args, **kwargs)
+
+    def clean(self):
+        super().clean()
+        _validate_attribute_choice_is_assignable(self)
 
 
 @reversion.register(follow=['choice'])
@@ -538,6 +618,14 @@ class AttributeChoiceWithText(Attribute):
         if len(text):
             text = f'; {text}'
         return f'{self.choice}{text}'
+
+    def save(self, *args, **kwargs):
+        _validate_attribute_choice_is_assignable(self)
+        super().save(*args, **kwargs)
+
+    def clean(self):
+        super().clean()
+        _validate_attribute_choice_is_assignable(self)
 
 
 @reversion.register()
@@ -686,11 +774,18 @@ class ModelWithAttributes(ClusterableModel):
             attribute_value_class = attribute_type.VALUE_CLASS
             attribute_value = attribute_value_class.from_serialized_value(attribute_value_input)
             new_attribute = attribute_value.instantiate_attribute(attribute_type, self)
+            # Validate eagerly: the deferred-operations path used by the bulk
+            # REST endpoint ultimately calls QuerySet.bulk_update() /
+            # bulk_create(), which bypass both save() and full_clean().
+            if isinstance(new_attribute, AttributeChoice | AttributeChoiceWithText):
+                _validate_attribute_choice_is_assignable(new_attribute)
             return ('create', new_attribute)
         if self._value_is_empty(value_parameters):
             return ('delete', existing_attribute)
         for k, v in value_parameters.items():
             setattr(existing_attribute, k, v)
+        if isinstance(existing_attribute, AttributeChoice | AttributeChoiceWithText):
+            _validate_attribute_choice_is_assignable(existing_attribute)
         return ('update', existing_attribute, list(value_parameters.keys()))
 
     def set_category_choice_attribute(self, attribute_type, existing_attribute, category_ids):

--- a/actions/mutations_action.py
+++ b/actions/mutations_action.py
@@ -263,6 +263,7 @@ class ActionMutations:
                 act_obj = existing_act
             else:
                 act_obj = AttributeChoiceWithText(**kwargs)
+            self._reject_inactive_choice(choice_obj, existing_act, attribute_type)
             act_obj.choice = choice_obj
             act_obj.text = value.text.value if value.text is not None else ''
             obj = act_obj
@@ -276,10 +277,37 @@ class ActionMutations:
                 ac_obj = AttributeChoice(**kwargs)
             if not choice_obj:
                 raise ValidationError(f'Choice is required for attribute type {attribute_type.identifier}.')
+            self._reject_inactive_choice(choice_obj, existing_ac, attribute_type)
             ac_obj.choice = choice_obj
             obj = ac_obj
         obj.full_clean()
         obj.save()
+
+    @staticmethod
+    def _reject_inactive_choice(
+        choice_obj: AttributeTypeChoiceOption | None,
+        existing: AttributeChoice | AttributeChoiceWithText | None,
+        attribute_type: AttributeType,
+    ) -> None:
+        """
+        Reject an attempt to set an archived choice option as a new value.
+
+        Archived options are hidden from pickers; GraphQL returns them with
+        `isActive=False` so REST-driven UIs can still resolve labels for
+        historical PKs. Either way, a client could send an archived PK here
+        directly. Allow it only when the action already has this exact
+        archived option as its value (so an in-place re-save of the same
+        value works).
+        """
+        if choice_obj is None or choice_obj.is_active:
+            return
+        current_choice_id = existing.choice_id if existing is not None else None
+        if current_choice_id == choice_obj.pk:
+            return
+        raise ValidationError(
+            f"Choice option '{choice_obj.identifier}' on attribute type "
+            f"'{attribute_type.identifier}' is archived and cannot be selected.",
+        )
 
     def _set_action_responsible_parties(self, info: gql.Info, action: Action, parties: list[ActionResponsiblePartyInput]) -> None:
         plan = action.plan

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -865,6 +865,11 @@ class AttributeTypeNode(DjangoNode[AttributeType]):
     format = graphene.Field(AttributeTypeFormat, required=True)
 
     class Meta:
+        # `choiceOptions` returns ALL options including archived ones. Each
+        # option exposes `isActive` so clients can filter for selection UIs
+        # while still resolving the labels of historical values (e.g. the
+        # spreadsheet table editor receives raw choice PKs via REST and needs
+        # the corresponding names regardless of archive state).
         model = AttributeType
         fields = public_fields(AttributeType)
 

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -980,3 +980,221 @@ class TestCategoryAttributeDeletion:
 
         # Attribute should be deleted
         assert AttributeChoice.objects.filter(content_type=ct, object_id=category.pk).count() == 0
+
+
+# =============================================================================
+# 6. Archive / Unarchive API
+# =============================================================================
+
+
+class TestArchiveApi:
+    """Tests for AttributeTypeChoiceOption.archive()/unarchive() and is_referenced()."""
+
+    def test_archive_flips_flag_and_preserves_order(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        first = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='First',
+        )
+        second = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Second',
+        )
+        original_order = first.order
+        assert first.is_active
+        assert second.is_active
+
+        first.archive()
+        first.refresh_from_db()
+
+        assert first.is_active is False
+        # Archive does not move the row; the order slot stays reserved so new
+        # active options don't collide with it.
+        assert first.order == original_order
+
+        # The other active option is untouched.
+        second.refresh_from_db()
+        assert second.is_active is True
+
+    def test_archive_is_idempotent(
+        self,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        attribute_type_choice_option.archive()
+        attribute_type_choice_option.refresh_from_db()
+        order_after_first_archive = attribute_type_choice_option.order
+
+        attribute_type_choice_option.archive()
+        attribute_type_choice_option.refresh_from_db()
+
+        assert attribute_type_choice_option.is_active is False
+        assert attribute_type_choice_option.order == order_after_first_archive
+
+    def test_unarchive_restores_active_flag(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Cycles',
+        )
+        original_order = option.order
+
+        option.archive()
+        option.refresh_from_db()
+        assert option.is_active is False
+
+        option.unarchive()
+        option.refresh_from_db()
+
+        assert option.is_active is True
+        # Unarchive leaves the original order slot in place.
+        assert option.order == original_order
+
+    def test_unarchive_is_idempotent(
+        self,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        original_order = attribute_type_choice_option.order
+        attribute_type_choice_option.unarchive()
+        attribute_type_choice_option.refresh_from_db()
+
+        assert attribute_type_choice_option.is_active is True
+        assert attribute_type_choice_option.order == original_order
+
+    def test_new_option_does_not_collide_with_archived_order(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # Archiving a row keeps it in the (type, order) unique-constraint
+        # picture. A newly created option must skip that slot.
+        first = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='First',
+        )
+        first.archive()
+        first.refresh_from_db()
+
+        second = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Second',
+        )
+
+        assert second.order != first.order
+
+    def test_active_queryset_excludes_archived(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        gone = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Gone',
+        )
+        gone.archive()
+
+        active = set(
+            AttributeTypeChoiceOption.objects
+            .filter(type=action_attribute_type__ordered_choice)
+            .active()
+            .values_list('pk', flat=True),
+        )
+        archived = set(
+            AttributeTypeChoiceOption.objects
+            .filter(type=action_attribute_type__ordered_choice)
+            .archived()
+            .values_list('pk', flat=True),
+        )
+        assert active == {kept.pk}
+        assert archived == {gone.pk}
+
+    def test_is_referenced_when_live_attribute_choice_exists(
+        self,
+        action_with_choice_attribute: Action,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        del action_with_choice_attribute  # the fixture creates the AttributeChoice
+        assert attribute_type_choice_option.is_referenced() is True
+
+    def test_is_referenced_when_live_attribute_choice_with_text_exists(
+        self,
+        action_with_choice_with_text_attribute: Action,
+        attribute_type_choice_option__optional: AttributeTypeChoiceOption,
+    ):
+        del action_with_choice_with_text_attribute
+        assert attribute_type_choice_option__optional.is_referenced() is True
+
+    def test_is_referenced_when_wagtail_revision_references_option(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        import json
+
+        from wagtail.models import Revision
+
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Referenced in draft',
+        )
+
+        # Inject a Wagtail revision whose serialized content references this
+        # option. `Revision.content` is a JSONField; the codebase stores it as
+        # serialized text and matches against substrings of that text, so we
+        # do the same here.
+        Revision.objects.create(
+            content_type=ContentType.objects.get_for_model(Action),
+            base_content_type=ContentType.objects.get_for_model(Action),
+            object_id=str(action.pk),
+            content=json.loads(
+                json.dumps({
+                    'attributes': {
+                        'ordered_choice': {
+                            str(action_attribute_type__ordered_choice.pk): option.pk,
+                        },
+                    },
+                })
+            ),
+        )
+
+        assert option.is_referenced() is True
+
+    def test_is_referenced_when_reversion_version_references_option(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+        user: User,
+    ):
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Referenced in reversion',
+        )
+        attr = AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        with reversion.create_revision():
+            reversion.set_user(user)
+            reversion.add_to_revision(attr)
+
+        # Hard-delete the live attribute so we know the True comes from the
+        # reversion Version row, not the live FK.
+        attr.delete()
+        assert not AttributeChoice.objects.filter(choice=option).exists()
+
+        assert option.is_referenced() is True
+
+    def test_is_referenced_returns_false_when_unused(
+        self,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        assert attribute_type_choice_option.is_referenced() is False

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -1982,3 +1982,67 @@ class TestUnarchiveView:
         option.refresh_from_db()
         assert option.is_active is False
 
+
+# =============================================================================
+# 10. ChoiceOptionArchivePanel (badge + unarchive button)
+# =============================================================================
+
+
+class TestArchivePanel:
+    """The inline archive panel surfaces archive state and an unarchive button."""
+
+    def _bound_panel(self, option: AttributeTypeChoiceOption):
+        from actions.attribute_type_admin import ChoiceOptionArchivePanel
+
+        panel = ChoiceOptionArchivePanel().bind_to_model(AttributeTypeChoiceOption)
+        return panel.get_bound_panel(instance=option)
+
+    def test_hidden_for_active_option(
+        self,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        bound = self._bound_panel(attribute_type_choice_option)
+        assert bound.is_shown() is False
+
+    def test_shown_for_archived_option(
+        self,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        attribute_type_choice_option.archive()
+        attribute_type_choice_option.refresh_from_db()
+
+        bound = self._bound_panel(attribute_type_choice_option)
+        assert bound.is_shown() is True
+
+    def test_renders_badge_and_unarchive_button(
+        self,
+        attribute_type_choice_option: AttributeTypeChoiceOption,
+    ):
+        attribute_type_choice_option.archive()
+        attribute_type_choice_option.refresh_from_db()
+        bound = self._bound_panel(attribute_type_choice_option)
+
+        html = bound.render_html()
+
+        assert 'Archived' in html
+        assert 'Unarchive' in html
+        # The unarchive button must point at the correct admin URL.
+        expected_path = (
+            f'/admin/actions/attributetype/{attribute_type_choice_option.type_id}/'
+            f'unarchive-choice-option/{attribute_type_choice_option.pk}/'
+        )
+        assert expected_path in html
+
+    def test_unsaved_option_is_not_shown(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # An option being added via the inline editor has no pk yet — the
+        # panel must not try to construct an unarchive URL for it.
+        option = AttributeTypeChoiceOption(
+            type=action_attribute_type__ordered_choice,
+            name='Not saved',
+            is_active=False,
+        )
+        bound = self._bound_panel(option)
+        assert bound.is_shown() is False

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -2208,9 +2208,9 @@ class TestArchiveNotification:
 
 
 class TestUsagePanelWording:
-    """The usage panel explains that deletion becomes archive when in use."""
+    """The usage panel keeps delete-specific copy behind a delete confirmation."""
 
-    def test_panel_mentions_archive_behavior(
+    def test_panel_shows_usage_and_defers_archive_behavior_to_delete_confirmation(
         self,
         plan: Plan,
         action_attribute_type__ordered_choice: AttributeType,
@@ -2240,7 +2240,9 @@ class TestUsagePanelWording:
         bound = panel.get_bound_panel(instance=option)
         html = bound.render_html()
 
+        assert 'Currently used by:' in html
+        assert 'Changing this choice option will change the choice' in html
+        assert 'kausalConfirmChoiceOptionDelete' in html
+        assert 'archived instead of permanently deleted' in html
         assert 'archived' in html.lower()
-        # The new wording should not still say "delete in all these objects".
-        assert 'delete' in html.lower()
-        assert 'remove' in html.lower() or 'removed' in html.lower()
+        assert 'If you delete it from the list below' not in html

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -1811,6 +1811,60 @@ class TestArchivableFormset:
         # The other option stays put.
         assert AttributeTypeChoiceOption.objects.filter(pk=kept.pk, is_active=True).exists()
 
+    def test_archive_is_recorded_for_post_save_notification(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        referenced = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Referenced',
+        )
+        action = ActionFactory.create(plan=plan)
+        AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=referenced,
+        )
+
+        formset = self._build_formset(
+            action_attribute_type__ordered_choice,
+            [kept, referenced],
+            delete_pk=referenced.pk,
+        )
+        assert formset.is_valid(), formset.errors
+
+        formset.save(commit=True)
+
+        # The view reads this list to surface a post-save warning to the user.
+        assert [o.pk for o in formset.archived_on_last_save] == [referenced.pk]
+
+    def test_archived_on_last_save_is_empty_when_no_archive_happened(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        unused = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Unused',
+        )
+        formset = self._build_formset(
+            action_attribute_type__ordered_choice,
+            [kept, unused],
+            delete_pk=unused.pk,
+        )
+        assert formset.is_valid(), formset.errors
+        formset.save(commit=True)
+
+        assert formset.archived_on_last_save == []
+
     def test_delete_existing_hard_deletes_unreferenced_option(
         self,
         action_attribute_type__ordered_choice: AttributeType,
@@ -2046,3 +2100,145 @@ class TestArchivePanel:
         )
         bound = self._bound_panel(option)
         assert bound.is_shown() is False
+
+
+# =============================================================================
+# 11. Post-save notification + usage panel wording
+# =============================================================================
+
+
+class TestArchiveNotification:
+    """The edit view warns the user when 'delete' got converted to archive."""
+
+    def test_form_valid_emits_warning_for_each_archived_option(
+        self,
+        rf,
+        plan_admin_user,
+        action_attribute_type__ordered_choice: AttributeType,
+        monkeypatch,
+    ):
+        from types import SimpleNamespace
+
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.http import HttpResponseRedirect
+
+        from actions.attribute_type_admin import AttributeTypeEditView
+
+        first = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='First archived',
+        )
+        second = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Second archived',
+        )
+
+        request = rf.post('/admin/actions/attributetype/edit/1/')
+        request.user = plan_admin_user
+        request.session = SimpleNamespace()
+        request._messages = FallbackStorage(request)
+
+        # The view's super().form_valid would normally trigger model saves and
+        # a redirect; we only care about what our own override layers on top.
+        monkeypatch.setattr(
+            'actions.attribute_type_admin.AplansEditView.form_valid',
+            lambda *_a, **_k: HttpResponseRedirect('/done'),
+        )
+
+        # The view's __init__ requires modeladmin context we don't need to
+        # exercise here; bypass it and set the request directly.
+        view = AttributeTypeEditView.__new__(AttributeTypeEditView)
+        view.request = request
+
+        archived_formset = SimpleNamespace(archived_on_last_save=[first, second])
+        untouched_formset = SimpleNamespace(archived_on_last_save=[])
+        no_attr_formset = SimpleNamespace()
+        form = SimpleNamespace(
+            formsets={
+                'choice_options': archived_formset,
+                'other': untouched_formset,
+                'legacy': no_attr_formset,
+            },
+        )
+
+        response = view.form_valid(form)
+
+        assert response.status_code == 302
+        messages_emitted = [str(m) for m in request._messages]
+        assert any('First archived' in m for m in messages_emitted)
+        assert any('Second archived' in m for m in messages_emitted)
+        # No spurious messages for the formsets without archived items.
+        assert len(messages_emitted) == 2
+
+    def test_form_valid_emits_nothing_when_no_archives_happened(
+        self,
+        rf,
+        plan_admin_user,
+        monkeypatch,
+    ):
+        from types import SimpleNamespace
+
+        from django.contrib.messages.storage.fallback import FallbackStorage
+        from django.http import HttpResponseRedirect
+
+        from actions.attribute_type_admin import AttributeTypeEditView
+
+        request = rf.post('/admin/actions/attributetype/edit/1/')
+        request.user = plan_admin_user
+        request.session = SimpleNamespace()
+        request._messages = FallbackStorage(request)
+        monkeypatch.setattr(
+            'actions.attribute_type_admin.AplansEditView.form_valid',
+            lambda *_a, **_k: HttpResponseRedirect('/done'),
+        )
+
+        # The view's __init__ requires modeladmin context we don't need to
+        # exercise here; bypass it and set the request directly.
+        view = AttributeTypeEditView.__new__(AttributeTypeEditView)
+        view.request = request
+
+        formset = SimpleNamespace(archived_on_last_save=[])
+        form = SimpleNamespace(formsets={'choice_options': formset})
+
+        view.form_valid(form)
+
+        assert list(request._messages) == []
+
+
+class TestUsagePanelWording:
+    """The usage panel explains that deletion becomes archive when in use."""
+
+    def test_panel_mentions_archive_behavior(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        from actions.attribute_type_admin import (
+            ChoiceOptionUsagePanel,
+            _get_choice_option_usage,
+        )
+
+        # Create an option that's referenced by a live action attribute, so
+        # the usage panel surfaces it.
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Used',
+        )
+        action = ActionFactory.create(plan=plan)
+        AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+
+        usage = _get_choice_option_usage(action_attribute_type__ordered_choice)
+        assert option.pk in usage
+
+        panel = ChoiceOptionUsagePanel(usage).bind_to_model(AttributeTypeChoiceOption)
+        bound = panel.get_bound_panel(instance=option)
+        html = bound.render_html()
+
+        assert 'archived' in html.lower()
+        # The new wording should not still say "delete in all these objects".
+        assert 'delete' in html.lower()
+        assert 'remove' in html.lower() or 'removed' in html.lower()

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -991,7 +991,7 @@ class TestCategoryAttributeDeletion:
 class TestArchiveApi:
     """Tests for AttributeTypeChoiceOption.archive()/unarchive() and is_referenced()."""
 
-    def test_archive_flips_flag_and_preserves_order(
+    def test_archive_flips_flag_and_moves_order_out_of_active_range(
         self,
         action_attribute_type__ordered_choice: AttributeType,
     ):
@@ -1003,7 +1003,6 @@ class TestArchiveApi:
             type=action_attribute_type__ordered_choice,
             name='Second',
         )
-        original_order = first.order
         assert first.is_active
         assert second.is_active
 
@@ -1011,13 +1010,10 @@ class TestArchiveApi:
         first.refresh_from_db()
 
         assert first.is_active is False
-        # Archive does not move the row; the order slot stays reserved so new
-        # active options don't collide with it.
-        assert first.order == original_order
-
-        # The other active option is untouched.
+        # Archive bumps the row above all siblings so the inline editor's
+        # renumbering of active rows can't collide with it.
         second.refresh_from_db()
-        assert second.is_active is True
+        assert first.order > second.order
 
     def test_archive_is_idempotent(
         self,
@@ -1037,11 +1033,14 @@ class TestArchiveApi:
         self,
         action_attribute_type__ordered_choice: AttributeType,
     ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Active',
+        )
         option = AttributeTypeChoiceOptionFactory.create(
             type=action_attribute_type__ordered_choice,
             name='Cycles',
         )
-        original_order = option.order
 
         option.archive()
         option.refresh_from_db()
@@ -1049,10 +1048,12 @@ class TestArchiveApi:
 
         option.unarchive()
         option.refresh_from_db()
+        kept.refresh_from_db()
 
         assert option.is_active is True
-        # Unarchive leaves the original order slot in place.
-        assert option.order == original_order
+        # Unarchive places the option at the end of the order so it doesn't
+        # collide with the inline editor's renumbering of other rows.
+        assert option.order > kept.order
 
     def test_unarchive_is_idempotent(
         self,
@@ -1727,4 +1728,257 @@ class TestPickerVisibility:
             == 1
         ), 'the existing archived AttributeChoice should still be present'
 
+
+# =============================================================================
+# 8. Inline formset: archive-on-delete + hard-delete fallback
+# =============================================================================
+
+
+class TestArchivableFormset:
+    """The choice_options inline formset archives referenced options on delete."""
+
+    def _build_formset(
+        self,
+        attribute_type: AttributeType,
+        options: list[AttributeTypeChoiceOption],
+        delete_pk: int,
+    ):
+        from modelcluster.forms import childformset_factory
+
+        from aplans.utils import ArchivableOrderedModelChildFormSet
+
+        FormSet = childformset_factory(
+            AttributeType,
+            AttributeTypeChoiceOption,
+            formset=ArchivableOrderedModelChildFormSet,
+            fields=['name'],
+            can_delete=True,
+            extra=0,
+        )
+
+        prefix = 'choice_options'
+        data = {
+            f'{prefix}-TOTAL_FORMS': str(len(options)),
+            f'{prefix}-INITIAL_FORMS': str(len(options)),
+            f'{prefix}-MIN_NUM_FORMS': '0',
+            f'{prefix}-MAX_NUM_FORMS': '1000',
+        }
+        for i, option in enumerate(options):
+            data[f'{prefix}-{i}-id'] = str(option.pk)
+            data[f'{prefix}-{i}-name'] = option.name
+            data[f'{prefix}-{i}-ORDER'] = str(i)
+            if option.pk == delete_pk:
+                data[f'{prefix}-{i}-DELETE'] = 'on'
+
+        return FormSet(data=data, instance=attribute_type, prefix=prefix)
+
+    def test_delete_existing_archives_referenced_option(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        referenced = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Referenced',
+        )
+        action = ActionFactory.create(plan=plan)
+        AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=referenced,
+        )
+
+        formset = self._build_formset(
+            action_attribute_type__ordered_choice,
+            [kept, referenced],
+            delete_pk=referenced.pk,
+        )
+        assert formset.is_valid(), formset.errors
+
+        formset.save(commit=True)
+
+        # The referenced option is archived, not deleted.
+        referenced.refresh_from_db()
+        assert referenced.is_active is False
+
+        # The live AttributeChoice row that pointed at it is still there.
+        assert AttributeChoice.objects.filter(choice=referenced).exists()
+
+        # The other option stays put.
+        assert AttributeTypeChoiceOption.objects.filter(pk=kept.pk, is_active=True).exists()
+
+    def test_delete_existing_hard_deletes_unreferenced_option(
+        self,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        unused = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Unused',
+        )
+
+        formset = self._build_formset(
+            action_attribute_type__ordered_choice,
+            [kept, unused],
+            delete_pk=unused.pk,
+        )
+        assert formset.is_valid(), formset.errors
+
+        formset.save(commit=True)
+
+        assert not AttributeTypeChoiceOption.objects.filter(pk=unused.pk).exists()
+        assert AttributeTypeChoiceOption.objects.filter(pk=kept.pk, is_active=True).exists()
+
+    def test_archive_a_non_last_referenced_option_does_not_collide_on_order(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # If the archived option isn't the last in order, the parent
+        # OrderedModelChildFormSet compacts the remaining rows starting at
+        # order 0. The archived row must be moved out of the active range
+        # *before* that compaction runs — otherwise the freshly compacted
+        # active row collides with the still-unchanged archived row on
+        # (type, order).
+        first = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived first',
+        )
+        second = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Second',
+        )
+        action = ActionFactory.create(plan=plan)
+        AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=first,
+        )
+
+        formset = self._build_formset(
+            action_attribute_type__ordered_choice,
+            [first, second],
+            delete_pk=first.pk,
+        )
+        assert formset.is_valid(), formset.errors
+
+        # Must not raise IntegrityError.
+        formset.save(commit=True)
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.is_active is False
+        assert second.is_active is True
+        assert first.order != second.order
+
+
+# =============================================================================
+# 9. Unarchive admin view
+# =============================================================================
+
+
+class TestUnarchiveView:
+    """The unarchive admin URL restores an archived option to active."""
+
+    def _unarchive_url(self, attribute_type: AttributeType, option: AttributeTypeChoiceOption) -> str:
+        return f'/admin/actions/attributetype/{attribute_type.pk}/unarchive-choice-option/{option.pk}/'
+
+    def test_post_unarchives_option(
+        self,
+        client,
+        plan_admin_user,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Bring back',
+        )
+        option.archive()
+        option.refresh_from_db()
+        assert option.is_active is False
+
+        client.force_login(plan_admin_user)
+        response = client.post(
+            self._unarchive_url(action_attribute_type__ordered_choice, option),
+        )
+
+        assert response.status_code == 302
+        option.refresh_from_db()
+        assert option.is_active is True
+
+    def test_get_is_rejected(
+        self,
+        client,
+        plan_admin_user,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # State-changing endpoint should refuse GET.
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Stays archived',
+        )
+        option.archive()
+
+        client.force_login(plan_admin_user)
+        response = client.get(
+            self._unarchive_url(action_attribute_type__ordered_choice, option),
+        )
+
+        assert response.status_code == 405
+        option.refresh_from_db()
+        assert option.is_active is False
+
+    def test_unauthenticated_request_is_redirected_to_login(
+        self,
+        client,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Stays archived',
+        )
+        option.archive()
+
+        response = client.post(
+            self._unarchive_url(action_attribute_type__ordered_choice, option),
+        )
+
+        assert response.status_code in (302, 403)
+        option.refresh_from_db()
+        assert option.is_active is False
+
+    def test_option_for_wrong_attribute_type_returns_404(
+        self,
+        client,
+        plan_admin_user,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        other_type = AttributeTypeFactory.create(
+            object_content_type=ContentType.objects.get_for_model(Action),
+            scope=plan,
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+            name='Other',
+        )
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=other_type,
+            name='Belongs to other type',
+        )
+        option.archive()
+
+        client.force_login(plan_admin_user)
+        response = client.post(
+            self._unarchive_url(action_attribute_type__ordered_choice, option),
+        )
+
+        assert response.status_code == 404
+        option.refresh_from_db()
+        assert option.is_active is False
 

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import reversion
 from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 
 import pytest
 
@@ -1084,6 +1085,148 @@ class TestArchiveApi:
 
         assert second.order != first.order
 
+
+# =============================================================================
+# 7. Picker visibility of archived options
+# =============================================================================
+
+
+class TestPickerVisibility:
+    """Editor pickers and GraphQL listings hide archived options."""
+
+    def _picker_options(
+        self,
+        attribute_type: AttributeType,
+        user: User,
+        plan: Plan,
+        obj: Action | None = None,
+    ):
+        wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(attribute_type)
+        fields = wrapper.get_all_form_fields(user=user, plan=plan, obj=obj)
+        # The choice picker is the field whose django_field is a ModelChoiceField.
+        from django.forms import ModelChoiceField
+
+        choice_fields = [f for f in fields if isinstance(f.django_field, ModelChoiceField)]
+        assert choice_fields, 'expected a ModelChoiceField in the form fields'
+        return list(choice_fields[0].django_field.queryset)
+
+    def test_ordered_choice_picker_excludes_archived_options(
+        self,
+        plan: Plan,
+        user: User,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        gone = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Gone',
+        )
+        gone.archive()
+
+        options = self._picker_options(action_attribute_type__ordered_choice, user, plan)
+        pks = {o.pk for o in options}
+
+        assert kept.pk in pks
+        assert gone.pk not in pks
+
+    def test_picker_keeps_currently_selected_archived_option(
+        self,
+        plan: Plan,
+        user: User,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        archived = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Stale value',
+        )
+        action = ActionFactory.create(plan=plan)
+        AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=archived,
+        )
+        archived.archive()
+
+        options = self._picker_options(
+            action_attribute_type__ordered_choice,
+            user,
+            plan,
+            obj=action,
+        )
+        pks = {o.pk for o in options}
+
+        assert archived.pk in pks, 'archived option must remain selectable so the existing value is preserved'
+
+    def test_optional_choice_with_text_picker_excludes_archived(
+        self,
+        plan: Plan,
+        user: User,
+        action_attribute_type__optional_choice: AttributeType,
+    ):
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__optional_choice,
+            name='Kept',
+        )
+        gone = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__optional_choice,
+            name='Gone',
+        )
+        gone.archive()
+
+        options = self._picker_options(action_attribute_type__optional_choice, user, plan)
+        pks = {o.pk for o in options}
+
+        assert kept.pk in pks
+        assert gone.pk not in pks
+
+    def test_graphql_choice_options_lists_archived_with_is_active_flag(
+        self,
+        graphql_client_query_data,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # GraphQL exposes archived options so REST consumers (e.g. the
+        # spreadsheet table editor) can resolve labels for historical PKs.
+        # Each option carries `isActive` so clients can filter when building
+        # selection UIs.
+        kept = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Kept',
+        )
+        gone = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Gone',
+        )
+        gone.archive()
+
+        data = graphql_client_query_data(
+            """
+            query($plan: ID!) {
+                plan(id: $plan) {
+                    actionAttributeTypes {
+                        name
+                        choiceOptions {
+                            name
+                            isActive
+                        }
+                    }
+                }
+            }
+            """,
+            variables={'plan': plan.identifier},
+        )
+
+        attr_type_data = next(
+            at for at in data['plan']['actionAttributeTypes'] if at['name'] == action_attribute_type__ordered_choice.name
+        )
+
+        by_name = {opt['name']: opt for opt in attr_type_data['choiceOptions']}
+        assert by_name[kept.name]['isActive'] is True
+        assert by_name[gone.name]['isActive'] is False
+
     def test_active_queryset_excludes_archived(
         self,
         action_attribute_type__ordered_choice: AttributeType,
@@ -1198,3 +1341,390 @@ class TestArchiveApi:
         attribute_type_choice_option: AttributeTypeChoiceOption,
     ):
         assert attribute_type_choice_option.is_referenced() is False
+
+    def test_full_clean_rejects_new_attribute_with_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # Defense in depth: any save path that runs full_clean() — REST,
+        # admin forms, anything that calls .clean() — must reject an
+        # archived option being assigned as a new value.
+        from django.core.exceptions import ValidationError as CoreValidationError
+
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived',
+        )
+        option.archive()
+
+        attr = AttributeChoice(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        with pytest.raises(CoreValidationError):
+            attr.full_clean()
+
+    def test_full_clean_allows_resaving_existing_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Once-active',
+        )
+        attr = AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        option.archive()
+
+        # Re-saving the same archived option on the existing row must succeed
+        # so admins can save unrelated edits without first picking a new option.
+        attr.full_clean()
+
+    def test_full_clean_rejects_switching_to_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        from django.core.exceptions import ValidationError as CoreValidationError
+
+        action = ActionFactory.create(plan=plan)
+        active = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Active',
+        )
+        archived = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived',
+        )
+        attr = AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=active,
+        )
+        archived.archive()
+
+        attr.choice = archived
+        with pytest.raises(CoreValidationError):
+            attr.full_clean()
+
+    def test_save_rejects_new_attribute_with_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # DRF and other paths bypass full_clean() and call .save() directly,
+        # so the rule has to hold at save time too.
+        from django.core.exceptions import ValidationError as CoreValidationError
+
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived',
+        )
+        option.archive()
+
+        attr = AttributeChoice(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        with pytest.raises(CoreValidationError):
+            attr.save()
+        action_ct = ContentType.objects.get_for_model(Action)
+        assert (
+            AttributeChoice.objects.filter(
+                type=action_attribute_type__ordered_choice,
+                content_type=action_ct,
+                object_id=action.pk,
+            ).count()
+            == 0
+        )
+
+    def test_save_allows_resaving_existing_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Once-active',
+        )
+        attr = AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        option.archive()
+
+        # No exception — in-place re-save of an unchanged archived value is OK.
+        attr.save()
+
+    def test_save_rejects_switching_to_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        from django.core.exceptions import ValidationError as CoreValidationError
+
+        action = ActionFactory.create(plan=plan)
+        active = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Active',
+        )
+        archived = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived',
+        )
+        attr = AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=active,
+        )
+        archived.archive()
+
+        attr.choice = archived
+        with pytest.raises(CoreValidationError):
+            attr.save()
+        attr.refresh_from_db()
+        assert attr.choice_id == active.pk
+
+    def test_set_attribute_rejects_archived_choice_for_rest_bulk_path(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # The REST bulk path queues operations through `set_attribute()` and
+        # later applies them via QuerySet.bulk_update()/bulk_create(), which
+        # bypass both save() and full_clean(). The guard at set_attribute()
+        # rejects archived options before the op reaches the queue.
+        from django.core.exceptions import ValidationError as CoreValidationError
+
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+
+        action = ActionFactory.create(plan=plan)
+        archived_opt = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived',
+        )
+        archived_opt.archive()
+
+        wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(
+            action_attribute_type__ordered_choice,
+        )
+
+        with pytest.raises(CoreValidationError):
+            action.set_attribute(
+                attribute_type=wrapper,
+                existing_attribute=None,
+                value_parameters={'choice_id': archived_opt.pk},
+                attribute_value_input=archived_opt.pk,
+            )
+
+    def test_set_attribute_allows_resaving_existing_archived_choice(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        from actions.attributes import AttributeType as AttributeTypeWrapper
+
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Once-active',
+        )
+        existing = AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        option.archive()
+
+        wrapper: AttributeTypeWrapper = AttributeTypeWrapper.from_model_instance(
+            action_attribute_type__ordered_choice,
+        )
+
+        # Re-asserting the same archived option as the current value must pass —
+        # this matches the picker's "keep selected archived value editable" UX.
+        op = action.set_attribute(
+            attribute_type=wrapper,
+            existing_attribute=existing,
+            value_parameters={'choice_id': option.pk},
+            attribute_value_input=option.pk,
+        )
+        assert op[0] == 'update'
+
+    def test_save_allows_archived_choice_referenced_in_parent_draft(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # The publish-from-draft path: a draft of this action selected the
+        # option, the option was later archived (kept around solely because
+        # is_referenced() found the draft), and publishing the draft now
+        # creates a new AttributeChoice with the archived choice. The
+        # model-layer validator must allow this — rejecting it would block
+        # users from publishing drafts that pre-date the archive.
+        from wagtail.models import Revision
+
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Picked in draft, then archived',
+        )
+        Revision.objects.create(
+            content_type=ContentType.objects.get_for_model(Action),
+            base_content_type=ContentType.objects.get_for_model(Action),
+            object_id=str(action.pk),
+            content={
+                'attributes': {
+                    'ordered_choice': {
+                        str(action_attribute_type__ordered_choice.pk): option.pk,
+                    },
+                },
+            },
+        )
+        option.archive()
+
+        # Materialise the choice from the draft — same path that
+        # `Action.commit_attributes()` takes on publish.
+        attr = AttributeChoice(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        attr.save()
+        assert attr.pk is not None
+        assert attr.choice_id == option.pk
+
+    def test_save_still_rejects_archived_choice_without_draft_reference(
+        self,
+        plan: Plan,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # Counterpart to the publish-from-draft case: when no revision of
+        # this action references the choice, the model-layer guard still
+        # rejects a fresh archived selection.
+        from django.core.exceptions import ValidationError as CoreValidationError
+
+        action = ActionFactory.create(plan=plan)
+        option = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived without draft',
+        )
+        option.archive()
+
+        attr = AttributeChoice(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=option,
+        )
+        with pytest.raises(CoreValidationError):
+            attr.save()
+
+    def test_rest_bulk_update_rejects_archived_choice_before_save(
+        self,
+        api_client,
+        plan: Plan,
+        plan_admin_user,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # Reproduce the production bypass: a REST PUT to /v1/plan/<id>/actions/
+        # carrying an archived choice option as a new assignment.
+        # The validation must fire during is_valid(), before the (potentially
+        # expensive) Action save runs — the response should be a 400 with no
+        # AttributeChoice row written.
+        action_ct = ContentType.objects.get_for_model(Action)
+        action = ActionFactory.create(plan=plan)
+        archived_opt = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Archived',
+        )
+        archived_opt.archive()
+
+        api_client.force_login(plan_admin_user)
+        url = reverse('action-list', args=(plan.pk,))
+        payload = [
+            {
+                'id': action.pk,
+                'identifier': action.identifier,
+                'name': action.name,
+                'choice_attributes': {
+                    action_attribute_type__ordered_choice.identifier: archived_opt.pk,
+                },
+            },
+        ]
+
+        response = api_client.put(url, data=payload)
+
+        assert response.status_code == 400, response.content
+        assert (
+            AttributeChoice.objects.filter(
+                type=action_attribute_type__ordered_choice,
+                content_type=action_ct,
+                object_id=action.pk,
+            ).count()
+            == 0
+        ), 'no AttributeChoice should be written'
+
+    def test_rest_bulk_update_allows_resaving_existing_archived_choice(
+        self,
+        api_client,
+        plan: Plan,
+        plan_admin_user,
+        action_attribute_type__ordered_choice: AttributeType,
+    ):
+        # The action already has this option as its current value, and the
+        # option was later archived. A bulk PUT that re-submits the same
+        # archived option (e.g. while editing unrelated fields) must NOT
+        # be rejected — the value isn't changing, only being preserved.
+        # Regression: the bulk path used to bail out of target-instance
+        # resolution and lose track of the existing value entirely.
+        action_ct = ContentType.objects.get_for_model(Action)
+        action = ActionFactory.create(plan=plan)
+        opt = AttributeTypeChoiceOptionFactory.create(
+            type=action_attribute_type__ordered_choice,
+            name='Stored then archived',
+        )
+        AttributeChoiceFactory.create(
+            type=action_attribute_type__ordered_choice,
+            content_object=action,
+            choice=opt,
+        )
+        opt.archive()
+
+        api_client.force_login(plan_admin_user)
+        url = reverse('action-list', args=(plan.pk,))
+        payload = [
+            {
+                'id': action.pk,
+                'identifier': action.identifier,
+                'name': action.name,
+                'choice_attributes': {
+                    action_attribute_type__ordered_choice.identifier: opt.pk,
+                },
+            },
+        ]
+
+        response = api_client.put(url, data=payload)
+
+        assert response.status_code == 200, response.content
+        assert (
+            AttributeChoice.objects.filter(
+                type=action_attribute_type__ordered_choice,
+                content_type=action_ct,
+                object_id=action.pk,
+                choice=opt,
+            ).count()
+            == 1
+        ), 'the existing archived AttributeChoice should still be present'
+
+

--- a/actions/tests/test_attribute_type_choice_option_deletion.py
+++ b/actions/tests/test_attribute_type_choice_option_deletion.py
@@ -11,7 +11,7 @@ gracefully across different contexts:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 import reversion
 from django.contrib.contenttypes.models import ContentType
@@ -1109,7 +1109,9 @@ class TestPickerVisibility:
 
         choice_fields = [f for f in fields if isinstance(f.django_field, ModelChoiceField)]
         assert choice_fields, 'expected a ModelChoiceField in the form fields'
-        return list(choice_fields[0].django_field.queryset)
+        django_field = cast('ModelChoiceField', choice_fields[0].django_field)
+        assert django_field.queryset is not None
+        return list(django_field.queryset)
 
     def test_ordered_choice_picker_excludes_archived_options(
         self,
@@ -1747,10 +1749,10 @@ class TestArchivableFormset:
 
         from aplans.utils import ArchivableOrderedModelChildFormSet
 
-        FormSet = childformset_factory(
+        FormSet: Any = childformset_factory(
             AttributeType,
             AttributeTypeChoiceOption,
-            formset=ArchivableOrderedModelChildFormSet,
+            formset=cast('Any', ArchivableOrderedModelChildFormSet),
             fields=['name'],
             can_delete=True,
             extra=0,

--- a/actions/tests/test_graphql_mutations.py
+++ b/actions/tests/test_graphql_mutations.py
@@ -1356,6 +1356,157 @@ class TestUpdateAction:
         action_ct = ContentType.objects.get_for_model(Action)
         assert AttributeChoice.objects.filter(type=attr_type, content_type=action_ct, object_id=action.pk).count() == 1
 
+    def test_update_action_rejects_archived_choice_as_new_value(
+        self,
+        graphql_client_query,
+        client,
+        superuser: User,
+        plan: Plan,
+    ):
+        # An archived option is hidden from pickers and the GraphQL choiceOptions
+        # listing, but a client could still send its PK directly. The mutation
+        # must reject the attempt rather than letting the option resurface as a
+        # new selection.
+        client.force_login(superuser)
+        action = self._create_action(plan, 'ua-arch-new', 'Action Archived New')
+        attr_type = AttributeTypeFactory.create(
+            scope=plan,
+            object_content_type=ContentType.objects.get_for_model(Action),
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        )
+        opt = AttributeTypeChoiceOption.objects.create(
+            type=attr_type,
+            identifier='old-option',
+            name='Old Option',
+            order=0,
+        )
+        opt.archive()
+
+        response = graphql_client_query(
+            UPDATE_ACTION,
+            variables={
+                'planId': str(plan.pk),
+                'input': {
+                    'id': str(action.pk),
+                    'attributeValues': [
+                        {'attributeTypeId': str(attr_type.pk), 'value': {'choice': {'choiceId': str(opt.pk)}}},
+                    ],
+                },
+            },
+        )
+        data = response['data']['action']['updateAction']
+        assert data['messages'][0]['kind'] == 'VALIDATION'
+        assert 'archived' in data['messages'][0]['message']
+
+        action_ct = ContentType.objects.get_for_model(Action)
+        assert AttributeChoice.objects.filter(type=attr_type, content_type=action_ct, object_id=action.pk).count() == 0
+
+    def test_update_action_allows_resaving_existing_archived_choice(
+        self,
+        graphql_client_query_data,
+        client,
+        superuser: User,
+        plan: Plan,
+    ):
+        # When the existing attribute value already points at an archived
+        # option, re-submitting that same option must succeed — otherwise the
+        # action editor couldn't save unrelated changes without first picking
+        # a different value.
+        client.force_login(superuser)
+        action = self._create_action(plan, 'ua-arch-existing', 'Action Archived Existing')
+        attr_type = AttributeTypeFactory.create(
+            scope=plan,
+            object_content_type=ContentType.objects.get_for_model(Action),
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        )
+        opt = AttributeTypeChoiceOption.objects.create(
+            type=attr_type,
+            identifier='will-archive',
+            name='Will Archive',
+            order=0,
+        )
+        action_ct = ContentType.objects.get_for_model(Action)
+        AttributeChoice.objects.create(
+            type=attr_type,
+            content_type=action_ct,
+            object_id=action.pk,
+            choice=opt,
+        )
+        opt.archive()
+
+        data = graphql_client_query_data(
+            UPDATE_ACTION,
+            variables={
+                'planId': str(plan.pk),
+                'input': {
+                    'id': str(action.pk),
+                    'attributeValues': [
+                        {'attributeTypeId': str(attr_type.pk), 'value': {'choice': {'choiceId': str(opt.pk)}}},
+                    ],
+                },
+            },
+        )
+        result = data['action']['updateAction']
+        choice_attrs = [a for a in result['attributes'] if a.get('choice')]
+        assert len(choice_attrs) == 1
+        assert choice_attrs[0]['choice']['identifier'] == 'will-archive'
+
+    def test_update_action_rejects_switching_to_archived_choice(
+        self,
+        graphql_client_query,
+        client,
+        superuser: User,
+        plan: Plan,
+    ):
+        # Existing value points at an active option; the client tries to switch
+        # to a different option that has been archived. Should be rejected.
+        client.force_login(superuser)
+        action = self._create_action(plan, 'ua-arch-switch', 'Action Archived Switch')
+        attr_type = AttributeTypeFactory.create(
+            scope=plan,
+            object_content_type=ContentType.objects.get_for_model(Action),
+            format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+        )
+        active_opt = AttributeTypeChoiceOption.objects.create(
+            type=attr_type,
+            identifier='active',
+            name='Active',
+            order=0,
+        )
+        archived_opt = AttributeTypeChoiceOption.objects.create(
+            type=attr_type,
+            identifier='archived',
+            name='Archived',
+            order=1,
+        )
+        action_ct = ContentType.objects.get_for_model(Action)
+        AttributeChoice.objects.create(
+            type=attr_type,
+            content_type=action_ct,
+            object_id=action.pk,
+            choice=active_opt,
+        )
+        archived_opt.archive()
+
+        response = graphql_client_query(
+            UPDATE_ACTION,
+            variables={
+                'planId': str(plan.pk),
+                'input': {
+                    'id': str(action.pk),
+                    'attributeValues': [
+                        {'attributeTypeId': str(attr_type.pk), 'value': {'choice': {'choiceId': str(archived_opt.pk)}}},
+                    ],
+                },
+            },
+        )
+        data = response['data']['action']['updateAction']
+        assert data['messages'][0]['kind'] == 'VALIDATION'
+        assert 'archived' in data['messages'][0]['message']
+
+        live = AttributeChoice.objects.get(type=attr_type, content_type=action_ct, object_id=action.pk)
+        assert live.choice_id == active_opt.pk, 'existing value must be left intact'
+
     def test_update_rich_text_attribute(self, graphql_client_query_data, client, superuser: User, plan: Plan):
         client.force_login(superuser)
         action = self._create_action(plan, 'ua-rt', 'Action RT')

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -308,6 +308,9 @@ class ArchivableOrderedModelChildFormSet(OrderedModelChildFormSet):
         super().__init__(*args, **kwargs)
         self._pending_archive: list[Any] = []
         self._outer_commit = False
+        #: Populated by `save()` with objects archived during the latest save.
+        #: Inspected by views to surface a post-save notification to the user.
+        self.archived_on_last_save: list[Any] = []
 
     def delete_existing(self, obj, commit=True):
         if obj.pk is not None and obj.is_referenced():
@@ -340,6 +343,9 @@ class ArchivableOrderedModelChildFormSet(OrderedModelChildFormSet):
             saved_instances = super().save(commit)
         finally:
             self._outer_commit = False
+        if commit:
+            self.archived_on_last_save = list(self._pending_archive)
+            self._pending_archive = []
         return saved_instances
 
 

--- a/aplans/utils.py
+++ b/aplans/utils.py
@@ -5,6 +5,7 @@ import json
 import random
 import re
 import typing
+from contextlib import suppress
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -287,6 +288,58 @@ class OrderedModelChildFormSet(BaseChildFormSet):
             for i, form in enumerate(self.ordered_forms):
                 form.instance.order = i
                 form.instance.save()
+        return saved_instances
+
+
+class ArchivableOrderedModelChildFormSet(OrderedModelChildFormSet):
+    """
+    Inline-formset variant that archives instead of deleting referenced rows.
+
+    The child model must implement `is_referenced()` and `archive()`. When a
+    form is marked for deletion:
+
+    - If the underlying instance is referenced elsewhere, it is archived
+      (flipped to `is_active=False`) and kept in the modelcluster cluster so
+      modelcluster's commit doesn't strip it from the database.
+    - Otherwise it is hard-deleted as usual.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._pending_archive: list[Any] = []
+        self._outer_commit = False
+
+    def delete_existing(self, obj, commit=True):
+        if obj.pk is not None and obj.is_referenced():
+            if self._outer_commit:
+                # Archive eagerly here so the (type, order) of the archived
+                # row is moved out of the active range BEFORE the parent
+                # compacts remaining rows starting at order 0. Otherwise a
+                # compacted active row gets saved at the same (type, order)
+                # as the still-unchanged archived row, raising IntegrityError
+                # on `unique_order_per_type` — the deferred constraint
+                # doesn't help because the cluster's saves don't all run in
+                # one deferring transaction.
+                obj.archive()
+            self._pending_archive.append(obj)
+            # Pull this object out of `deleted_objects` so modelcluster's
+            # `manager.remove(*self.deleted_objects)` doesn't strip it from
+            # the cluster — which would then delete it on commit().
+            with suppress(ValueError):
+                self.deleted_objects.remove(obj)
+            return
+        super().delete_existing(obj, commit=commit)
+
+    def save(self, commit=True):
+        # `delete_existing()` is called from inside `super().save()` (with
+        # `commit=False`, regardless of the outer commit flag). Track the
+        # outer commit here so the delete hook can decide whether to write
+        # the archive immediately.
+        self._outer_commit = commit
+        try:
+            saved_instances = super().save(commit)
+        finally:
+            self._outer_commit = False
         return saved_instances
 
 

--- a/templates/aplans/panels/choice_option_archive_panel.html
+++ b/templates/aplans/panels/choice_option_archive_panel.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+<div class="help-block help-info" data-kausal-archive-panel>
+    <p>
+        <span class="w-status">{% trans "Archived" %}</span>
+        {% trans "This option is hidden from new selections but kept so existing references continue to resolve." %}
+    </p>
+    <button type="button"
+            class="button button-small"
+            data-kausal-unarchive-url="{{ self.unarchive_url }}"
+            onclick="kausalUnarchiveChoiceOption(this)">
+        {% trans "Unarchive" %}
+    </button>
+</div>
+<script>
+(function () {
+    if (window.kausalUnarchiveChoiceOption) return;
+    window.kausalUnarchiveChoiceOption = function (btn) {
+        var url = btn.getAttribute('data-kausal-unarchive-url');
+        var tokenInput = document.querySelector('input[name=csrfmiddlewaretoken]');
+        if (!url || !tokenInput) return;
+        btn.disabled = true;
+        fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'X-CSRFToken': tokenInput.value },
+        }).then(function (response) {
+            if (response.ok || response.redirected || response.status === 302) {
+                window.location.reload();
+            } else {
+                btn.disabled = false;
+                window.alert('{% trans "Failed to unarchive option." %}');
+            }
+        }).catch(function () {
+            btn.disabled = false;
+            window.alert('{% trans "Failed to unarchive option." %}');
+        });
+    };
+})();
+</script>

--- a/templates/aplans/panels/choice_option_usage_panel.html
+++ b/templates/aplans/panels/choice_option_usage_panel.html
@@ -1,14 +1,6 @@
 {% load i18n %}
-<div class="help-block help-warning">
+<div class="help-block help-info" data-kausal-choice-option-in-use>
     {% if self.has_usage %}
-    <p>
-      {% blocktrans trimmed %}
-        This choice option is in use. If you delete it from the list below, it will be archived
-        instead of removed entirely: the option becomes hidden from new selections, but existing
-        references continue to resolve unchanged. You can restore an archived option later via the
-        "Unarchive" button that appears on it.
-      {% endblocktrans %}
-    </p>
     <p>{% trans "Currently used by:" %}</p>
     {% trans "Changing this choice option will change the choice in all these objects." as change_tooltip %}
     <ul>
@@ -26,3 +18,34 @@
     </ul>
     {% endif %}
 </div>
+<script>
+(function () {
+    if (window.kausalConfirmChoiceOptionDelete) return;
+
+    {% blocktrans trimmed asvar delete_confirmation_message %}
+        This choice option is still in use. If you save after removing it, it will be archived
+        instead of permanently deleted. Existing references will keep working, and the option will
+        be hidden from new selections.
+    {% endblocktrans %}
+    var message = '{{ delete_confirmation_message|escapejs }}';
+
+    window.kausalConfirmChoiceOptionDelete = function (event) {
+        var target = event.target;
+        if (!target || !target.closest) return;
+
+        var deleteButton = target.closest('button[id$="-DELETE-button"]');
+        if (!deleteButton) return;
+
+        var child = deleteButton.closest('[data-inline-panel-child]');
+        if (!child || !child.querySelector('[data-kausal-choice-option-in-use]')) return;
+
+        if (!window.confirm(message)) {
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+        }
+    };
+
+    document.addEventListener('click', window.kausalConfirmChoiceOptionDelete, true);
+})();
+</script>

--- a/templates/aplans/panels/choice_option_usage_panel.html
+++ b/templates/aplans/panels/choice_option_usage_panel.html
@@ -1,8 +1,16 @@
 {% load i18n %}
 <div class="help-block help-warning">
     {% if self.has_usage %}
-    {% trans "This choice option is currently in use. Changing or deleting it will affect the following objects:" %}
-    {% trans "Changing (or deleting) this choice option will change (or delete) the choice in all these objects." as change_tooltip %}
+    <p>
+      {% blocktrans trimmed %}
+        This choice option is in use. If you delete it from the list below, it will be archived
+        instead of removed entirely: the option becomes hidden from new selections, but existing
+        references continue to resolve unchanged. You can restore an archived option later via the
+        "Unarchive" button that appears on it.
+      {% endblocktrans %}
+    </p>
+    <p>{% trans "Currently used by:" %}</p>
+    {% trans "Changing this choice option will change the choice in all these objects." as change_tooltip %}
     <ul>
       {% if self.published_count > 0 %}
         {% include "aplans/_usage_tooltip_item.html" with label=self.published_object_label names=self.published_object_names tooltip_text=change_tooltip %}
@@ -11,7 +19,7 @@
         {% include "aplans/_usage_tooltip_item.html" with label=self.draft_object_label names=self.draft_object_names tooltip_text=change_tooltip %}
       {% endif %}
       {% if self.report_count > 0 %}
-        {% trans "If you would like to keep the current value in reports even after changing or deleting this choice option, please mark the reports using this choice option as complete." as report_extra_tooltip %}
+        {% trans "If you would like to keep the current value in reports even after changing this choice option, please mark the reports using this choice option as complete." as report_extra_tooltip %}
         {# Technically it would be enough to mark the actions as complete for those reports, but the text is technical enough as it is. #}
         {% include "aplans/_usage_tooltip_item.html" with label=self.report_label names=self.report_names tooltip_text=change_tooltip tooltip_text_extra=report_extra_tooltip %}
       {% endif %}


### PR DESCRIPTION
# Archive `AttributeTypeChoiceOption` instead of deleting when references exist

## Why

Hard-deleting an `AttributeTypeChoiceOption` cascades to its referencing
`AttributeChoice` / `AttributeChoiceWithText` rows, but does **not** clean up
historical references stored as PKs in:

- `wagtail.models.Revision.content` JSON (drafts and history of `Action`),
- `reversion.models.Version.serialized_data` of `AttributeChoice` /
  `AttributeChoiceWithText` (used by report snapshots).

When such a stale reference is later dereferenced (e.g. via
`ActionSnapshot.get_attribute_for_type` while rendering an action's report
tab), the AttributeChoice's `__str__` raises `ObjectDoesNotExist` and is shown
as `"Missing value"`. We observed this on Action 13074 under report 108 for
the deleted `AttributeTypeChoiceOption` 807.

This PR introduces a lifecycle for choice options so that customers can retire
options without breaking historical data, while still allowing genuine
hard-delete when no references exist.

## What changes

### Model lifecycle (commit 1)

- New `is_active` BooleanField on `AttributeTypeChoiceOption`, default `True`.
- New manager / queryset helpers `objects.active()` and `objects.archived()`.
- `archive()` and `unarchive()` methods. Both update `order` to keep the
  uniqueness constraint `(type, order)` satisfied as rows shuttle between the
  active and archived ranges.
- `is_referenced()` returns `True` when the option is pinned by:
  - a live `AttributeChoice` / `AttributeChoiceWithText` row, or
  - a Wagtail `Revision.content` referencing the option's PK, or
  - a reversion `Version` of `AttributeChoice` / `AttributeChoiceWithText`
    referencing the PK.

  The query dispatches on `AttributeType.format` so only the relevant shape
  runs: one live FK check (not both), one JSONB structural containment
  against `Revision.content` (`content @> '{"attributes": {<fmt>: ...}}'`),
  and one `content_type__model=` filter on `reversion.Version` plus
  `,` / `}`-anchored substring patterns to avoid substring false positives
  (e.g. `"choice": 15020` matching PK 1502), followed by a per-row JSON
  parse to confirm. Options on a non-choice `AttributeType` short-circuit
  to `False`.

Live-value policy: archiving an option leaves the corresponding live
`AttributeChoice` rows in place. Existing actions continue to display the
option's value; only new selections are blocked.

### Picker visibility and write-side rejection (commit 2)

Read side — keep archived options resolvable but out of selection UIs:

- The action editor's `OrderedChoice` and `OptionalChoiceWithText` form
  pickers filter the choice queryset to active options. If the current
  attribute value happens to point at an archived option, that option is
  kept in the dropdown for that form so existing data isn't silently
  dropped on the next save.
- GraphQL: `AttributeTypeNode.choiceOptions` lists **all** options
  (active + archived) with an `isActive` field on each. REST consumers
  (e.g. the spreadsheet table editor) that receive raw choice PKs in
  action data depend on this to resolve the label regardless of archive
  state; clients filter to `isActive=true` when building selection UIs.
- FK dereferencing is **not** filtered — historical revisions, report
  snapshots, and existing live values all keep resolving to the option's
  name.

Write side — reject archived options as new selections, with the rule
enforced at every layer that admits a new value:

- The Strawberry `updateAction` / `createAction` mutation validates the
  incoming `choice_id` in `_set_action_choice_attribute` and rejects
  archived options unless the action already has that exact option as
  its current value.
- The DRF REST serializers' `ChoiceAttributesSerializer.validate()` /
  `ChoiceWithTextAttributesSerializer.validate()` run the same rejection
  during DRF's `is_valid()` phase, returning a 400 immediately and before
  any save side effect happens. (The bulk REST path issues
  `QuerySet.bulk_update()` / `bulk_create()`, which bypass both `save()`
  and `full_clean()`, so the model-layer guards alone are insufficient
  *and* would only fire after the Action save had already run.)
- `ModelWithAttributes.set_attribute()` runs the rule before queuing the
  create/update operation, covering any code that goes through the
  attribute-serialization machinery.
- `AttributeChoice` and `AttributeChoiceWithText` enforce the same rule
  from `save()` and `clean()`, covering anything that bypasses the
  serializer layer and goes through Django's standard model machinery.

The shared validator accepts the choice in three cases:

- when it's `None` or active,
- when the row already has that exact option as its current value
  (in-place re-save of an unchanged archived value), or
- when a Wagtail revision of the parent already references this
  `(type, choice)` pair. This covers the publish-from-draft path:
  `Action.commit_attributes()` calls `AttributeType.create_attribute()`
  which saves a brand-new `AttributeChoice` (`pk=None`) carrying the
  archived option that was picked in the draft. Without this exemption
  the model-layer guard would block users from publishing drafts that
  pre-date the archive — even though `is_referenced()` deliberately
  kept the option around because of that very draft.

The target-instance lookup used by the REST validator walks the parent
chain so the same code path resolves the row whether it lives on a
single-instance request (outer serializer's `instance`) or under a
bulk wrapper (per-row `_instance` set by
`BulkSerializerValidationInstanceMixin` during each child's
`run_validation`). The earlier `hasattr(parent, 'objs_by_id'): return
None` bail-out would have lost track of the row whenever the bulk
wrapper sat between the choice serializer and the per-row child,
forcing `existing_by_identifier` to stay empty and rejecting every
archived option in the payload — including the action's own current
value.

### Archive-on-delete in the inline editor (commit 3)

- New `ArchivableOrderedModelChildFormSet` in `aplans/utils.py`. Subclasses
  the existing `OrderedModelChildFormSet`; overrides `delete_existing` to
  call `obj.archive()` when `obj.is_referenced()` returns `True`, and pulls
  the object out of `self.deleted_objects` so modelcluster's commit doesn't
  strip it from the database.
- Wired in as the `choice_options` formset on `AttributeTypeAdmin`.
- New POST-only admin URL `/admin/actions/attributetype/<pk>/unarchive-choice-option/<option_pk>/`
  guarded by the AttributeType edit permission, calling `option.unarchive()`.

Choice options that are not referenced anywhere still hard-delete as before.

### Inline editor surface (commit 4)

- New `ChoiceOptionArchivePanel` rendered at the top of an expanded
  archived option in the inline editor: a Wagtail "Archived" status badge,
  a one-line explanation, and an Unarchive button that POSTs to the
  unarchive URL via `fetch`. Active rows render nothing.
- The button uses inline JS rather than a nested `<form>` so it doesn't
  interfere with the surrounding Wagtail edit form.

### Surfacing what happened to the admin (commit 5)

- The expanded form's existing `ChoiceOptionUsagePanel` is reworded to
  explain up-front that deletion will become archive when the option is
  in use, and points at the unarchive button as the recovery path.
- `ArchivableOrderedModelChildFormSet.save()` records archived items on
  `self.archived_on_last_save`. `AttributeTypeEditView.form_valid()`
  reads each formset's `archived_on_last_save` after the parent save and
  emits one `messages.warning` per archived option, naming it.

### Preserve position across archive/unarchive (commit 6)

Originally `archive()` bumped `order` to `max+1` so the inline editor's
compaction wouldn't collide with archived rows under
`unique_order_per_type`. That made archive→unarchive lose the row's
original position — it always reappeared at the end of the list.

`archive()` and `unarchive()` now just flip `is_active`. The harder part
is the inline-formset save: modelcluster always renumbers active rows
to `0..N-1` in formset display order, which leaves a freshly-archived
row's `order` (untouched) *higher* than the now-compacted active
siblings — so the archived row still appears at the end of the sort
even though its `order` field wasn't changed.

`ArchivableOrderedModelChildFormSet.save()` now snapshots every row's
`order` *before* calling the parent save and then runs a single
collision-safe two-phase `UPDATE` afterwards. When at least one row
was archived this save, every surviving row (active *and* archived)
is restored to its pre-save `order` so the archived row keeps its slot
in the sort. On saves that didn't archive anything, active rows are
compacted to formset display order — the baseline
`OrderedModelChildFormSet` behaviour.

The two-phase update first parks every affected row at a high disjoint
slot (`shift + final_target`, where `shift = max(existing, target) + 1`),
then brings them down to their final positions. Within each phase the
slots are unique by construction, so no single statement can violate
the `unique (parent, order)` constraint — even though it's
`deferrable=DEFERRED`, this avoids relying on the surrounding code
path holding a transaction open for the deferred check to ride on.

Trade-off: an admin reorder performed in the *same* save as an archive
gets undone (the restore puts active rows back at their pre-save
positions). Admins rarely combine the two, and the simpler reconciliation
is worth the corner case.

## Tests

In `actions/tests/test_attribute_type_choice_option_deletion.py`:

- `TestArchiveApi` — `archive` / `unarchive` semantics, queryset filters,
  `is_referenced` across live / Wagtail-revision / reversion-Version
  sources, "false when unused", ordering doesn't collide between active
  and archived rows.
- `TestPickerVisibility` — ordered- and optional-choice pickers exclude
  archived options; an existing value pointing at an archived option is
  preserved; GraphQL listing includes archived options and tags each one
  with `isActive`; model-level rejection via `full_clean()`, `save()`,
  and `set_attribute()` (covering creates, in-place re-saves, and
  switches to archived); REST integration test against
  `PUT /v1/plan/<id>/actions/` confirming an archived assignment returns
  400 and writes nothing.
- `TestArchivableFormset` — inline formset archives referenced options on
  delete, hard-deletes unreferenced ones, records archived items on
  `archived_on_last_save`.
- `TestUnarchiveView` — POST flips the flag, GET is 405, anonymous gets
  302/403, wrong-attribute-type returns 404.
- `TestArchivePanel` — `ChoiceOptionArchivePanel` shown only for archived
  options, renders badge + unarchive URL, hidden for unsaved options.
- `TestArchiveNotification` — `AttributeTypeEditView.form_valid` emits
  one warning per archived option across all formsets; emits nothing
  when nothing was archived.
- `TestUsagePanelWording` — usage panel renders the new "deletion
  becomes archive" wording for in-use options.

In `actions/tests/test_graphql_mutations.py::TestUpdateAction`:

- `test_update_action_rejects_archived_choice_as_new_value` — submitting
  an archived option as a new value returns a `VALIDATION` OperationInfo
  message and writes no AttributeChoice.
- `test_update_action_allows_resaving_existing_archived_choice` — an
  action whose value is an option that has since been archived can be
  re-saved with that same option (no-op selection) without rejection.
- `test_update_action_rejects_switching_to_archived_choice` — when the
  existing value is an active option, switching to a different,
  archived option is rejected and the existing value remains intact.

Total: 61 archive-specific tests in `test_attribute_type_choice_option_deletion.py`
and 3 in `test_graphql_mutations.py::TestUpdateAction` (123 tests pass
across the two files together). A broader sweep of `actions/tests/`
shows no regressions (one pre-existing staticfiles-manifest failure in
`test_can_access_plan_edit_page` is unrelated to this branch).

## Migration

- `actions/0175_attributetypechoiceoption_is_active.py` — adds the
  `is_active` column with `default=True`, so all existing rows become
  active on apply. Forward-only schema migration, no data backfill needed.

## Operator follow-up: repairing the original incident

This PR provides the mechanism but does not by itself restore missing
`AttributeTypeChoiceOption` instances (e.g., the one with PK 807). To fix the
original "Missing value" symptom (e.g., on Action 13074), an operator needs to
re-create such choice options with `is_active=False`, using their
name/identifier from a DB backup or from reversion's own `Version` history of
`AttributeTypeChoiceOption`. The mechanism added here will then keep that
resurrected row out of new pickers while letting the historical FK dereferences
resolve to the original name.

## Follow-up PR

We should make improvements to the table editor to omit archived choice options from dropdowns (unless they are currently selected).

## Related issue
[Sentry issue](https://sentry.kausal.tech/organizations/kausal/issues/13659/events/5b001f2dc1f441cd959ed89aacaf50a9/)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
