### PR TITLE
Copy indicator dataset schemas with plan indicators

### DIFF
--- a/copying/main.py
+++ b/copying/main.py
@@ -27,6 +27,13 @@ from wagtail.models.reference_index import ReferenceIndex
 from loguru import logger
 from relations_iterator import AbstractVisitor, ConfigurableRelationTree, RelationTreeIterator  # type: ignore
 
+from kausal_common.datasets.models import (
+    DatasetMetric,
+    DatasetMetricComputation,
+    DatasetSchema,
+    Dimension as DatasetDimension,
+)
+
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
 from actions.models.category import Category, CategoryType, CommonCategory, CommonCategoryType
@@ -262,6 +269,20 @@ DIMENSION_CLONE_STRUCTURE: CloneStructure = {
     'common_indicators': EXCLUDED,  # CommonIndicator is not plan-scoped
 }
 
+DATASET_SCHEMA_CLONE_STRUCTURE: CloneStructure = {
+    # Metrics must be copied before computations because DatasetMetricComputation.target_metric is unique and must be
+    # remapped to the copied metric before the computation copy is saved.
+    'metrics': {
+        'computed_by': EXCLUDED,  # DatasetMetricComputation is copied via DatasetSchema → computations
+        'data_points': EXCLUDED,  # actual dataset values are not part of the schema definition
+    },
+    'computations': {},
+    'dimensions': {},  # copies through model instances, not dataset Dimension instances
+    'scopes': {},
+    'datasets': EXCLUDED,  # actual dataset instances are not part of the schema definition
+    'indicator': EXCLUDED,  # Indicator is the copy root that points to the copied DatasetSchema
+}
+
 # Models that are not scoped by a plan and thus deliberately excluded from copying. References to these models are
 # skipped in `UpdateReferencesVisitor.get_references()` and warnings are suppressed in `update_reference()`.
 MODELS_NOT_COPIED = [
@@ -270,6 +291,7 @@ MODELS_NOT_COPIED = [
     CommonCategoryType,
     CommonIndicator,
     ContentType,
+    DatasetDimension,
     Group,
     Locale,
     Organization,
@@ -299,9 +321,18 @@ UNIQUE_FIELD_COPY_POLICIES: dict[type[Model], dict[str, str]] = {
         'uuid': UNIQUE_FIELD_POLICY_REGENERATED,
     },
     Indicator: {
-        'dataset_schema': UNIQUE_FIELD_POLICY_UNSUPPORTED_IF_SET,
+        'dataset_schema': UNIQUE_FIELD_POLICY_REPLACED_BEFORE_SAVE,
         'kausal_paths_node_uuid': UNIQUE_FIELD_POLICY_UNSUPPORTED_IF_SET,
         'reference_value': UNIQUE_FIELD_POLICY_CLEARED_THEN_RESTORED,
+        'uuid': UNIQUE_FIELD_POLICY_REGENERATED,
+    },
+    DatasetMetric: {
+        'uuid': UNIQUE_FIELD_POLICY_REGENERATED,
+    },
+    DatasetMetricComputation: {
+        'target_metric': UNIQUE_FIELD_POLICY_REPLACED_BEFORE_SAVE,
+    },
+    DatasetSchema: {
         'uuid': UNIQUE_FIELD_POLICY_REGENERATED,
     },
     NotificationSettings: {
@@ -377,6 +408,7 @@ def get_unclassified_unique_field_copy_policies() -> list[str]:
         (cast('type[Model]', AttributeType), ATTRIBUTE_TYPE_CLONE_STRUCTURE),
         (cast('type[Model]', Indicator), INDICATOR_CLONE_STRUCTURE),
         (cast('type[Model]', Dimension), DIMENSION_CLONE_STRUCTURE),
+        (cast('type[Model]', DatasetSchema), DATASET_SCHEMA_CLONE_STRUCTURE),
     ]
     missing = []
     for root_model, structure in roots:
@@ -424,6 +456,8 @@ def _iter_instances_for_unique_field_validation(plan: Plan, copy_indicators: boo
         return
     for indicator in plan.indicators.all():
         yield from yield_unseen(_iter_clone_structure_instances(indicator, INDICATOR_CLONE_STRUCTURE))
+        if indicator.dataset_schema is not None:
+            yield from yield_unseen(_iter_clone_structure_instances(indicator.dataset_schema, DATASET_SCHEMA_CLONE_STRUCTURE))
     for dimension in Dimension.objects.filter(id__in=plan.dimensions.values_list('dimension_id')):
         yield from yield_unseen(_iter_clone_structure_instances(dimension, DIMENSION_CLONE_STRUCTURE))
 
@@ -786,7 +820,17 @@ class CloneVisitor(AbstractVisitor):
     @pre_visit.register
     def _(self, instance: Indicator) -> None:
         self.prepare_instance_for_copy(instance)
+        if instance.dataset_schema is not None:
+            original_schema = shallow_copy(instance.dataset_schema)
+            if not self.has_copy(original_schema):
+                visit_tree(instance.dataset_schema, DATASET_SCHEMA_CLONE_STRUCTURE, self)
+            instance.dataset_schema = self.get_copy(original_schema)
         self.remove_link(instance, 'reference_value')
+
+    @pre_visit.register
+    def _(self, instance: DatasetMetricComputation) -> None:
+        self.prepare_instance_for_copy(instance)
+        instance.target_metric = self.get_copy(instance.target_metric)
 
     @pre_visit.register
     def _(self, instance: Site) -> None:
@@ -1720,8 +1764,21 @@ def update_references_in_indicators(indicators: list[Indicator], clone_visitor: 
 
     # Also visit the indicator tree to handle foreign keys and other references
     # in indicators and their related objects (values, goals, dimensions, etc.)
+    dataset_schema_ids = set()
     for indicator in indicators:
         visit_tree(indicator, INDICATOR_CLONE_STRUCTURE, update_references_visitor)
+        if indicator.dataset_schema is not None and indicator.dataset_schema_id not in dataset_schema_ids:
+            _delete_uncopied_dataset_schema_scopes(indicator.dataset_schema, clone_visitor)
+            visit_tree(indicator.dataset_schema, DATASET_SCHEMA_CLONE_STRUCTURE, update_references_visitor)
+            dataset_schema_ids.add(indicator.dataset_schema_id)
+
+
+def _delete_uncopied_dataset_schema_scopes(schema: DatasetSchema, clone_visitor: CloneVisitor) -> None:
+    for scope in schema.scopes.all():
+        scope_target = scope.scope
+        if isinstance(scope_target, Model) and clone_visitor.has_copy(scope_target):
+            continue
+        scope.delete()
 
 
 def _to_copy_structure(structure: CloneStructure) -> dict:

--- a/copying/tests/test_clone_structure_coverage.py
+++ b/copying/tests/test_clone_structure_coverage.py
@@ -4,10 +4,13 @@ from typing import TYPE_CHECKING
 
 from django.db.models import ManyToManyRel, ManyToOneRel
 
+from kausal_common.datasets.models import DatasetSchema
+
 from actions.models.attributes import AttributeType
 from actions.models.plan import Plan
 from copying.main import (
     ATTRIBUTE_TYPE_CLONE_STRUCTURE,
+    DATASET_SCHEMA_CLONE_STRUCTURE,
     DIMENSION_CLONE_STRUCTURE,
     INDICATOR_CLONE_STRUCTURE,
     PLAN_CLONE_STRUCTURE,
@@ -77,6 +80,9 @@ class TestCloneStructureCoverage:
 
     def test_dimension_clone_structure_coverage(self):
         _check_coverage(Dimension, DIMENSION_CLONE_STRUCTURE, set())
+
+    def test_dataset_schema_clone_structure_coverage(self):
+        _check_coverage(DatasetSchema, DATASET_SCHEMA_CLONE_STRUCTURE, set())
 
     def test_unique_field_copy_policy_coverage(self):
         assert get_unclassified_unique_field_copy_policies() == []

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -11,6 +11,8 @@ from wagtail.rich_text import RichText
 
 import pytest
 
+from kausal_common.datasets.models import DatasetMetricComputation, DatasetSchema
+
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
 from actions.models.category import CategoryType
@@ -37,7 +39,13 @@ from copying.main import (
     _validate_unique_field_copy_policy_applied,
     copy_plan,
 )
-from datasets.tests.factories import DatasetSchemaFactory
+from datasets.tests.factories import (
+    DatasetMetricFactory,
+    DatasetSchemaDimensionFactory,
+    DatasetSchemaFactory,
+    DatasetSchemaScopeFactory,
+    DimensionFactory as DatasetDimensionFactory,
+)
 from documentation.models import DocumentationRootPage
 from documents.models import AplansDocument
 from documents.tests.factories import AplansDocumentFactory
@@ -423,12 +431,63 @@ def test_unique_field_policy_rejects_unregistered_restored_value(indicator):
 
 
 @pytest.mark.parametrize('indicator__common', [None])
-def test_rejects_copy_indicator_with_dataset_schema(plan_with_pages, indicator):
-    indicator.dataset_schema = DatasetSchemaFactory.create()
+def test_copy_indicator_dataset_schema(plan_with_pages, indicator):
+    schema = DatasetSchemaFactory.create()
+    dimension = DatasetDimensionFactory.create()
+    DatasetSchemaDimensionFactory.create(schema=schema, dimension=dimension)
+    DatasetSchemaScopeFactory.create(schema=schema, scope=indicator)
+    operand_a = DatasetMetricFactory.create(schema=schema, label='Operand A')
+    operand_b = DatasetMetricFactory.create(schema=schema, label='Operand B')
+    target_metric = DatasetMetricFactory.create(schema=schema, label='Target')
+    computation = DatasetMetricComputation.objects.create(
+        schema=schema,
+        target_metric=target_metric,
+        operand_a=operand_a,
+        operand_b=operand_b,
+        operation=DatasetMetricComputation.Operation.MULTIPLY,
+    )
+    indicator.dataset_schema = schema
     indicator.save(update_fields=['dataset_schema'])
 
-    with pytest.raises(ValueError, match=r'indicators\.Indicator\.dataset_schema'):
-        copy_plan(plan_with_pages, copy_indicators=True)
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    schema_copy = indicator_copy.dataset_schema
+    assert schema_copy is not None
+    assert schema_copy != schema
+    assert schema_copy.uuid != schema.uuid
+    assert schema_copy.name == schema.name
+    assert schema_copy.dimensions.get().dimension == dimension
+    assert schema_copy.scopes.get().scope == indicator_copy
+
+    metric_copies = {metric.label: metric for metric in schema_copy.metrics.all()}
+    assert set(metric_copies) == {'Operand A', 'Operand B', 'Target'}
+    for metric in metric_copies.values():
+        assert metric.uuid not in {operand_a.uuid, operand_b.uuid, target_metric.uuid}
+
+    computation_copy = schema_copy.computations.get()
+    assert computation_copy != computation
+    assert computation_copy.target_metric == metric_copies['Target']
+    assert computation_copy.operand_a == metric_copies['Operand A']
+    assert computation_copy.operand_b == metric_copies['Operand B']
+
+
+@pytest.mark.parametrize('indicator__common', [None])
+def test_copy_indicator_dataset_schema_does_not_copy_external_scopes(plan_with_pages, indicator):
+    schema = DatasetSchemaFactory.create()
+    other_plan = PlanFactory.create()
+    DatasetSchemaScopeFactory.create(schema=schema, scope=indicator)
+    DatasetSchemaScopeFactory.create(schema=schema, scope=other_plan)
+    indicator.dataset_schema = schema
+    indicator.save(update_fields=['dataset_schema'])
+
+    plan_copy = copy_plan(plan_with_pages, copy_indicators=True)
+
+    indicator_copy = plan_copy.indicators.get(name=indicator.name)
+    schema_copy = indicator_copy.dataset_schema
+    assert schema_copy is not None
+    assert schema_copy.scopes.get().scope == indicator_copy
+    assert list(DatasetSchema.objects.for_scope(other_plan)) == [schema]
 
 
 @pytest.mark.parametrize('indicator__common', [None])


### PR DESCRIPTION
Teach the indicator copy path to duplicate an attached dataset schema before inserting the copied indicator, including schema metrics, computations, dimensions, and scope rows while leaving actual datasets and data points untouched. Metric computation references are remapped to copied metrics, clone-structure coverage now includes dataset schemas, and the regression test verifies that copied indicators point to copied schema definitions.

## Requirements, dependencies and related PRs
Builds upon https://github.com/kausaltech/kausal-watch/pull/615 -- review that one first.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
