### PR TITLE
Fix migration order

### DIFF
--- a/pages/migrations/0072_remove_categorytypepagelevellayout_layout_aside.py
+++ b/pages/migrations/0072_remove_categorytypepagelevellayout_layout_aside.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("pages", "0068_alter_categorypage_body_alter_planrootpage_body_and_more"),
+        ("pages", "0071_preserve_indicator_value_highlight_goal_met"),
     ]
 
     operations = [


### PR DESCRIPTION
Pushing an old PR to main caused migrations to go out of order, because some new migrations had been pushed to `main` meanwhile the PR was pending. Fix the dependency order.