### PR TITLE
Fix breadcrumbs teleport error on singleton edit views

### DIFF
--- a/admin_site/templates/admin_site/edit_partials.html
+++ b/admin_site/templates/admin_site/edit_partials.html
@@ -1,0 +1,5 @@
+{% extends "wagtailadmin/generic/edit_partials.html" %}
+{# Skip the breadcrumbs teleport when items is empty: views using #}
+{# SuccessUrlEditPageMixin render no `header [data-w-breadcrumbs]` target, #}
+{# and the upstream teleport throws on AJAX save. #}
+{% block breadcrumbs %}{% if breadcrumbs_items %}{{ block.super }}{% endif %}{% endblock %}

--- a/admin_site/viewsets.py
+++ b/admin_site/viewsets.py
@@ -49,6 +49,7 @@ class WatchEditView[ModelT: Model, FormT: WagtailAdminModelForm = WagtailAdminMo
 ):
     object: ModelT
     model: type[ModelT]
+    partials_template_name = 'admin_site/edit_partials.html'
 
     def get_form_kwargs(self):
         return {


### PR DESCRIPTION
## Description
Singleton settings views (PlanFeatures, NotificationSettings, etc.) mix in SuccessUrlEditPageMixin, which returns [] from get_breadcrumbs_items() to hide the snippet breadcrumb trail. With empty breadcrumbs, Wagtail renders shared/header.html instead of slim_header.html, so the live DOM contains no `header [data-w-breadcrumbs]` element. The upstream edit_partials.html still unconditionally emits a w-teleport into that selector, which made every AJAX save raise a Stimulus "No valid target container found" error in the browser.

Override edit_partials.html via WatchEditView.partials_template_name and guard only the breadcrumbs block behind {% if breadcrumbs_items %}, falling back to {{ block.super }} for the rest so upstream teleports for title, side panels and history continue to work.

Fixes WATCH-BACKEND-3N8

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    - Go to Plan Features, open console. Change any value, wait 500ms (don't save). `Error: No valid target container found at 'header [data-w-breadcrumbs]'.` should not pop up anymore.

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
