### PR TITLE
Declare id and from_plan_id as FilterFields on Plan

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -615,6 +615,8 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         index.AutocompleteField('identifier', boost=5),
         index.FilterField('organization'),
         index.FilterField('is_active'),
+        index.FilterField('id'),
+        index.FilterField('from_plan_id'),
         index.RelatedFields(
             'organization',
             [


### PR DESCRIPTION
## Description
PlanChooser combines Plan.objects.filter(pk=plan.pk) with plan.related_plans.all() (self-referential M2M) before calling .autocomplete(), so the search backend sees id and from_plan_id in the filter clause and raises FilterFieldError when they aren't indexed.

Fixes WATCH-BACKEND-4YP

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
