### PR TITLE
Renormalize new contact/responsible-party items on publish

### DIFF
--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -287,18 +287,25 @@ def _renormalize_pks_for_unique_constraint(
     if not target_items:
         return
 
+    # If the target itself contains duplicate wrapped IDs the caller already violates the
+    # unique constraint; bail out so the IntegrityError surfaces instead of silently
+    # collapsing both entries onto the same DB pk during renormalization.
+    target_wrapped_ids = [get_wrapped_id_target(item) for item in target_items]
+    if len(set(target_wrapped_ids)) != len(target_wrapped_ids):
+        return
+
     # Build mapping: wrapped_id -> current DB pk
     wrapped_to_pk_db = {get_wrapped_id_db(item): get_pk_db(item) for item in db_items if get_pk_db(item) is not None}
 
-    # Detect if any wrapped ID is moving to a different PK
+    # Detect if any wrapped ID is moving to a different PK, including from None (new item
+    # targeting a wrapped value already in the DB under another PK).
     needs_renormalization = False
     for item in target_items:
-        pk = get_pk_target(item)
-        if pk is None:
-            continue
         wrapped_id = get_wrapped_id_target(item)
         current_pk_for_wrapped = wrapped_to_pk_db.get(wrapped_id)
-        if current_pk_for_wrapped is not None and current_pk_for_wrapped != pk:
+        if current_pk_for_wrapped is None:
+            continue
+        if get_pk_target(item) != current_pk_for_wrapped:
             needs_renormalization = True
             break
 

--- a/actions/tests/test_admin.py
+++ b/actions/tests/test_admin.py
@@ -823,6 +823,153 @@ def test_action_contact_person_swap_on_publish_draft(plan):
     assert contact_a_after.role == ActionContactPerson.Role.MODERATOR
 
 
+def test_publish_with_new_contact_person_already_in_live_db(plan):
+    """
+    Publishing must not violate the unique (action, person) constraint.
+
+    Revision content adds a new contact person (pk=None) for a person who is
+    already a live contact person (under a different pk), and at the same time
+    reassigns that existing pk to a different person. Without renormalization
+    of pk=None items, publishing INSERTs the new row before the existing row's
+    person_id is rewritten, violating the unique constraint.
+    """
+    from wagtail.models import Revision
+
+    from actions.models import ActionContactPerson
+    from actions.tests.factories import ActionFactory
+    from people.tests.factories import PersonFactory
+
+    person_kept = PersonFactory.create()  # stays as moderator
+    person_promoted = PersonFactory.create()  # currently moderator, becomes editor
+    person_new = PersonFactory.create()  # new moderator replacing person_promoted
+
+    action = ActionFactory.create(plan=plan)
+    acp_kept = ActionContactPerson.objects.create(
+        action=action,
+        person=person_kept,
+        role=ActionContactPerson.Role.MODERATOR,
+        order=0,
+    )
+    acp_to_reassign = ActionContactPerson.objects.create(
+        action=action,
+        person=person_promoted,
+        role=ActionContactPerson.Role.MODERATOR,
+        order=1,
+    )
+
+    initial_revision = action.save_revision()
+    revision_content = initial_revision.content.copy()
+    if 'attributes' not in revision_content:
+        revision_content['attributes'] = {}
+
+    revision_content['contact_persons'] = [
+        {
+            'pk': None,
+            'role': 'editor',
+            'order': 0,
+            'action': action.pk,
+            'person': person_promoted.pk,
+            'primary_contact': True,
+        },
+        {
+            'pk': acp_kept.pk,
+            'role': 'moderator',
+            'order': 1,
+            'action': action.pk,
+            'person': person_kept.pk,
+            'primary_contact': False,
+        },
+        {
+            'pk': acp_to_reassign.pk,
+            'role': 'moderator',
+            'order': 2,
+            'action': action.pk,
+            'person': person_new.pk,
+            'primary_contact': False,
+        },
+    ]
+
+    revision: Revision = Revision(
+        content_type=initial_revision.content_type,
+        base_content_type=initial_revision.base_content_type,
+        object_id=action.pk,
+    )
+    revision.content = revision_content
+    revision.save()
+
+    revision.publish()
+
+    action.refresh_from_db()
+    contacts_after = ActionContactPerson.objects.filter(action=action)
+    assert contacts_after.count() == 3
+    assert contacts_after.get(person=person_promoted).role == ActionContactPerson.Role.EDITOR
+    assert contacts_after.get(person=person_kept).role == ActionContactPerson.Role.MODERATOR
+    assert contacts_after.get(person=person_new).role == ActionContactPerson.Role.MODERATOR
+
+
+def test_publish_with_duplicate_contact_person_in_revision_raises(plan):
+    """
+    Renormalization must not collapse duplicate (action, person) entries onto the same pk.
+
+    If revision content contains two entries for the same person, the unique
+    (action, person) constraint is already violated by the payload itself.
+    Renormalization must not silently merge them onto one DB row (which would
+    let one entry's role/order overwrite the other); the IntegrityError must
+    surface so the caller can correct the data.
+    """
+    from django.db import IntegrityError
+    from wagtail.models import Revision
+
+    from actions.models import ActionContactPerson
+    from actions.tests.factories import ActionFactory
+    from people.tests.factories import PersonFactory
+
+    person = PersonFactory.create()
+
+    action = ActionFactory.create(plan=plan)
+    existing = ActionContactPerson.objects.create(
+        action=action,
+        person=person,
+        role=ActionContactPerson.Role.MODERATOR,
+        order=0,
+    )
+
+    initial_revision = action.save_revision()
+    revision_content = initial_revision.content.copy()
+    if 'attributes' not in revision_content:
+        revision_content['attributes'] = {}
+
+    revision_content['contact_persons'] = [
+        {
+            'pk': existing.pk,
+            'role': 'moderator',
+            'order': 0,
+            'action': action.pk,
+            'person': person.pk,
+            'primary_contact': False,
+        },
+        {
+            'pk': None,
+            'role': 'editor',
+            'order': 1,
+            'action': action.pk,
+            'person': person.pk,
+            'primary_contact': True,
+        },
+    ]
+
+    revision: Revision = Revision(
+        content_type=initial_revision.content_type,
+        base_content_type=initial_revision.base_content_type,
+        object_id=action.pk,
+    )
+    revision.content = revision_content
+    revision.save()
+
+    with pytest.raises(IntegrityError):
+        revision.publish()
+
+
 def test_publish_does_not_overwrite_order(plan):
     """
     Publishing a revision must not revert the action's order to the value stored in the revision.


### PR DESCRIPTION
## Description
When a revision adds a new (pk=None) ActionContactPerson or ActionResponsibleParty for a person/org already attached to the live action under another pk, modelcluster's commit() runs the INSERT before the existing row's wrapped_id is rewritten, violating the unique (action, person) / (action, organization) constraint.
The detection loop in _renormalize_pks_for_unique_constraint skipped pk=None targets, so the renormalize step never ran. Detect them too and let the existing renormalize logic reassign the new item to the holding row's pk.

Fixes WATCH-BACKEND-5WW

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/16934/?project=3&query=is%3Aunresolved&referrer=issue-stream&sort=new

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
