### PR TITLE
[draft] Remove Plan.site_url

### DIFF
--- a/.github/workflows/admin-e2e-tests.yaml
+++ b/.github/workflows/admin-e2e-tests.yaml
@@ -68,6 +68,7 @@ jobs:
           REDIS_URL: redis://localhost
           DB_ENDPOINT: localhost:5432
           ALLOWED_HOSTS: localhost
+          HOSTNAME_PLAN_DOMAINS: admin-e2e.test
           KUBERNETES_LOGGING: 1
           TEST_MODE: 1
           ENABLE_TEST_MODE: 1

--- a/actions/apps.py
+++ b/actions/apps.py
@@ -52,6 +52,7 @@ class ActionsConfig(AppConfig):
     def ready(self):
         # monkeypatch filtering of Collections
         monkeypatch_image_chooser_viewset()
+        import actions.checks
         import actions.signals
 
         actions.signals.register_signal_handlers()

--- a/actions/checks.py
+++ b/actions/checks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from django.core.checks import Error, register as register_check
 
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 @register_check(deploy=True)
-def check_hostname_plan_domains(app_configs: Sequence[AppConfig] | None, **_kwargs) -> list[CheckMessage]:
+def check_hostname_plan_domains(*, app_configs: Sequence[AppConfig] | None, **_kwargs: Any) -> list[CheckMessage]:
     from django.conf import settings
 
     domains: list[str] = getattr(settings, 'HOSTNAME_PLAN_DOMAINS', [])
@@ -22,6 +22,7 @@ def check_hostname_plan_domains(app_configs: Sequence[AppConfig] | None, **_kwar
             Error(
                 'HOSTNAME_PLAN_DOMAINS is empty.',
                 hint='Set HOSTNAME_PLAN_DOMAINS to a list containing your production domain(s).',
+                obj=settings,
                 id='watch.D001',
             ),
         ]
@@ -32,6 +33,7 @@ def check_hostname_plan_domains(app_configs: Sequence[AppConfig] | None, **_kwar
             Error(
                 'HOSTNAME_PLAN_DOMAINS contains only the default "localhost".',
                 hint='Add your production domain(s) to HOSTNAME_PLAN_DOMAINS.',
+                obj=settings,
                 id='watch.D002',
             ),
         ]

--- a/actions/checks.py
+++ b/actions/checks.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core.checks import Error, register as register_check
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from django.apps import AppConfig
+    from django.core.checks import CheckMessage
+
+
+@register_check(deploy=True)
+def check_hostname_plan_domains(app_configs: Sequence[AppConfig] | None, **_kwargs) -> list[CheckMessage]:
+    from django.conf import settings
+
+    domains: list[str] = getattr(settings, 'HOSTNAME_PLAN_DOMAINS', [])
+
+    if not domains:
+        return [
+            Error(
+                'HOSTNAME_PLAN_DOMAINS is empty.',
+                hint='Set HOSTNAME_PLAN_DOMAINS to a list containing your production domain(s).',
+                id='watch.D001',
+            ),
+        ]
+
+    non_localhost = [d for d in domains if d != 'localhost']
+    if not non_localhost:
+        return [
+            Error(
+                'HOSTNAME_PLAN_DOMAINS contains only the default "localhost".',
+                hint='Add your production domain(s) to HOSTNAME_PLAN_DOMAINS.',
+                id='watch.D002',
+            ),
+        ]
+
+    return []

--- a/actions/models/action.py
+++ b/actions/models/action.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypedDict, cast
 
 import reversion
 import strawberry as sb
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericRelation
@@ -1085,7 +1086,7 @@ class Action(
     def get_notification_context(self, plan=None, request=None):
         if plan is None:
             plan = self.plan
-        change_url = reverse('actions_action_modeladmin_edit', kwargs=dict(instance_pk=self.id))
+        change_url = settings.ADMIN_BASE_URL + reverse('actions_action_modeladmin_edit', kwargs=dict(instance_pk=self.id))
         return {
             'id': self.id,
             'identifier': self.identifier,

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -801,6 +801,8 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
     def create_default_site(self, hostname=None):
         if hostname is None:
             hostname = self.default_hostname()
+            if not hostname:
+                raise ValueError(f"Cannot determine hostname for plan '{self.identifier}': no hostname plan domains configured")
         if self.site is not None:
             return
         root_page = self.create_default_pages()
@@ -1134,7 +1136,10 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
                 port_str = ''
             return '%s://%s%s%s%s' % (scheme, hostname, port_str, base_path, locale_prefix)
 
-        return f'https://{self.default_hostname(include_all_domains=True)}{locale_prefix}'
+        hostname = self.default_hostname(include_all_domains=True)
+        if not hostname:
+            raise ValueError(f"Cannot determine hostname for plan '{self.identifier}': no hostname plan domains configured")
+        return f'https://{hostname}{locale_prefix}'
 
     @classmethod
     def create_with_defaults(
@@ -1180,6 +1185,8 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         plan.statuses_updated_manually = True
         if not hostname:
             hostname = plan.default_hostname()
+            if not hostname:
+                raise ValueError(f"Cannot determine hostname for plan '{plan.identifier}': no hostname plan domains configured")
         plan.create_default_site(hostname)
         plan.save()
 
@@ -1208,19 +1215,27 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         management.call_command('initialize_notifications', plan=plan.identifier)
         return plan
 
-    def default_hostname(self, include_all_domains: bool = False) -> str:
+    def default_hostname(self, include_all_domains: bool = False) -> str | None:
         """Build a hostname from plan identifier and any item in HOSTNAME_PLAN_DOMAINS that's not localhost."""
         hostname_plan_domains = (x for x in settings.HOSTNAME_PLAN_DOMAINS if x != 'localhost')
         try:
             default_domain = next(hostname_plan_domains)
-        except StopIteration as e:
-            if not include_all_domains:
-                raise Exception('Cannot create default hostname if no hostname plan domains are configured') from e
-            default_domain = next(iter(settings.HOSTNAME_PLAN_DOMAINS))
+        except StopIteration:
+            if include_all_domains and settings.DEPLOYMENT_TYPE == 'development':
+                try:
+                    default_domain = next(iter(settings.HOSTNAME_PLAN_DOMAINS))
+                except StopIteration:
+                    return None
+            else:
+                return None
         if COUNTRY_PLACEHOLDER in default_domain:
             country_code = self.country.code.lower() if self.country else None
             if not country_code:
-                raise Exception(f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'")
+                sentry_sdk.capture_message(
+                    f"Plan '{self.identifier}' has no country set; using fallback for wildcard domain '{default_domain}'",
+                    level='error',
+                )
+                country_code = 'unknown'
             default_domain = default_domain.replace(COUNTRY_PLACEHOLDER, country_code, 1)
         return f'{self.identifier}.{default_domain}'
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -1072,7 +1072,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
 
     @staticmethod
     def _scheme_for_hostname(hostname: str) -> str:
-        return 'http' if 'localhost' in hostname else 'https'
+        return 'http' if hostname == 'localhost' or hostname.endswith('.localhost') else 'https'
 
     def get_view_url(  # noqa: C901, PLR0912
         self,
@@ -1161,12 +1161,18 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         production domains so the URL falls back to a preview/development
         domain or the wildcard.
         """
-        domains = [d for d in self.domains.all() if not d.redirect_to_hostname]
+        domains = [d for d in self.domains.order_by('pk') if not d.redirect_to_hostname]
         if not domains:
             return None
         if self.is_live():
             production = [d for d in domains if d.deployment_environment == PlanDomain.DeploymentEnvironment.PRODUCTION]
             if production:
+                if len(production) > 1:
+                    sentry_sdk.capture_message(
+                        f"Plan '{self.identifier}' has {len(production)} non-redirect production domains; "
+                        f"using '{production[0].hostname}' as canonical",
+                        level='warning',
+                    )
                 return production[0]
         else:
             domains = [d for d in domains if d.deployment_environment != PlanDomain.DeploymentEnvironment.PRODUCTION]
@@ -1217,7 +1223,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
 
         plan.statuses_updated_manually = True
         if not hostname:
-            hostname = plan.default_hostname()
+            hostname = plan.default_hostname(include_all_domains=True)
             if not hostname:
                 raise ValueError(f"Cannot determine hostname for plan '{plan.identifier}': no hostname plan domains configured")
         plan.create_default_site(hostname)
@@ -1264,11 +1270,9 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         if COUNTRY_PLACEHOLDER in default_domain:
             country_code = self.country.code.lower() if self.country else None
             if not country_code:
-                sentry_sdk.capture_message(
-                    f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'",
-                    level='error',
+                raise ValueError(
+                    f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'"
                 )
-                return None
             default_domain = default_domain.replace(COUNTRY_PLACEHOLDER, country_code, 1)
         return f'{self.identifier}.{default_domain}'
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -800,8 +800,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
 
     def create_default_site(self, hostname=None):
         if hostname is None:
-            parsed_url = urlparse(self.site_url)
-            hostname = parsed_url.hostname
+            hostname = self.default_hostname()
         if self.site is not None:
             return
         root_page = self.create_default_pages()
@@ -920,7 +919,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
 
     def get_site_notification_context(self):
         return dict(
-            view_url=self.site_url,
+            view_url=self.get_view_url(),
             title=self.general_content.site_title,
         )
 
@@ -1134,13 +1133,8 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
             else:
                 port_str = ''
             return '%s://%s%s%s%s' % (scheme, hostname, port_str, base_path, locale_prefix)
-        else:  # noqa: RET505
-            assert self.site_url is not None
-            if self.site_url.startswith('http'):
-                url = self.site_url.rstrip('/')
-            else:
-                url = 'https://%s' % self.site_url
-            return f'{url}{locale_prefix}'
+
+        return f'https://{self.default_hostname(include_all_domains=True)}{locale_prefix}'
 
     @classmethod
     def create_with_defaults(
@@ -1151,7 +1145,6 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         organization: Organization,
         other_languages: list[str] | None = None,
         short_name: str | None = None,
-        base_path: str | None = None,
         hostname: str | None = None,
         client_name: str | None = None,
     ) -> Plan:
@@ -1173,14 +1166,13 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
             if client is None:
                 client = Client.objects.create(name=client_name)
             ClientPlan.objects.create(plan=plan, client=client)
-        return cls.apply_defaults(plan, hostname=hostname, base_path=base_path)
+        return cls.apply_defaults(plan, hostname=hostname)
 
     @classmethod
     @transaction.atomic()
     def apply_defaults(
         cls,
         plan: Plan,
-        base_path: str | None = None,
         hostname: str | None = None,
     ) -> Plan:
         from actions.defaults import DEFAULT_ACTION_IMPLEMENTATION_PHASES, DEFAULT_ACTION_STATUSES
@@ -1188,10 +1180,6 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         plan.statuses_updated_manually = True
         if not hostname:
             hostname = plan.default_hostname()
-        site_url = f'https://{hostname}'
-        if base_path:
-            site_url += '/' + base_path.strip('/')
-        plan.site_url = site_url
         plan.create_default_site(hostname)
         plan.save()
 
@@ -1220,13 +1208,15 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         management.call_command('initialize_notifications', plan=plan.identifier)
         return plan
 
-    def default_hostname(self) -> str:
+    def default_hostname(self, include_all_domains: bool = False) -> str:
         """Build a hostname from plan identifier and any item in HOSTNAME_PLAN_DOMAINS that's not localhost."""
         hostname_plan_domains = (x for x in settings.HOSTNAME_PLAN_DOMAINS if x != 'localhost')
         try:
-            default_domain = next(iter(hostname_plan_domains))
+            default_domain = next(hostname_plan_domains)
         except StopIteration as e:
-            raise Exception('Cannot create default hostname if no hostname plan domains are configured') from e
+            if not include_all_domains:
+                raise Exception('Cannot create default hostname if no hostname plan domains are configured') from e
+            default_domain = next(iter(settings.HOSTNAME_PLAN_DOMAINS))
         if COUNTRY_PLACEHOLDER in default_domain:
             country_code = self.country.code.lower() if self.country else None
             if not country_code:

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -1134,12 +1134,39 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
                 port_str = ':%s' % port
             else:
                 port_str = ''
-            return '%s://%s%s%s%s' % (scheme, hostname, port_str, base_path, locale_prefix)
+            return '%s://%s%s%s%s' % (scheme, hostname, port_str, locale_prefix, base_path)
+
+        candidate = self._find_canonical_domain()
+        if candidate is not None:
+            bp = (candidate.base_path or '').rstrip('/')
+            return f'https://{candidate.hostname}{locale_prefix}{bp}'
 
         hostname = self.default_hostname(include_all_domains=True)
         if not hostname:
             raise ValueError(f"Cannot determine hostname for plan '{self.identifier}': no hostname plan domains configured")
         return f'https://{hostname}{locale_prefix}'
+
+    def _find_canonical_domain(self) -> PlanDomain | None:
+        """
+        Find the best PlanDomain to use as the canonical URL for this plan.
+
+        Filters out redirect domains. For published (live) plans, prefers
+        production deployment environment. For unpublished plans, excludes
+        production domains so the URL falls back to a preview/development
+        domain or the wildcard.
+        """
+        domains = [d for d in self.domains.all() if not d.redirect_to_hostname]
+        if not domains:
+            return None
+        if self.is_live():
+            production = [d for d in domains if d.deployment_environment == PlanDomain.DeploymentEnvironment.PRODUCTION]
+            if production:
+                return production[0]
+        else:
+            domains = [d for d in domains if d.deployment_environment != PlanDomain.DeploymentEnvironment.PRODUCTION]
+            if not domains:
+                return None
+        return domains[0]
 
     @classmethod
     def create_with_defaults(

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -1070,6 +1070,10 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
             return ''
         return next((f'/{lang}' for lang in self.other_languages if lang.lower() == locale.lower()), '')
 
+    @staticmethod
+    def _scheme_for_hostname(hostname: str) -> str:
+        return 'http' if 'localhost' in hostname else 'https'
+
     def get_view_url(  # noqa: C901, PLR0912
         self,
         client_url: str | None = None,
@@ -1139,12 +1143,14 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         candidate = self._find_canonical_domain()
         if candidate is not None:
             bp = (candidate.base_path or '').rstrip('/')
-            return f'https://{candidate.hostname}{locale_prefix}{bp}'
+            scheme = self._scheme_for_hostname(candidate.hostname)
+            return f'{scheme}://{candidate.hostname}{locale_prefix}{bp}'
 
         hostname = self.default_hostname(include_all_domains=True)
         if not hostname:
             raise ValueError(f"Cannot determine hostname for plan '{self.identifier}': no hostname plan domains configured")
-        return f'https://{hostname}{locale_prefix}'
+        scheme = self._scheme_for_hostname(hostname)
+        return f'{scheme}://{hostname}{locale_prefix}'
 
     def _find_canonical_domain(self) -> PlanDomain | None:
         """

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -1265,10 +1265,10 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
             country_code = self.country.code.lower() if self.country else None
             if not country_code:
                 sentry_sdk.capture_message(
-                    f"Plan '{self.identifier}' has no country set; using fallback for wildcard domain '{default_domain}'",
+                    f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'",
                     level='error',
                 )
-                country_code = 'unknown'
+                return None
             default_domain = default_domain.replace(COUNTRY_PLACEHOLDER, country_code, 1)
         return f'{self.identifier}.{default_domain}'
 

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -840,7 +840,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         for pledge in source_pledges:
             pledge.ensure_locale_copies()
 
-    def save(self, *args, **kwargs):  # noqa: C901, PLR0912
+    def save(self, *args, **kwargs):  # noqa: C901, PLR0912, PLR0915
         previous_language_codes: set[str] | None = None
         save_update_fields = kwargs.get('update_fields')
         if self.pk is not None:
@@ -1074,7 +1074,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
     def _scheme_for_hostname(hostname: str) -> str:
         return 'http' if hostname == 'localhost' or hostname.endswith('.localhost') else 'https'
 
-    def get_view_url(  # noqa: C901, PLR0912
+    def get_view_url(  # noqa: C901, PLR0912, PLR0915
         self,
         client_url: str | None = None,
         active_locale: str | None = None,
@@ -1152,33 +1152,55 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         scheme = self._scheme_for_hostname(hostname)
         return f'{scheme}://{hostname}{locale_prefix}'
 
+    def _first_production_domain(self, candidates: list[PlanDomain]) -> PlanDomain | None:
+        production = [d for d in candidates if d.deployment_environment == PlanDomain.DeploymentEnvironment.PRODUCTION]
+        if not production:
+            return None
+        if len(production) > 1:
+            sentry_sdk.capture_message(
+                f"Plan '{self.identifier}' has {len(production)} non-redirect production domains; "
+                f"using '{production[0].hostname}' as canonical",
+                level='warning',
+            )
+        return production[0]
+
+    def _find_live_canonical_domain(self, domains: list[PlanDomain]) -> PlanDomain | None:
+        published_domains = [d for d in domains if d.status == PublicationStatus.PUBLISHED]
+        if not published_domains:
+            return None
+        return self._first_production_domain(published_domains) or published_domains[0]
+
+    def _find_unpublished_canonical_domain(self, domains: list[PlanDomain]) -> PlanDomain | None:
+        explicitly_published = [d for d in domains if d.publication_status_override == PublicationStatus.PUBLISHED]
+        if explicitly_published:
+            return self._first_production_domain(explicitly_published) or explicitly_published[0]
+
+        non_production_domains = [
+            d
+            for d in domains
+            if d.deployment_environment != PlanDomain.DeploymentEnvironment.PRODUCTION
+            and d.publication_status_override != PublicationStatus.UNPUBLISHED
+        ]
+        if not non_production_domains:
+            return None
+        return non_production_domains[0]
+
     def _find_canonical_domain(self) -> PlanDomain | None:
         """
         Find the best PlanDomain to use as the canonical URL for this plan.
 
         Filters out redirect domains. For published (live) plans, prefers
-        production deployment environment. For unpublished plans, excludes
-        production domains so the URL falls back to a preview/development
-        domain or the wildcard.
+        published production domains. For unpublished plans, explicit
+        publication overrides take precedence; otherwise production domains are
+        excluded so the URL falls back to a preview/development domain or the
+        wildcard.
         """
         domains = [d for d in self.domains.order_by('pk') if not d.redirect_to_hostname]
         if not domains:
             return None
         if self.is_live():
-            production = [d for d in domains if d.deployment_environment == PlanDomain.DeploymentEnvironment.PRODUCTION]
-            if production:
-                if len(production) > 1:
-                    sentry_sdk.capture_message(
-                        f"Plan '{self.identifier}' has {len(production)} non-redirect production domains; "
-                        f"using '{production[0].hostname}' as canonical",
-                        level='warning',
-                    )
-                return production[0]
-        else:
-            domains = [d for d in domains if d.deployment_environment != PlanDomain.DeploymentEnvironment.PRODUCTION]
-            if not domains:
-                return None
-        return domains[0]
+            return self._find_live_canonical_domain(domains)
+        return self._find_unpublished_canonical_domain(domains)
 
     @classmethod
     def create_with_defaults(
@@ -1270,9 +1292,7 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         if COUNTRY_PLACEHOLDER in default_domain:
             country_code = self.country.code.lower() if self.country else None
             if not country_code:
-                raise ValueError(
-                    f"Plan '{self.identifier}' has no country set; cannot resolve wildcard domain '{default_domain}'"
-                )
+                return None
             default_domain = default_domain.replace(COUNTRY_PLACEHOLDER, country_code, 1)
         return f'{self.identifier}.{default_domain}'
 

--- a/actions/tests/factories.py
+++ b/actions/tests/factories.py
@@ -86,7 +86,7 @@ class PlanFactory(ModelFactory[Plan]):
     name = Sequence(lambda i: f'Plan {i}')
     identifier = Sequence(lambda i: f'plan{i}')
     image = SubFactory[Plan, AplansImage](AplansImageFactory)
-    site_url = Sequence(lambda i: f'https://plan{i}.example.com')
+    site_url = Sequence(lambda i: f'https://should-not-be-used-{i}.example.org')
     accessibility_statement_url = 'https://example.com'
     primary_language = 'en'
     other_languages = ['fi']

--- a/actions/tests/test_checks.py
+++ b/actions/tests/test_checks.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from django.core.checks import Error
+from django.test import override_settings
+
+from actions.checks import check_hostname_plan_domains
+
+
+@override_settings(HOSTNAME_PLAN_DOMAINS=[])
+def test_empty_hostname_plan_domains_produces_error():
+    errors = check_hostname_plan_domains(app_configs=None)
+    assert len(errors) == 1
+    assert isinstance(errors[0], Error)
+    assert errors[0].id == 'watch.D001'
+
+
+@override_settings(HOSTNAME_PLAN_DOMAINS=['localhost'])
+def test_only_localhost_produces_error():
+    errors = check_hostname_plan_domains(app_configs=None)
+    assert len(errors) == 1
+    assert isinstance(errors[0], Error)
+    assert errors[0].id == 'watch.D002'
+
+
+@override_settings(HOSTNAME_PLAN_DOMAINS=['example.com'])
+def test_valid_domain_produces_no_error():
+    errors = check_hostname_plan_domains(app_configs=None)
+    assert errors == []
+
+
+@override_settings(HOSTNAME_PLAN_DOMAINS=['localhost', 'example.com'])
+def test_localhost_with_other_domain_produces_no_error():
+    errors = check_hostname_plan_domains(app_configs=None)
+    assert errors == []

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -112,10 +112,10 @@ class TestGetViewUrlWithPlanDomain:
         url = plan.get_view_url(client_url='https://climate.city.gov', active_locale='fi')
         assert url == 'https://climate.city.gov/fi'
 
-    def test_locale_prefix_after_base_path(self, plan):
+    def test_locale_prefix_before_base_path(self, plan):
         PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate')
         url = plan.get_view_url(client_url='https://city.gov', active_locale='fi')
-        assert url == 'https://city.gov/climate/fi'
+        assert url == 'https://city.gov/fi/climate'
 
 
 class TestGetViewUrlFallback:
@@ -287,7 +287,250 @@ class TestGetViewUrlLocalhostFallback:
         assert url == 'https://myplan.example.com'
 
 
+@pytest.fixture
+def plan_no_wildcards(settings):
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    return PlanFactory.create(
+        identifier='myplan',
+        primary_language='en',
+        other_languages=['fi'],
+    )
+
+
+class TestGetViewUrlPlanDomainFallback:
+    """Test get_view_url falls back to PlanDomain when no client_url or no match."""
+
+    def test_uses_plan_domain_with_base_path_when_no_client_url(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate')
+        url = plan.get_view_url()
+        assert url == 'https://city.gov/climate'
+
+    def test_uses_plan_domain_without_base_path_when_no_client_url(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        PlanDomainFactory.create(plan=plan, hostname='climate.city.gov')
+        url = plan.get_view_url()
+        assert url == 'https://climate.city.gov'
+
+    def test_skips_redirect_domains(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        PlanDomainFactory.create(plan=plan, hostname='old.city.gov', redirect_to_hostname='new.city.gov')
+        PlanDomainFactory.create(plan=plan, hostname='new.city.gov')
+        url = plan.get_view_url()
+        assert url == 'https://new.city.gov'
+
+    def test_base_path_with_locale_prefix(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate')
+        url = plan.get_view_url(active_locale='fi')
+        assert url == 'https://city.gov/fi/climate'
+
+    def test_prefers_production_domain(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        from actions.models.plan import PlanDomain
+
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='preview.city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PREVIEW,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        url = plan.get_view_url()
+        assert url == 'https://city.gov'
+
+    def test_raises_when_only_redirect_domains_and_no_wildcards(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        PlanDomainFactory.create(plan=plan, hostname='old.city.gov', redirect_to_hostname='new.city.gov')
+        with pytest.raises(ValueError, match='no hostname plan domains configured'):
+            plan.get_view_url()
+
+    def test_uses_plan_domain_when_client_url_does_not_match(self, plan_no_wildcards):
+        plan = plan_no_wildcards
+        PlanDomainFactory.create(plan=plan, hostname='city.gov', base_path='/climate')
+        url = plan.get_view_url(client_url='https://unknown.example.org')
+        assert url == 'https://city.gov/climate'
+
+
+class TestGetViewUrlPlanDomainPriority:
+    """Test that a production PlanDomain takes priority over wildcard settings, but a wildcard from the UI overrides it."""
+
+    @pytest.fixture
+    def published_plan_with_production_domain(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            other_languages=['fi'],
+        )
+        from actions.models.plan import PlanDomain
+
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        return plan
+
+    def test_uses_plan_domain_over_wildcard_settings_when_no_client_url(self, published_plan_with_production_domain):
+        url = published_plan_with_production_domain.get_view_url()
+        assert url == 'https://city.gov/climate'
+
+    def test_uses_plan_domain_over_wildcard_settings_with_locale(self, published_plan_with_production_domain):
+        url = published_plan_with_production_domain.get_view_url(active_locale='fi')
+        assert url == 'https://city.gov/fi/climate'
+
+    def test_wildcard_from_ui_overrides_plan_domain(self, published_plan_with_production_domain):
+        url = published_plan_with_production_domain.get_view_url(client_url='https://anything.example.com')
+        assert url == 'https://myplan.example.com'
+
+    def test_wildcard_from_ui_overrides_plan_domain_with_locale(self, published_plan_with_production_domain):
+        url = published_plan_with_production_domain.get_view_url(
+            client_url='https://anything.example.com',
+            active_locale='fi',
+        )
+        assert url == 'https://myplan.example.com/fi'
+
+    def test_wildcard_from_request_header_overrides_plan_domain(self, published_plan_with_production_domain, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = []
+        request = SimpleNamespace(wildcard_domains=['example.com'])
+        url = published_plan_with_production_domain.get_view_url(
+            client_url='https://anything.example.com',
+            request=request,
+        )
+        assert url == 'https://myplan.example.com'
+
+    def test_non_matching_client_url_falls_back_to_plan_domain(self, published_plan_with_production_domain):
+        url = published_plan_with_production_domain.get_view_url(client_url='https://unknown.example.org')
+        assert url == 'https://city.gov/climate'
+
+
+class TestGetViewUrlUnpublishedPlan:
+    """Unpublished plans should use the wildcard domain, not PRODUCTION PlanDomains."""
+
+    @pytest.fixture
+    def unpublished_plan_with_production_domain(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            other_languages=['fi'],
+            published_at=None,
+        )
+        from actions.models.plan import PlanDomain
+
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        return plan
+
+    def test_uses_wildcard_domain_when_no_client_url(self, unpublished_plan_with_production_domain):
+        url = unpublished_plan_with_production_domain.get_view_url()
+        assert url == 'https://myplan.example.com'
+
+    def test_uses_wildcard_domain_with_locale(self, unpublished_plan_with_production_domain):
+        url = unpublished_plan_with_production_domain.get_view_url(active_locale='fi')
+        assert url == 'https://myplan.example.com/fi'
+
+    def test_uses_non_production_domain_when_available(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        from actions.models.plan import PlanDomain
+
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            other_languages=['fi'],
+            published_at=None,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='preview.city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PREVIEW,
+        )
+        url = plan.get_view_url()
+        assert url == 'https://preview.city.gov'
+
+    def test_wildcard_from_ui_still_used(self, unpublished_plan_with_production_domain):
+        url = unpublished_plan_with_production_domain.get_view_url(client_url='https://anything.example.com')
+        assert url == 'https://myplan.example.com'
+
+    def test_falls_back_to_wildcard_when_no_non_production_domains(self, unpublished_plan_with_production_domain):
+        """Only a PRODUCTION domain exists, plan is unpublished -> use wildcard."""
+        url = unpublished_plan_with_production_domain.get_view_url()
+        assert url == 'https://myplan.example.com'
+
+
 class TestGetSiteNotificationContext:
-    def test_view_url_uses_get_view_url(self, plan):
+    def test_view_url_uses_wildcard_when_no_plan_domain(self, plan):
         context = plan.get_site_notification_context()
         assert context['view_url'] == 'https://myplan.example.com'
+
+    def test_view_url_uses_production_domain_for_published_plan(self, settings):
+        from actions.models.plan import PlanDomain
+
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        context = plan.get_site_notification_context()
+        assert context['view_url'] == 'https://city.gov/climate'
+
+    def test_view_url_uses_wildcard_for_unpublished_plan_with_production_domain(self, settings):
+        from actions.models.plan import PlanDomain
+
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            published_at=None,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        context = plan.get_site_notification_context()
+        assert context['view_url'] == 'https://myplan.example.com'
+
+    def test_view_url_uses_preview_domain_for_unpublished_plan(self, settings):
+        from actions.models.plan import PlanDomain
+
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            published_at=None,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='preview.city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PREVIEW,
+        )
+        context = plan.get_site_notification_context()
+        assert context['view_url'] == 'https://preview.city.gov'

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -10,9 +10,10 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def plan():
+def plan(settings):
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
     return PlanFactory.create(
-        site_url='https://myplan.example.com',
+        identifier='myplan',
         primary_language='en',
         other_languages=['fi'],
     )
@@ -31,15 +32,11 @@ def wildcard_domain(request, settings):
 
 @pytest.fixture
 def no_wildcard_domains(settings):
-    settings.HOSTNAME_PLAN_DOMAINS = []
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
 
 
 class TestGetViewUrlNoClientUrl:
-    def test_returns_site_url(self, plan):
-        assert plan.get_view_url() == 'https://myplan.example.com'
-
-    def test_returns_site_url_with_trailing_slash_stripped(self):
-        plan = PlanFactory.create(site_url='https://myplan.example.com/')
+    def test_returns_url_from_default_hostname(self, plan):
         assert plan.get_view_url() == 'https://myplan.example.com'
 
     def test_adds_locale_prefix_for_non_primary_language(self, plan):
@@ -53,10 +50,6 @@ class TestGetViewUrlNoClientUrl:
     def test_no_locale_prefix_for_unknown_language(self, plan):
         url = plan.get_view_url(active_locale='sv')
         assert url == 'https://myplan.example.com'
-
-    def test_site_url_without_scheme_gets_https(self):
-        plan = PlanFactory.create(site_url='myplan.example.com')
-        assert plan.get_view_url() == 'https://myplan.example.com'
 
 
 class TestGetViewUrlWithWildcardDomain:
@@ -126,7 +119,7 @@ class TestGetViewUrlWithPlanDomain:
 
 
 class TestGetViewUrlFallback:
-    """Test get_view_url falls back to site_url when client_url doesn't match anything."""
+    """Test get_view_url falls back to default_hostname URL when client_url doesn't match anything."""
 
     def test_falls_back_when_hostname_not_in_wildcard_or_domains(self, plan, no_wildcard_domains):
         url = plan.get_view_url(client_url='https://unknown.example.org')
@@ -138,9 +131,10 @@ class TestGetViewUrlFallback:
 
 
 @pytest.fixture
-def plan_with_country():
+def plan_with_country(settings):
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
     return PlanFactory.create(
-        site_url='https://myplan.example.com',
+        identifier='myplan',
         primary_language='en',
         other_languages=['fi'],
         country='FI',
@@ -259,3 +253,31 @@ class TestGetViewUrlWithSimpleWildcardDomain:
         plan = plan_with_country
         url = plan.get_view_url(client_url='https://anything.de.dummy.io', **simple_wildcard_domain)
         assert url == f'https://{plan.identifier}.de.dummy.io'
+
+
+class TestGetViewUrlLocalhostFallback:
+    """Test get_view_url falls back to localhost domain when it's the only one configured."""
+
+    def test_falls_back_to_localhost_when_only_domain(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+        plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
+        url = plan.get_view_url()
+        assert url == 'https://myplan.localhost'
+
+    def test_falls_back_to_localhost_with_locale_prefix(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+        plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
+        url = plan.get_view_url(active_locale='fi')
+        assert url == 'https://myplan.localhost/fi'
+
+    def test_prefers_non_localhost_domain(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['localhost', 'example.com']
+        plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
+        url = plan.get_view_url()
+        assert url == 'https://myplan.example.com'
+
+
+class TestGetSiteNotificationContext:
+    def test_view_url_uses_get_view_url(self, plan):
+        context = plan.get_site_notification_context()
+        assert context['view_url'] == 'https://myplan.example.com'

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -258,17 +258,27 @@ class TestGetViewUrlWithSimpleWildcardDomain:
 class TestGetViewUrlLocalhostFallback:
     """Test get_view_url falls back to localhost domain when it's the only one configured."""
 
-    def test_falls_back_to_localhost_when_only_domain(self, settings):
+    def test_falls_back_to_localhost_in_development(self, settings):
         settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+        settings.DEPLOYMENT_TYPE = 'development'
         plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
         url = plan.get_view_url()
         assert url == 'https://myplan.localhost'
 
-    def test_falls_back_to_localhost_with_locale_prefix(self, settings):
+    def test_falls_back_to_localhost_with_locale_prefix_in_development(self, settings):
         settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+        settings.DEPLOYMENT_TYPE = 'development'
         plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
         url = plan.get_view_url(active_locale='fi')
         assert url == 'https://myplan.localhost/fi'
+
+    @pytest.mark.parametrize('deployment_type', ['production', 'staging', 'testing', 'wip', 'ci'])
+    def test_raises_when_only_localhost_in_non_development(self, settings, deployment_type):
+        settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+        settings.DEPLOYMENT_TYPE = deployment_type
+        plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
+        with pytest.raises(ValueError, match='no hostname plan domains configured'):
+            plan.get_view_url()
 
     def test_prefers_non_localhost_domain(self, settings):
         settings.HOSTNAME_PLAN_DOMAINS = ['localhost', 'example.com']

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -513,6 +513,16 @@ class TestGetViewUrlUnpublishedPlan:
         url = plan.get_view_url()
         assert url == 'https://preview.city.gov'
 
+    def test_uses_published_production_override(self, unpublished_plan_with_production_domain):
+        from actions.models.plan import PublicationStatus
+
+        domain = unpublished_plan_with_production_domain.domains.get(hostname='city.gov')
+        domain.publication_status_override = PublicationStatus.PUBLISHED
+        domain.save()
+
+        url = unpublished_plan_with_production_domain.get_view_url()
+        assert url == 'https://city.gov/climate'
+
     def test_wildcard_from_ui_still_used(self, unpublished_plan_with_production_domain):
         url = unpublished_plan_with_production_domain.get_view_url(client_url='https://anything.example.com')
         assert url == 'https://myplan.example.com'
@@ -521,6 +531,29 @@ class TestGetViewUrlUnpublishedPlan:
         """Only a PRODUCTION domain exists, plan is unpublished -> use wildcard."""
         url = unpublished_plan_with_production_domain.get_view_url()
         assert url == 'https://myplan.example.com'
+
+    def test_skips_unpublished_domain_override(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        from actions.models.plan import PlanDomain, PublicationStatus
+
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            other_languages=['fi'],
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+            publication_status_override=PublicationStatus.UNPUBLISHED,
+        )
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='preview.city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PREVIEW,
+        )
+        url = plan.get_view_url()
+        assert url == 'https://preview.city.gov'
 
 
 class TestDefaultHostnameMissingCountry:

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -263,14 +263,14 @@ class TestGetViewUrlLocalhostFallback:
         settings.DEPLOYMENT_TYPE = 'development'
         plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
         url = plan.get_view_url()
-        assert url == 'https://myplan.localhost'
+        assert url == 'http://myplan.localhost'
 
     def test_falls_back_to_localhost_with_locale_prefix_in_development(self, settings):
         settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
         settings.DEPLOYMENT_TYPE = 'development'
         plan = PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
         url = plan.get_view_url(active_locale='fi')
-        assert url == 'https://myplan.localhost/fi'
+        assert url == 'http://myplan.localhost/fi'
 
     @pytest.mark.parametrize('deployment_type', ['production', 'staging', 'testing', 'wip', 'ci'])
     def test_raises_when_only_localhost_in_non_development(self, settings, deployment_type):

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -473,6 +473,34 @@ class TestGetViewUrlUnpublishedPlan:
         assert url == 'https://myplan.example.com'
 
 
+class TestDefaultHostnameMissingCountry:
+    """A <country> wildcard domain has no resolvable hostname when the plan has no country."""
+
+    @pytest.fixture
+    def plan_no_country(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
+        return PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            country='',
+        )
+
+    def test_default_hostname_returns_none(self, plan_no_country):
+        assert plan_no_country.default_hostname() is None
+
+    def test_default_hostname_with_all_domains_returns_none(self, plan_no_country):
+        assert plan_no_country.default_hostname(include_all_domains=True) is None
+
+    def test_get_view_url_raises(self, plan_no_country):
+        with pytest.raises(ValueError, match='no hostname plan domains configured'):
+            plan_no_country.get_view_url()
+
+    def test_plan_with_country_still_resolves(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['<country>.dummy.io']
+        plan = PlanFactory.create(identifier='myplan', primary_language='en', country='FI')
+        assert plan.default_hostname() == 'myplan.fi.dummy.io'
+
+
 class TestGetSiteNotificationContext:
     def test_view_url_uses_wildcard_when_no_plan_domain(self, plan):
         context = plan.get_site_notification_context()

--- a/actions/tests/test_get_view_url.py
+++ b/actions/tests/test_get_view_url.py
@@ -409,6 +409,56 @@ class TestGetViewUrlPlanDomainPriority:
         assert url == 'https://city.gov/climate'
 
 
+class TestGetViewUrlMultipleProductionDomains:
+    """When several production domains exist, selection is deterministic (first by pk) and warns."""
+
+    @pytest.fixture
+    def published_plan(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        return PlanFactory.create(identifier='myplan', primary_language='en', other_languages=['fi'])
+
+    def _add_production_domain(self, plan, hostname):
+        from actions.models.plan import PlanDomain
+
+        return PlanDomainFactory.create(
+            plan=plan,
+            hostname=hostname,
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+
+    def test_picks_first_production_domain_by_pk(self, published_plan):
+        self._add_production_domain(published_plan, 'first.city.gov')
+        self._add_production_domain(published_plan, 'second.city.gov')
+        assert published_plan.get_view_url() == 'https://first.city.gov'
+
+    def test_warns_when_multiple_production_domains(self, published_plan, monkeypatch):
+        captured = []
+
+        def fake_capture_message(message, *args, **kwargs):
+            captured.append((message, kwargs.get('level')))
+
+        from actions.models import plan as plan_module
+
+        monkeypatch.setattr(plan_module.sentry_sdk, 'capture_message', fake_capture_message)
+        self._add_production_domain(published_plan, 'first.city.gov')
+        self._add_production_domain(published_plan, 'second.city.gov')
+        published_plan.get_view_url()
+        assert len(captured) == 1
+        message, level = captured[0]
+        assert level == 'warning'
+        assert '2 non-redirect production domains' in message
+        assert 'first.city.gov' in message
+
+    def test_does_not_warn_with_single_production_domain(self, published_plan, monkeypatch):
+        captured = []
+        from actions.models import plan as plan_module
+
+        monkeypatch.setattr(plan_module.sentry_sdk, 'capture_message', lambda *a, **_k: captured.append(a))
+        self._add_production_domain(published_plan, 'only.city.gov')
+        published_plan.get_view_url()
+        assert captured == []
+
+
 class TestGetViewUrlUnpublishedPlan:
     """Unpublished plans should use the wildcard domain, not PRODUCTION PlanDomains."""
 

--- a/actions/tests/test_graphql_mutations.py
+++ b/actions/tests/test_graphql_mutations.py
@@ -332,7 +332,7 @@ class TestDeletePlan:
     @staticmethod
     def _create_deletable_plan(**kwargs) -> Plan:
         plan = PlanFactory.create(**kwargs)
-        plan.create_default_site()
+        plan.create_default_site(hostname=f'{plan.identifier}.example.com')
         plan.save()
         return plan
 

--- a/actions/tests/test_graphql_plans_for_hostname.py
+++ b/actions/tests/test_graphql_plans_for_hostname.py
@@ -320,12 +320,77 @@ def test_default_hostname_with_exact_domain(settings, plan_factory):
     assert plan.default_hostname() == f'{plan.identifier}.dummy.io'
 
 
-def test_default_hostname_pattern_no_country_raises(settings, plan_factory):
-    """default_hostname() raises if plan has no country and domain is a pattern."""
+def test_default_hostname_pattern_no_country_uses_fallback(settings, plan_factory):
+    """default_hostname() uses 'UNKNOWN' as country fallback and reports to Sentry."""
     settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     plan = plan_factory(country='')
-    with pytest.raises(Exception, match='no country set'):
-        plan.default_hostname()
+    assert plan.default_hostname() == f'{plan.identifier}.watch.unknown.dummy.io'
+
+
+def test_default_hostname_returns_none_when_no_domains(settings, plan_factory):
+    """default_hostname() returns None when HOSTNAME_PLAN_DOMAINS is empty."""
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    plan = plan_factory()
+    assert plan.default_hostname() is None
+
+
+def test_default_hostname_returns_none_when_only_localhost_in_production(settings, plan_factory):
+    """default_hostname(include_all_domains=True) returns None in production when only localhost is configured."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+    settings.DEPLOYMENT_TYPE = 'production'
+    plan = plan_factory()
+    assert plan.default_hostname(include_all_domains=True) is None
+
+
+def test_default_hostname_returns_localhost_in_development(settings, plan_factory):
+    """default_hostname(include_all_domains=True) falls back to localhost in development."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+    settings.DEPLOYMENT_TYPE = 'development'
+    plan = plan_factory()
+    assert plan.default_hostname(include_all_domains=True) == f'{plan.identifier}.localhost'
+
+
+def test_get_view_url_raises_when_no_hostname(settings, plan_factory):
+    """get_view_url() raises when default_hostname() returns None."""
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    plan = plan_factory()
+    with pytest.raises(ValueError, match='Cannot determine'):
+        plan.get_view_url()
+
+
+def test_get_view_url_raises_when_only_localhost_in_production(settings, plan_factory):
+    """get_view_url() raises in production when only localhost is configured."""
+    settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+    settings.DEPLOYMENT_TYPE = 'production'
+    plan = plan_factory()
+    with pytest.raises(ValueError, match='Cannot determine'):
+        plan.get_view_url()
+
+
+def test_create_default_site_raises_when_no_hostname(settings, plan_factory):
+    """create_default_site() raises when default_hostname() returns None."""
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    plan = plan_factory()
+    with pytest.raises(ValueError, match='Cannot determine'):
+        plan.create_default_site()
+
+
+def test_apply_defaults_raises_when_no_hostname(settings, plan_factory):
+    """apply_defaults() raises when default_hostname() returns None."""
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    plan = plan_factory()
+    with pytest.raises(ValueError, match='Cannot determine'):
+        plan.apply_defaults(plan)
+
+
+def test_new_site_hostname_raises_when_no_hostname(settings, plan_factory):
+    """_new_site_hostname() raises when default_hostname() returns None."""
+    from copying.main import _new_site_hostname
+
+    settings.HOSTNAME_PLAN_DOMAINS = []
+    plan = plan_factory()
+    with pytest.raises(ValueError, match='Cannot determine'):
+        _new_site_hostname(plan, 'copy-plan')
 
 
 # --- Tests for legacy hostname redirect (<plan>.domain → <plan>.<country>.domain) ---

--- a/actions/tests/test_graphql_plans_for_hostname.py
+++ b/actions/tests/test_graphql_plans_for_hostname.py
@@ -320,11 +320,11 @@ def test_default_hostname_with_exact_domain(settings, plan_factory):
     assert plan.default_hostname() == f'{plan.identifier}.dummy.io'
 
 
-def test_default_hostname_pattern_no_country_uses_fallback(settings, plan_factory):
-    """default_hostname() uses 'UNKNOWN' as country fallback and reports to Sentry."""
+def test_default_hostname_pattern_no_country_returns_none(settings, plan_factory):
+    """default_hostname() returns None if plan has no country and domain is a pattern."""
     settings.HOSTNAME_PLAN_DOMAINS = ['watch.<country>.dummy.io']
     plan = plan_factory(country='')
-    assert plan.default_hostname() == f'{plan.identifier}.watch.unknown.dummy.io'
+    assert plan.default_hostname() is None
 
 
 def test_default_hostname_returns_none_when_no_domains(settings, plan_factory):

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -987,9 +987,12 @@ class PlanPublishView(
 
     def get_preview_url(self):
         try:
-            return f'https://{self.object.default_hostname()}'
+            hostname = self.object.default_hostname()
         except Exception:
             return None
+        if not hostname:
+            return None
+        return f'https://{hostname}'
 
     def is_scheduled(self):
         return self.object.publication_state == Plan.PublicationState.SCHEDULED

--- a/actions/wagtail_admin.py
+++ b/actions/wagtail_admin.py
@@ -321,7 +321,6 @@ class PlanAdmin(AplansModelAdmin[Plan]):
         FieldPanel('short_identifier'),
         FieldPanel('version_name'),
         FieldPanel('actions_locked'),
-        FieldPanel('site_url'),
         FieldPanel('accessibility_statement_url'),
         FieldPanel('primary_language'),
         FieldPanel('other_languages'),

--- a/admin_site/tests/test_plan_page_isolation.py
+++ b/admin_site/tests/test_plan_page_isolation.py
@@ -34,14 +34,10 @@ pytestmark = pytest.mark.django_db
 # ---------------------------------------------------------------------------
 
 
-def _create_plan_with_site(name: str, identifier: str, hostname: str) -> Plan:
+def _create_plan_with_site(name: str, identifier: str) -> Plan:
     from actions.perms import sync_all_group_permissions_for_plan
 
-    plan = PlanFactory.create(
-        name=name,
-        identifier=identifier,
-        site_url=f'https://{hostname}',
-    )
+    plan = PlanFactory.create(name=name, identifier=identifier)
     plan.create_default_site()
     plan.save()
     sync_all_group_permissions_for_plan(plan)
@@ -50,16 +46,18 @@ def _create_plan_with_site(name: str, identifier: str, hostname: str) -> Plan:
 
 @pytest.fixture
 @factory.django.mute_signals(post_save)
-def plan_a() -> Plan:
+def plan_a(settings) -> Plan:
     """First plan with its own Wagtail site and page tree."""
-    return _create_plan_with_site('Plan A', 'plan-a', 'plan-a.example.com')
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+    return _create_plan_with_site('Plan A', 'plan-a')
 
 
 @pytest.fixture
 @factory.django.mute_signals(post_save)
-def plan_b() -> Plan:
+def plan_b(settings) -> Plan:
     """Second plan with its own Wagtail site and page tree."""
-    return _create_plan_with_site('Plan B', 'plan-b', 'plan-b.example.com')
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+    return _create_plan_with_site('Plan B', 'plan-b')
 
 
 @pytest.fixture
@@ -122,9 +120,17 @@ class TestPlanSiteIsolation:
     def test_plans_have_distinct_root_pages(self, plan_a: Plan, plan_b: Plan):
         assert plan_a.root_page.pk != plan_b.root_page.pk
 
-    def test_plan_site_hostname_derived_from_site_url(self, plan_a: Plan):
+    def test_plan_site_hostname_derived_from_default_hostname(self, plan_a: Plan):
         assert plan_a.site is not None
         assert plan_a.site.hostname == 'plan-a.example.com'
+
+    def test_create_default_site_uses_default_hostname(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['correct-domain.io']
+        plan = PlanFactory.create(identifier='testplan')
+        plan.create_default_site()
+        plan.save()
+        assert plan.site is not None
+        assert plan.site.hostname == 'testplan.correct-domain.io'
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +273,7 @@ class TestCrossPlanAccessDenied:
 def _request_with_site(site):
     """Create a GET request with ``_wagtail_site`` pre-set."""
     request = RequestFactory().get('/')
-    request._wagtail_site = site
+    request._wagtail_site = site  # type: ignore[attr-defined]
     return request
 
 
@@ -309,7 +315,7 @@ class TestWagtailSiteEffect:
         assert url_parts is not None
         site_id, root_url, _page_path = url_parts
         assert site_id == plan_a.site_id
-        assert root_url == plan_a.site_url
+        assert root_url == f'https://{plan_a.default_hostname()}'
 
     # -- Code path 2: Page.get_url relative vs full URL --
 
@@ -336,7 +342,7 @@ class TestWagtailSiteEffect:
         request = _request_with_site(plan_b.site)
         url = plan_a_child_page.specific.get_url(request=request)
         assert url is not None
-        assert url.startswith(plan_a.site_url)
+        assert url.startswith(f'https://{plan_a.default_hostname()}')
 
     def test_get_url_returns_full_url_when_no_wagtail_site(
         self,
@@ -347,7 +353,7 @@ class TestWagtailSiteEffect:
         request = RequestFactory().get('/')
         url = plan_a_child_page.specific.get_url(request=request)
         assert url is not None
-        assert url.startswith(plan_a.site_url)
+        assert url.startswith(f'https://{plan_a.default_hostname()}')
 
     # -- Code path 3: Page.route_for_request --
 

--- a/admin_site/tests/test_plan_page_isolation.py
+++ b/admin_site/tests/test_plan_page_isolation.py
@@ -1,0 +1,393 @@
+"""
+Tests for multi-tenant plan admin console page isolation.
+
+Verifies that the Wagtail admin page explorer only shows pages
+belonging to the active plan's site, and that the ``_wagtail_site``
+attribute on the request is respected by the explorer hooks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db.models.signals import post_save
+from django.test import RequestFactory
+from wagtail.models import Page
+
+import factory
+import pytest
+
+from actions.tests.factories import PlanFactory
+from pages.tests.factories import StaticPageFactory
+from people.tests.factories import PersonFactory
+from users.tests.factories import UserFactory
+
+if TYPE_CHECKING:
+    from actions.models import Plan
+    from users.models import User
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _create_plan_with_site(name: str, identifier: str, hostname: str) -> Plan:
+    from actions.perms import sync_all_group_permissions_for_plan
+
+    plan = PlanFactory.create(
+        name=name,
+        identifier=identifier,
+        site_url=f'https://{hostname}',
+    )
+    plan.create_default_site()
+    plan.save()
+    sync_all_group_permissions_for_plan(plan)
+    return plan
+
+
+@pytest.fixture
+@factory.django.mute_signals(post_save)
+def plan_a() -> Plan:
+    """First plan with its own Wagtail site and page tree."""
+    return _create_plan_with_site('Plan A', 'plan-a', 'plan-a.example.com')
+
+
+@pytest.fixture
+@factory.django.mute_signals(post_save)
+def plan_b() -> Plan:
+    """Second plan with its own Wagtail site and page tree."""
+    return _create_plan_with_site('Plan B', 'plan-b', 'plan-b.example.com')
+
+
+@pytest.fixture
+def plan_a_child_page(plan_a: Plan) -> Page:
+    return StaticPageFactory.create(parent=plan_a.root_page, title='Plan A child')
+
+
+@pytest.fixture
+def plan_b_child_page(plan_b: Plan) -> Page:
+    return StaticPageFactory.create(parent=plan_b.root_page, title='Plan B child')
+
+
+def _create_plan_admin(plan: Plan) -> User:
+    from actions.perms import add_plan_admin_perms
+
+    user = UserFactory.create()
+    PersonFactory.create(user=user, general_admin_plans=[plan])
+    add_plan_admin_perms(user)
+    return user
+
+
+@pytest.fixture
+def admin_user_a(plan_a: Plan) -> User:
+    """Admin user who administers Plan A."""
+    return _create_plan_admin(plan_a)
+
+
+@pytest.fixture
+def admin_user_b(plan_b: Plan) -> User:
+    """Admin user who administers Plan B."""
+    return _create_plan_admin(plan_b)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_explorer_pages(user: User, parent_page: Page) -> list[Page]:
+    """Invoke the ``restrict_pages_to_plan`` hook and return the filtered pages."""
+    from admin_site.wagtail_hooks import restrict_pages_to_plan
+
+    all_pages = Page.objects.all()
+    request = RequestFactory().get('/admin/pages/')
+    request.user = user
+    return list(restrict_pages_to_plan(parent_page, all_pages, request))
+
+
+# ---------------------------------------------------------------------------
+# Tests - site isolation
+# ---------------------------------------------------------------------------
+
+
+class TestPlanSiteIsolation:
+    def test_plans_have_distinct_sites(self, plan_a: Plan, plan_b: Plan):
+        assert plan_a.site is not None
+        assert plan_b.site is not None
+        assert plan_a.site.pk != plan_b.site.pk
+
+    def test_plans_have_distinct_root_pages(self, plan_a: Plan, plan_b: Plan):
+        assert plan_a.root_page.pk != plan_b.root_page.pk
+
+    def test_plan_site_hostname_derived_from_site_url(self, plan_a: Plan):
+        assert plan_a.site is not None
+        assert plan_a.site.hostname == 'plan-a.example.com'
+
+
+# ---------------------------------------------------------------------------
+# Tests - page explorer filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures('plan_b_child_page')
+class TestPageExplorerFiltering:
+    def test_admin_sees_own_plan_root_and_child(
+        self,
+        plan_a: Plan,
+        plan_a_child_page: Page,
+        admin_user_a: User,
+    ):
+        pages = _get_explorer_pages(admin_user_a, plan_a.root_page)
+        page_ids = {p.pk for p in pages}
+        assert plan_a.root_page.pk in page_ids
+        assert plan_a_child_page.pk in page_ids
+
+    def test_admin_does_not_see_other_plan_pages(
+        self,
+        plan_a: Plan,
+        plan_b: Plan,
+        plan_b_child_page: Page,
+        admin_user_a: User,
+    ):
+        pages = _get_explorer_pages(admin_user_a, plan_a.root_page)
+        page_ids = {p.pk for p in pages}
+        assert plan_b.root_page.pk not in page_ids
+        assert plan_b_child_page.pk not in page_ids
+
+    def test_other_admin_sees_only_own_pages(
+        self,
+        plan_a: Plan,
+        plan_b: Plan,
+        plan_a_child_page: Page,
+        plan_b_child_page: Page,
+        admin_user_b: User,
+    ):
+        pages = _get_explorer_pages(admin_user_b, plan_b.root_page)
+        page_ids = {p.pk for p in pages}
+        assert plan_b.root_page.pk in page_ids
+        assert plan_b_child_page.pk in page_ids
+        assert plan_a.root_page.pk not in page_ids
+        assert plan_a_child_page.pk not in page_ids
+
+
+# ---------------------------------------------------------------------------
+# Tests - full HTTP admin view
+# ---------------------------------------------------------------------------
+
+
+class TestAdminPageExplorerView:
+    def test_admin_explorer_returns_200(
+        self,
+        client,
+        plan_a: Plan,
+        admin_user_a: User,
+    ):
+        client.force_login(admin_user_a)
+        response = client.get(f'/admin/pages/{plan_a.root_page.pk}/')
+        assert response.status_code == 200
+
+    def test_admin_explorer_contains_own_child_page(
+        self,
+        client,
+        plan_a: Plan,
+        plan_a_child_page: Page,
+        admin_user_a: User,
+    ):
+        client.force_login(admin_user_a)
+        response = client.get(f'/admin/pages/{plan_a.root_page.pk}/')
+        assert plan_a_child_page.title.encode() in response.content
+
+    @pytest.mark.usefixtures('plan_a_child_page')
+    def test_admin_explorer_excludes_other_plan_child_page(
+        self,
+        client,
+        plan_a: Plan,
+        plan_b_child_page: Page,
+        admin_user_a: User,
+    ):
+        client.force_login(admin_user_a)
+        response = client.get(f'/admin/pages/{plan_a.root_page.pk}/')
+        assert plan_b_child_page.title.encode() not in response.content
+
+
+# ---------------------------------------------------------------------------
+# Tests - cross-plan access denied
+# ---------------------------------------------------------------------------
+
+
+class TestCrossPlanAccessDenied:
+    """Verify that an admin cannot edit or usefully browse pages from the other plan."""
+
+    def test_editing_other_plans_root_page_is_denied(
+        self,
+        client,
+        plan_b: Plan,
+        admin_user_a: User,
+    ):
+        """Plan A's admin cannot open the edit view for plan B's root page."""
+        client.force_login(admin_user_a)
+        response = client.get(f'/admin/pages/{plan_b.root_page.pk}/edit/')
+        # Wagtail raises PermissionDenied which the admin decorator turns
+        # into a 302 redirect to the admin home.
+        assert response.status_code == 302
+        assert response.url == '/admin/'
+
+    def test_editing_other_plans_child_page_is_denied(
+        self,
+        client,
+        plan_b_child_page: Page,
+        admin_user_a: User,
+    ):
+        """Plan A's admin cannot open the edit view for a plan B child page."""
+        client.force_login(admin_user_a)
+        response = client.get(f'/admin/pages/{plan_b_child_page.pk}/edit/')
+        assert response.status_code == 302
+        assert response.url == '/admin/'
+
+    def test_own_plan_edit_still_works(
+        self,
+        client,
+        plan_a_child_page: Page,
+        admin_user_a: User,
+    ):
+        """Sanity check: plan A's admin *can* edit their own plan's pages."""
+        client.force_login(admin_user_a)
+        response = client.get(f'/admin/pages/{plan_a_child_page.pk}/edit/')
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests - _wagtail_site effect on Wagtail internals
+# ---------------------------------------------------------------------------
+
+
+def _request_with_site(site):
+    """Create a GET request with ``_wagtail_site`` pre-set."""
+    request = RequestFactory().get('/')
+    request._wagtail_site = site
+    return request
+
+
+@pytest.fixture
+def _only_plan_sites(plan_a: Plan, plan_b: Plan):
+    """Delete any Wagtail sites not belonging to the two test plans."""
+    from wagtail.models import Site
+
+    Site.objects.exclude(pk__in=[plan_a.site_id, plan_b.site_id]).delete()
+    Site.clear_site_root_paths_cache()
+
+
+@pytest.mark.usefixtures('_only_plan_sites')
+class TestWagtailSiteEffect:
+    """
+    Verify how ``_wagtail_site`` influences Wagtail URL resolution and routing.
+
+    The reason for this is that our admin middleware is short-circuiting
+    Wagtail's site resolving code by injecting that attribute to the request.
+    We need to verify that Wagtail keeps using that internal attribute.
+
+    ``AplansPage.get_url_parts`` short-circuits the base Wagtail
+    implementation, making URL parts plan-intrinsic.  ``Page.get_url``
+    and ``Page.route_for_request`` still consult ``_wagtail_site`` via
+    ``Site.find_for_request``.
+    """
+
+    # -- Code path 1: AplansPage.get_url_parts --
+
+    def test_get_url_parts_returns_own_plan_regardless_of_wagtail_site(
+        self,
+        plan_a: Plan,
+        plan_b: Plan,
+        plan_a_child_page: Page,
+    ):
+        """``get_url_parts`` returns the page's own plan site regardless of ``_wagtail_site``."""
+        request = _request_with_site(plan_b.site)
+        url_parts = plan_a_child_page.specific.get_url_parts(request=request)
+        assert url_parts is not None
+        site_id, root_url, _page_path = url_parts
+        assert site_id == plan_a.site_id
+        assert root_url == plan_a.site_url
+
+    # -- Code path 2: Page.get_url relative vs full URL --
+
+    def test_get_url_returns_relative_path_when_wagtail_site_matches(
+        self,
+        plan_a: Plan,
+        plan_a_child_page: Page,
+    ):
+        """``get_url`` returns a relative path when ``_wagtail_site`` matches."""
+        request = _request_with_site(plan_a.site)
+        url = plan_a_child_page.specific.get_url(request=request)
+        assert url is not None
+        assert url == plan_a_child_page.url_path
+        assert url.startswith('/')
+        assert '://' not in url
+
+    def test_get_url_returns_full_url_when_wagtail_site_differs(
+        self,
+        plan_a: Plan,
+        plan_b: Plan,
+        plan_a_child_page: Page,
+    ):
+        """``get_url`` returns a full URL when ``_wagtail_site`` belongs to another plan."""
+        request = _request_with_site(plan_b.site)
+        url = plan_a_child_page.specific.get_url(request=request)
+        assert url is not None
+        assert url.startswith(plan_a.site_url)
+
+    def test_get_url_returns_full_url_when_no_wagtail_site(
+        self,
+        plan_a: Plan,
+        plan_a_child_page: Page,
+    ):
+        """``get_url`` returns a full URL when no ``_wagtail_site`` is set."""
+        request = RequestFactory().get('/')
+        url = plan_a_child_page.specific.get_url(request=request)
+        assert url is not None
+        assert url.startswith(plan_a.site_url)
+
+    # -- Code path 3: Page.route_for_request --
+
+    def test_route_for_request_finds_page_under_wagtail_site(
+        self,
+        plan_a: Plan,
+        plan_a_child_page: Page,
+    ):
+        """``route_for_request`` finds a page under the ``_wagtail_site`` tree."""
+        request = _request_with_site(plan_a.site)
+        result = Page.route_for_request(request, plan_a_child_page.slug + '/')
+        assert result is not None
+        assert result.page.pk == plan_a_child_page.pk
+
+    def test_route_for_request_cannot_find_other_sites_page(
+        self,
+        plan_a: Plan,
+        plan_b_child_page: Page,
+    ):
+        """``route_for_request`` returns ``None`` for a page in another site tree."""
+        request = _request_with_site(plan_a.site)
+        result = Page.route_for_request(request, plan_b_child_page.slug + '/')
+        assert result is None
+
+    def test_route_for_request_returns_none_without_wagtail_site(
+        self,
+    ):
+        """``route_for_request`` returns ``None`` without ``_wagtail_site`` or matching host."""
+        request = RequestFactory().get('/')
+        result = Page.route_for_request(request, 'any/')
+        assert result is None
+
+    def test_route_for_request_caches_result(
+        self,
+        plan_a: Plan,
+        plan_a_child_page: Page,
+    ):
+        """``route_for_request`` caches its result on the request object."""
+        request = _request_with_site(plan_a.site)
+        first = Page.route_for_request(request, plan_a_child_page.slug + '/')
+        assert hasattr(request, '_wagtail_route_for_request')
+        second = Page.route_for_request(request, plan_a_child_page.slug + '/')
+        assert first is second

--- a/conftest.py
+++ b/conftest.py
@@ -165,7 +165,8 @@ register(wagtail_factories.factories.CollectionFactory)
 
 @pytest.fixture
 @factory.django.mute_signals(post_save)
-def plan_with_pages(plan):
+def plan_with_pages(plan, settings):
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
     plan.create_default_site()
     plan.save()
     return plan

--- a/copying/main.py
+++ b/copying/main.py
@@ -469,8 +469,7 @@ def _validate_unique_field_copy_policies(plan: Plan, copy_indicators: bool) -> N
     missing = get_unclassified_unique_field_copy_policies()
     if missing:
         raise RuntimeError(
-            'Copying has unique fields without copy policies. Add entries to UNIQUE_FIELD_COPY_POLICIES: '
-            + ', '.join(missing)
+            'Copying has unique fields without copy policies. Add entries to UNIQUE_FIELD_COPY_POLICIES: ' + ', '.join(missing)
         )
 
     unsupported_fields = []
@@ -486,15 +485,12 @@ def _validate_unique_field_copy_policies(plan: Plan, copy_indicators: bool) -> N
 
     if unsupported_fields:
         raise ValueError(
-            'Cannot copy plan because some unique fields do not have copy support yet: '
-            + ', '.join(sorted(unsupported_fields))
+            'Cannot copy plan because some unique fields do not have copy support yet: ' + ', '.join(sorted(unsupported_fields))
         )
 
 
 def _raise_unique_field_policy_error(instance: Model, field: Field, policy: str, message: str) -> NoReturn:
-    raise RuntimeError(
-        f'Unique field copy policy {policy!r} was not applied for {instance._meta.label}.{field.name}: {message}'
-    )
+    raise RuntimeError(f'Unique field copy policy {policy!r} was not applied for {instance._meta.label}.{field.name}: {message}')
 
 
 def _validate_unsupported_if_set_policy(
@@ -1612,6 +1608,8 @@ def _new_site_hostname(old_plan: Plan, new_plan_identifier: str) -> str:
     old_plan.identifier = new_plan_identifier
     new_site_hostname = old_plan.default_hostname()
     old_plan.identifier = old_identifier
+    if not new_site_hostname:
+        raise ValueError(f"Cannot determine hostname for plan '{new_plan_identifier}': no hostname plan domains configured")
     return new_site_hostname
 
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -865,7 +865,6 @@ class CloneVisitor(AbstractVisitor):
         site_copy = self.get_copy(instance.site)
         assert site_copy
         instance.site = site_copy
-        instance.site_url = f'https://{site_copy.hostname}'
         # TODO: Ideally it should be configurable whether 'published_at` is reset
         instance.published_at = None
 

--- a/indicators/models/indicator.py
+++ b/indicators/models/indicator.py
@@ -562,7 +562,9 @@ class Indicator(
         from django.conf import settings
 
         if 'kausal_watch_extensions' in settings.INSTALLED_APPS:
-            edit_values_url = reverse('indicators_indicator_modeladmin_edit_values', kwargs=dict(instance_pk=self.id))
+            edit_values_url = settings.ADMIN_BASE_URL + reverse(
+                'indicators_indicator_modeladmin_edit_values', kwargs=dict(instance_pk=self.id)
+            )
         else:
             edit_values_url = None
         return {

--- a/notifications/apps.py
+++ b/notifications/apps.py
@@ -5,3 +5,10 @@ from django.utils.translation import gettext_lazy as _
 class NotificationsConfig(AppConfig):
     name = 'notifications'
     verbose_name = _('Notifications')
+
+    def ready(self) -> None:
+        from django.core.checks import register
+
+        from .checks import check_admin_base_url
+
+        register(check_admin_base_url, deploy=True)

--- a/notifications/checks.py
+++ b/notifications/checks.py
@@ -8,13 +8,13 @@ from .utils import is_valid_public_domain_url
 
 def check_admin_base_url(app_configs, **kwargs) -> list[Error]:
     """
-    Ensure ``ADMIN_BASE_URL`` is a public URL outside of debug mode.
+    Ensure ``ADMIN_BASE_URL`` is a public URL outside of development.
 
     Notification emails embed admin edit links derived from ``ADMIN_BASE_URL``.
     A localhost or private-network value would render unusable links, so we fail
     fast at startup rather than at send time.
     """
-    if settings.DEBUG or settings.DEPLOYMENT_TYPE == 'development':
+    if settings.DEPLOYMENT_TYPE == 'development':
         return []
     if is_valid_public_domain_url(settings.ADMIN_BASE_URL):
         return []

--- a/notifications/checks.py
+++ b/notifications/checks.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.checks import Error
+
+from .utils import is_valid_public_domain_url
+
+
+def check_admin_base_url(app_configs, **kwargs) -> list[Error]:
+    """
+    Ensure ``ADMIN_BASE_URL`` is a public URL outside of debug mode.
+
+    Notification emails embed admin edit links derived from ``ADMIN_BASE_URL``.
+    A localhost or private-network value would render unusable links, so we fail
+    fast at startup rather than at send time.
+    """
+    if settings.DEBUG or settings.DEPLOYMENT_TYPE == 'development':
+        return []
+    if is_valid_public_domain_url(settings.ADMIN_BASE_URL):
+        return []
+    return [
+        Error(
+            f'ADMIN_BASE_URL is not a public URL: {settings.ADMIN_BASE_URL}',
+            hint='Set ADMIN_BASE_URL to a publicly reachable https URL so notification admin links work.',
+            id='notifications.E001',
+        )
+    ]

--- a/notifications/engine.py
+++ b/notifications/engine.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from logging import getLogger
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.core.mail import EmailMessage
 from django.utils import translation
 
@@ -16,6 +17,7 @@ from indicators.models import IndicatorContactPerson
 
 from .mjml import render_mjml_from_template
 from .models import ManuallyScheduledNotificationTemplate
+from .utils import validate_notification_context_urls
 from .notifications import (
     ActionNotUpdatedNotification,
     ManuallyScheduledNotification,
@@ -253,6 +255,7 @@ class NotificationEngine:
                 **template.base.get_notification_context(),
                 **context,
             )
+            validate_notification_context_urls(context, allow_localhost=settings.DEBUG)
 
             rendered['html_body'] = render_mjml_from_template(
                 template.type,

--- a/notifications/engine.py
+++ b/notifications/engine.py
@@ -17,7 +17,6 @@ from indicators.models import IndicatorContactPerson
 
 from .mjml import render_mjml_from_template
 from .models import ManuallyScheduledNotificationTemplate
-from .utils import validate_notification_context_urls
 from .notifications import (
     ActionNotUpdatedNotification,
     ManuallyScheduledNotification,
@@ -31,6 +30,7 @@ from .notifications import (
 )
 from .queue import NotificationQueue
 from .recipients import PersonRecipient
+from .utils import validate_notification_context_urls
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -255,7 +255,7 @@ class NotificationEngine:
                 **template.base.get_notification_context(),
                 **context,
             )
-            validate_notification_context_urls(context, allow_localhost=settings.DEBUG)
+            validate_notification_context_urls(context, allow_localhost=settings.DEPLOYMENT_TYPE == 'development')
 
             rendered['html_body'] = render_mjml_from_template(
                 template.type,

--- a/notifications/mjml-templates/includes/modify_action_button.mjml
+++ b/notifications/mjml-templates/includes/modify_action_button.mjml
@@ -1,3 +1,3 @@
-<mj-button align="left" href="{{ admin_url }}{{ action.change_url }}">
+<mj-button align="left" href="{{ action.change_url }}">
     <strong style="color: {{ theme.link_in_brand_bg_color }}">{% trans %}Edit action{% endtrans %}</strong>
 </mj-button>

--- a/notifications/mjml-templates/includes/modify_indicator_button.mjml
+++ b/notifications/mjml-templates/includes/modify_indicator_button.mjml
@@ -1,3 +1,3 @@
-<mj-button align="left" href="{{ admin_url }}{{ indicator.edit_values_url }}">
+<mj-button align="left" href="{{ indicator.edit_values_url }}">
     <strong style="color: {{ theme.link_in_brand_bg_color }}">{% trans %}Edit indicator data{% endtrans %}</strong>
 </mj-button>

--- a/notifications/tests/conftest.py
+++ b/notifications/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _notification_test_settings(settings) -> None:
+    settings.ADMIN_BASE_URL = 'https://admin.example.com'

--- a/notifications/tests/test_change_url.py
+++ b/notifications/tests/test_change_url.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.urls import reverse
+
+import pytest
+
+from actions.tests.factories import ActionFactory
+from indicators.tests.factories import IndicatorLevelFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_action_change_url_is_absolute_admin_url():
+    action = ActionFactory.create()
+    expected = settings.ADMIN_BASE_URL + reverse('actions_action_modeladmin_edit', kwargs=dict(instance_pk=action.id))
+    context = action.get_notification_context()
+    assert context['change_url'] == expected
+    assert context['change_url'].startswith(settings.ADMIN_BASE_URL)
+
+
+def test_indicator_edit_values_url_is_absolute_admin_url():
+    indicator_level = IndicatorLevelFactory.create()
+    indicator = indicator_level.indicator
+    plan = indicator_level.plan
+    context = indicator.get_notification_context(plan)
+    assert context['edit_values_url'].startswith(settings.ADMIN_BASE_URL)

--- a/notifications/tests/test_checks.py
+++ b/notifications/tests/test_checks.py
@@ -2,7 +2,7 @@ from notifications.checks import check_admin_base_url
 
 
 def test_check_errors_for_localhost_admin_url(settings):
-    settings.DEBUG = False
+    settings.DEPLOYMENT_TYPE = 'production'
     settings.ADMIN_BASE_URL = 'http://localhost:8000'
     errors = check_admin_base_url(app_configs=None)
     assert len(errors) == 1
@@ -10,7 +10,7 @@ def test_check_errors_for_localhost_admin_url(settings):
 
 
 def test_check_errors_for_ip_admin_url(settings):
-    settings.DEBUG = False
+    settings.DEPLOYMENT_TYPE = 'production'
     settings.ADMIN_BASE_URL = 'http://192.168.1.1/admin/'
     errors = check_admin_base_url(app_configs=None)
     assert len(errors) == 1
@@ -18,12 +18,12 @@ def test_check_errors_for_ip_admin_url(settings):
 
 
 def test_check_passes_for_public_admin_url(settings):
-    settings.DEBUG = False
+    settings.DEPLOYMENT_TYPE = 'production'
     settings.ADMIN_BASE_URL = 'https://admin.example.com'
     assert check_admin_base_url(app_configs=None) == []
 
 
-def test_check_allows_localhost_in_debug(settings):
-    settings.DEBUG = True
+def test_check_allows_localhost_in_development(settings):
+    settings.DEPLOYMENT_TYPE = 'development'
     settings.ADMIN_BASE_URL = 'http://localhost:8000'
     assert check_admin_base_url(app_configs=None) == []

--- a/notifications/tests/test_checks.py
+++ b/notifications/tests/test_checks.py
@@ -17,6 +17,14 @@ def test_check_errors_for_ip_admin_url(settings):
     assert errors[0].id == 'notifications.E001'
 
 
+def test_check_errors_for_unsupported_admin_url_scheme(settings):
+    settings.DEPLOYMENT_TYPE = 'production'
+    settings.ADMIN_BASE_URL = 'ftp://admin.example.com/admin/'
+    errors = check_admin_base_url(app_configs=None)
+    assert len(errors) == 1
+    assert errors[0].id == 'notifications.E001'
+
+
 def test_check_passes_for_public_admin_url(settings):
     settings.DEPLOYMENT_TYPE = 'production'
     settings.ADMIN_BASE_URL = 'https://admin.example.com'

--- a/notifications/tests/test_checks.py
+++ b/notifications/tests/test_checks.py
@@ -1,0 +1,29 @@
+from notifications.checks import check_admin_base_url
+
+
+def test_check_errors_for_localhost_admin_url(settings):
+    settings.DEBUG = False
+    settings.ADMIN_BASE_URL = 'http://localhost:8000'
+    errors = check_admin_base_url(app_configs=None)
+    assert len(errors) == 1
+    assert errors[0].id == 'notifications.E001'
+
+
+def test_check_errors_for_ip_admin_url(settings):
+    settings.DEBUG = False
+    settings.ADMIN_BASE_URL = 'http://192.168.1.1/admin/'
+    errors = check_admin_base_url(app_configs=None)
+    assert len(errors) == 1
+    assert errors[0].id == 'notifications.E001'
+
+
+def test_check_passes_for_public_admin_url(settings):
+    settings.DEBUG = False
+    settings.ADMIN_BASE_URL = 'https://admin.example.com'
+    assert check_admin_base_url(app_configs=None) == []
+
+
+def test_check_allows_localhost_in_debug(settings):
+    settings.DEBUG = True
+    settings.ADMIN_BASE_URL = 'http://localhost:8000'
+    assert check_admin_base_url(app_configs=None) == []

--- a/notifications/tests/test_notifications.py
+++ b/notifications/tests/test_notifications.py
@@ -362,6 +362,7 @@ def test_i18n(plan: Plan, plan_admin_person: Person):
 
 
 def test_localhost_admin_url_raises(settings):
+    settings.DEPLOYMENT_TYPE = 'production'
     settings.ADMIN_BASE_URL = 'http://localhost:8000'
     plan = PlanFactory.create()
     AutomaticNotificationTemplateFactory(base__plan=plan, type=NotificationType.TASK_LATE.identifier)
@@ -375,7 +376,8 @@ def test_localhost_admin_url_raises(settings):
         engine.generate_notifications()
 
 
-def test_localhost_hostname_plan_domains_raises(settings):
+def test_localhost_hostname_plan_domains_raises_when_not_development(settings):
+    settings.DEPLOYMENT_TYPE = 'production'
     settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
     settings.ADMIN_BASE_URL = 'https://admin.example.com'
     plan = PlanFactory.create()
@@ -386,12 +388,12 @@ def test_localhost_hostname_plan_domains_raises(settings):
     ActionContactFactory.create(action=task.action)
     ClientPlanFactory.create(plan=plan)
     engine = NotificationEngine(plan, only_type=NotificationType.TASK_LATE.identifier, now=now)
-    with pytest.raises(ValueError, match='localhost'):
+    with pytest.raises(ValueError, match='Cannot determine hostname'):
         engine.generate_notifications()
 
 
-def test_localhost_allowed_in_debug_mode(settings):
-    settings.DEBUG = True
+def test_localhost_allowed_in_development(settings):
+    settings.DEPLOYMENT_TYPE = 'development'
     settings.ADMIN_BASE_URL = 'http://localhost:8000'
     plan = PlanFactory.create()
     AutomaticNotificationTemplateFactory(base__plan=plan, type=NotificationType.TASK_LATE.identifier)

--- a/notifications/tests/test_notifications.py
+++ b/notifications/tests/test_notifications.py
@@ -359,3 +359,47 @@ def test_i18n(plan: Plan, plan_admin_person: Person):
     engine = NotificationEngine(plan, only_type=NotificationType.TASK_LATE.identifier, now=now)
     engine.generate_notifications()
     assert 'Hallo' in mail.outbox[0].body
+
+
+def test_localhost_admin_url_raises(settings):
+    settings.ADMIN_BASE_URL = 'http://localhost:8000'
+    plan = PlanFactory.create()
+    AutomaticNotificationTemplateFactory(base__plan=plan, type=NotificationType.TASK_LATE.identifier)
+    now = plan.to_local_timezone(datetime(2000, 1, 1, 0, 0, tzinfo=UTC))
+    due_at = now.date() - timedelta(days=1)
+    task = ActionTaskFactory.create(action__plan=plan, due_at=due_at)
+    ActionContactFactory.create(action=task.action)
+    ClientPlanFactory.create(plan=plan)
+    engine = NotificationEngine(plan, only_type=NotificationType.TASK_LATE.identifier, now=now)
+    with pytest.raises(ValueError, match='localhost'):
+        engine.generate_notifications()
+
+
+def test_localhost_hostname_plan_domains_raises(settings):
+    settings.HOSTNAME_PLAN_DOMAINS = ['localhost']
+    settings.ADMIN_BASE_URL = 'https://admin.example.com'
+    plan = PlanFactory.create()
+    AutomaticNotificationTemplateFactory(base__plan=plan, type=NotificationType.TASK_LATE.identifier)
+    now = plan.to_local_timezone(datetime(2000, 1, 1, 0, 0, tzinfo=UTC))
+    due_at = now.date() - timedelta(days=1)
+    task = ActionTaskFactory.create(action__plan=plan, due_at=due_at)
+    ActionContactFactory.create(action=task.action)
+    ClientPlanFactory.create(plan=plan)
+    engine = NotificationEngine(plan, only_type=NotificationType.TASK_LATE.identifier, now=now)
+    with pytest.raises(ValueError, match='localhost'):
+        engine.generate_notifications()
+
+
+def test_localhost_allowed_in_debug_mode(settings):
+    settings.DEBUG = True
+    settings.ADMIN_BASE_URL = 'http://localhost:8000'
+    plan = PlanFactory.create()
+    AutomaticNotificationTemplateFactory(base__plan=plan, type=NotificationType.TASK_LATE.identifier)
+    now = plan.to_local_timezone(datetime(2000, 1, 1, 0, 0, tzinfo=UTC))
+    due_at = now.date() - timedelta(days=1)
+    task = ActionTaskFactory.create(action__plan=plan, due_at=due_at)
+    ActionContactFactory.create(action=task.action)
+    ClientPlanFactory.create(plan=plan)
+    engine = NotificationEngine(plan, only_type=NotificationType.TASK_LATE.identifier, now=now)
+    engine.generate_notifications()
+    assert len(mail.outbox) == 1

--- a/notifications/tests/test_url_validation.py
+++ b/notifications/tests/test_url_validation.py
@@ -1,0 +1,129 @@
+import pytest
+
+from notifications.utils import find_urls_in_context, is_valid_public_domain_url, validate_notification_context_urls
+
+
+class TestIsValidPublicDomainUrl:
+    def test_accepts_https_domain(self):
+        assert is_valid_public_domain_url('https://example.com') is True
+
+    def test_accepts_http_domain(self):
+        assert is_valid_public_domain_url('http://example.com') is True
+
+    def test_accepts_domain_with_path(self):
+        assert is_valid_public_domain_url('https://plan0.example.org/actions/a1') is True
+
+    def test_accepts_subdomain(self):
+        assert is_valid_public_domain_url('https://sub.domain.example.com/path') is True
+
+    def test_accepts_domain_with_port(self):
+        assert is_valid_public_domain_url('https://example.com:8443/admin/') is True
+
+    def test_rejects_localhost(self):
+        assert is_valid_public_domain_url('http://localhost:8000/admin/') is False
+
+    def test_rejects_localhost_no_port(self):
+        assert is_valid_public_domain_url('http://localhost/something') is False
+
+    def test_rejects_localhost_subdomain(self):
+        assert is_valid_public_domain_url('https://my.localhost/thing') is False
+
+    def test_rejects_ipv4_loopback(self):
+        assert is_valid_public_domain_url('http://127.0.0.1:8000/admin/') is False
+
+    def test_rejects_ipv4_private(self):
+        assert is_valid_public_domain_url('http://192.168.1.1/admin/') is False
+
+    def test_rejects_ipv4_public(self):
+        assert is_valid_public_domain_url('http://8.8.8.8/admin/') is False
+
+    def test_rejects_ipv6_loopback(self):
+        assert is_valid_public_domain_url('http://[::1]/admin/') is False
+
+    def test_rejects_ipv6_public(self):
+        assert is_valid_public_domain_url('http://[2001:db8::1]/admin/') is False
+
+    def test_rejects_dot_local(self):
+        assert is_valid_public_domain_url('https://myhost.local/admin/') is False
+
+    def test_rejects_dot_internal(self):
+        assert is_valid_public_domain_url('https://myhost.internal/admin/') is False
+
+    def test_rejects_dot_test(self):
+        assert is_valid_public_domain_url('https://myhost.test/admin/') is False
+
+    def test_rejects_dot_invalid(self):
+        assert is_valid_public_domain_url('https://myhost.invalid/admin/') is False
+
+    def test_rejects_empty_string(self):
+        assert is_valid_public_domain_url('') is False
+
+    def test_rejects_no_hostname(self):
+        assert is_valid_public_domain_url('http:///path') is False
+
+
+class TestFindUrlsInContext:
+    def test_finds_url_in_flat_dict(self):
+        ctx = {'admin_url': 'https://admin.example.com', 'title': 'My Plan'}
+        result = find_urls_in_context(ctx)
+        assert result == [('admin_url', 'https://admin.example.com')]
+
+    def test_finds_urls_in_nested_dict(self):
+        ctx = {'site': {'view_url': 'https://example.com', 'title': 'Site'}}
+        result = find_urls_in_context(ctx)
+        assert result == [('site.view_url', 'https://example.com')]
+
+    def test_finds_urls_in_list_of_dicts(self):
+        ctx = {'items': [{'view_url': 'https://example.com/a/1'}, {'view_url': 'https://example.com/a/2'}]}
+        result = find_urls_in_context(ctx)
+        assert result == [
+            ('items[0].view_url', 'https://example.com/a/1'),
+            ('items[1].view_url', 'https://example.com/a/2'),
+        ]
+
+    def test_ignores_non_url_strings(self):
+        ctx = {'title': 'Hello world', 'count': 42, 'flag': True}
+        result = find_urls_in_context(ctx)
+        assert result == []
+
+    def test_returns_empty_for_empty_context(self):
+        assert find_urls_in_context({}) == []
+
+    def test_ignores_mailto(self):
+        ctx = {'email_link': 'mailto:test@example.com'}
+        result = find_urls_in_context(ctx)
+        assert result == []
+
+
+class TestValidateNotificationContextUrls:
+    def test_passes_for_valid_urls(self):
+        ctx = {
+            'admin_url': 'https://admin.example.com',
+            'site': {'view_url': 'https://example.com'},
+        }
+        validate_notification_context_urls(ctx)
+
+    def test_raises_for_localhost_url(self):
+        ctx = {'admin_url': 'http://localhost:8000'}
+        with pytest.raises(ValueError, match='localhost'):
+            validate_notification_context_urls(ctx)
+
+    def test_raises_for_ip_address(self):
+        ctx = {'admin_url': 'http://192.168.1.1/admin/'}
+        with pytest.raises(ValueError, match=r'192\.168\.1\.1'):
+            validate_notification_context_urls(ctx)
+
+    def test_lists_all_bad_urls(self):
+        ctx = {
+            'admin_url': 'http://localhost:8000',
+            'site': {'view_url': 'http://127.0.0.1/'},
+        }
+        with pytest.raises(ValueError, match=r'localhost.*127\.0\.0\.1|127\.0\.0\.1.*localhost'):
+            validate_notification_context_urls(ctx)
+
+    def test_allows_localhost_when_flag_set(self):
+        ctx = {'admin_url': 'http://localhost:8000'}
+        validate_notification_context_urls(ctx, allow_localhost=True)
+
+    def test_passes_for_empty_context(self):
+        validate_notification_context_urls({})

--- a/notifications/tests/test_url_validation.py
+++ b/notifications/tests/test_url_validation.py
@@ -58,6 +58,15 @@ class TestIsValidPublicDomainUrl:
     def test_rejects_empty_string(self):
         assert is_valid_public_domain_url('') is False
 
+    def test_rejects_no_scheme(self):
+        assert is_valid_public_domain_url('example.com') is False
+
+    def test_rejects_scheme_relative_url(self):
+        assert is_valid_public_domain_url('//example.com/admin/') is False
+
+    def test_rejects_unsupported_scheme(self):
+        assert is_valid_public_domain_url('ftp://example.com/admin/') is False
+
     def test_rejects_no_hostname(self):
         assert is_valid_public_domain_url('http:///path') is False
 
@@ -89,10 +98,15 @@ class TestFindUrlsInContext:
     def test_returns_empty_for_empty_context(self):
         assert find_urls_in_context({}) == []
 
-    def test_ignores_mailto(self):
+    def test_finds_mailto(self):
         ctx = {'email_link': 'mailto:test@example.com'}
         result = find_urls_in_context(ctx)
-        assert result == []
+        assert result == [('email_link', 'mailto:test@example.com')]
+
+    def test_finds_unsupported_scheme(self):
+        ctx = {'admin_url': 'ftp://example.com/admin/'}
+        result = find_urls_in_context(ctx)
+        assert result == [('admin_url', 'ftp://example.com/admin/')]
 
 
 class TestValidateNotificationContextUrls:
@@ -111,6 +125,16 @@ class TestValidateNotificationContextUrls:
     def test_raises_for_ip_address(self):
         ctx = {'admin_url': 'http://192.168.1.1/admin/'}
         with pytest.raises(ValueError, match=r'192\.168\.1\.1'):
+            validate_notification_context_urls(ctx)
+
+    def test_raises_for_unsupported_scheme(self):
+        ctx = {'admin_url': 'ftp://example.com/admin/'}
+        with pytest.raises(ValueError, match=r'ftp://example\.com'):
+            validate_notification_context_urls(ctx)
+
+    def test_raises_for_mailto(self):
+        ctx = {'email_link': 'mailto:test@example.com'}
+        with pytest.raises(ValueError, match=r'mailto:test@example\.com'):
             validate_notification_context_urls(ctx)
 
     def test_lists_all_bad_urls(self):

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse
+
+RESERVED_TLDS = ('.localhost', '.local', '.internal', '.test', '.invalid')
+
+
+def is_valid_public_domain_url(url: str) -> bool:
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    if hostname == 'localhost' or hostname.endswith('.localhost'):
+        return False
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        return False
+    if any(hostname.endswith(tld) for tld in RESERVED_TLDS):
+        return False
+    return True
+
+
+def _check_value(value: object, path: str, results: list[tuple[str, str]]) -> None:
+    if isinstance(value, str) and value.startswith(('http://', 'https://')):
+        results.append((path, value))
+    elif isinstance(value, (dict, list)):
+        results.extend(find_urls_in_context(value, path))
+
+
+def find_urls_in_context(context: dict | list, _prefix: str = '') -> list[tuple[str, str]]:
+    results: list[tuple[str, str]] = []
+    if isinstance(context, dict):
+        for key, value in context.items():
+            _check_value(value, f'{_prefix}.{key}' if _prefix else key, results)
+    elif isinstance(context, list):
+        for i, item in enumerate(context):
+            _check_value(item, f'{_prefix}[{i}]', results)
+    return results
+
+
+def validate_notification_context_urls(context: dict, *, allow_localhost: bool = False) -> None:
+    if allow_localhost:
+        return
+    urls = find_urls_in_context(context)
+    invalid = [(path, url) for path, url in urls if not is_valid_public_domain_url(url)]
+    if invalid:
+        details = ', '.join(f'{path}: {url}' for path, url in invalid)
+        raise ValueError(f'Notification context contains non-public URLs: {details}')

--- a/notifications/utils.py
+++ b/notifications/utils.py
@@ -4,10 +4,14 @@ import ipaddress
 from urllib.parse import urlparse
 
 RESERVED_TLDS = ('.localhost', '.local', '.internal', '.test', '.invalid')
+PUBLIC_URL_SCHEMES = ('http', 'https')
+NON_HIERARCHICAL_URL_SCHEMES = ('mailto',)
 
 
 def is_valid_public_domain_url(url: str) -> bool:
     parsed = urlparse(url)
+    if parsed.scheme not in PUBLIC_URL_SCHEMES:
+        return False
     hostname = parsed.hostname
     if not hostname:
         return False
@@ -24,8 +28,17 @@ def is_valid_public_domain_url(url: str) -> bool:
     return True
 
 
+def _looks_like_url(value: str) -> bool:
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        return False
+    if parsed.netloc:
+        return True
+    return parsed.scheme in NON_HIERARCHICAL_URL_SCHEMES
+
+
 def _check_value(value: object, path: str, results: list[tuple[str, str]]) -> None:
-    if isinstance(value, str) and value.startswith(('http://', 'https://')):
+    if isinstance(value, str) and _looks_like_url(value):
         results.append((path, value))
     elif isinstance(value, (dict, list)):
         results.extend(find_urls_in_context(value, path))

--- a/pages/models.py
+++ b/pages/models.py
@@ -257,14 +257,11 @@ class AplansPage(SearchableModel['PageQuerySet'], Page):
         if not plan:
             return super().get_url_parts(request)
 
-        url_path = self.url_path
-        if self.locale.language_code != plan.primary_language:
-            url_path = f'/{self.locale.language_code}{url_path}'
-
-        hostname = plan.default_hostname()
-        if not hostname:
+        try:
+            root_url = plan.get_view_url(active_locale=self.locale.language_code)
+        except ValueError:
             return None
-        return (plan.site_id, f'https://{hostname}', url_path)
+        return (plan.site_id, root_url, self.url_path)
 
     # Disable Wagtail's previews because our hacks make them break
     @property

--- a/pages/models.py
+++ b/pages/models.py
@@ -261,7 +261,10 @@ class AplansPage(SearchableModel['PageQuerySet'], Page):
         if self.locale.language_code != plan.primary_language:
             url_path = f'/{self.locale.language_code}{url_path}'
 
-        return (plan.site_id, f'https://{plan.default_hostname()}', url_path)
+        hostname = plan.default_hostname()
+        if not hostname:
+            return None
+        return (plan.site_id, f'https://{hostname}', url_path)
 
     # Disable Wagtail's previews because our hacks make them break
     @property

--- a/pages/models.py
+++ b/pages/models.py
@@ -261,7 +261,7 @@ class AplansPage(SearchableModel['PageQuerySet'], Page):
         if self.locale.language_code != plan.primary_language:
             url_path = f'/{self.locale.language_code}{url_path}'
 
-        return (plan.site_id, plan.site_url, url_path)
+        return (plan.site_id, f'https://{plan.default_hostname()}', url_path)
 
     # Disable Wagtail's previews because our hacks make them break
     @property

--- a/pages/tests/test_models.py
+++ b/pages/tests/test_models.py
@@ -1,8 +1,97 @@
+import datetime
+
+from django.utils.timezone import make_aware
+
 import pytest
 
+from actions.tests.factories import PlanDomainFactory, PlanFactory
 from pages.models import ActionListPage
+from pages.tests.factories import StaticPageFactory
 
 pytestmark = pytest.mark.django_db
+
+PUBLISHED_AT = make_aware(datetime.datetime(2021, 1, 1))  # noqa: DTZ001
+
+
+@pytest.fixture
+def published_url_plan(settings):
+    settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+    plan = PlanFactory.create(
+        identifier='myplan',
+        primary_language='en',
+        other_languages=['fi'],
+        published_at=PUBLISHED_AT,
+    )
+    plan.create_default_site()
+    plan.save()
+    return plan
+
+
+class TestGetUrlParts:
+    """AplansPage.get_url_parts must reuse Plan.get_view_url's canonical resolution."""
+
+    def test_published_plan_uses_plan_domain_with_base_path(self, published_url_plan):
+        from actions.models.plan import PlanDomain
+
+        PlanDomainFactory.create(
+            plan=published_url_plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        page = StaticPageFactory.create(parent=published_url_plan.root_page)
+        site_id, root_url, page_path = page.get_url_parts()
+        assert site_id == published_url_plan.site_id
+        assert root_url == 'https://city.gov/climate'
+        assert page_path == page.url_path
+
+    def test_published_plan_prefers_production_plan_domain_over_wildcard(self, published_url_plan):
+        from actions.models.plan import PlanDomain
+
+        PlanDomainFactory.create(
+            plan=published_url_plan,
+            hostname='climate.city.gov',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        page = StaticPageFactory.create(parent=published_url_plan.root_page)
+        _, root_url, _ = page.get_url_parts()
+        assert root_url == 'https://climate.city.gov'
+
+    def test_unpublished_plan_ignores_production_plan_domain(self, settings):
+        from actions.models.plan import PlanDomain
+
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(
+            identifier='myplan',
+            primary_language='en',
+            published_at=None,
+        )
+        plan.create_default_site()
+        plan.save()
+        PlanDomainFactory.create(
+            plan=plan,
+            hostname='city.gov',
+            base_path='/climate',
+            deployment_environment=PlanDomain.DeploymentEnvironment.PRODUCTION,
+        )
+        page = StaticPageFactory.create(parent=plan.root_page)
+        _, root_url, _ = page.get_url_parts()
+        assert root_url == 'https://myplan.example.com'
+
+    def test_falls_back_to_wildcard_hostname(self, published_url_plan):
+        page = StaticPageFactory.create(parent=published_url_plan.root_page)
+        _, root_url, _ = page.get_url_parts()
+        assert root_url == 'https://myplan.example.com'
+
+    def test_returns_none_when_hostname_unresolvable(self, settings):
+        settings.HOSTNAME_PLAN_DOMAINS = ['example.com']
+        plan = PlanFactory.create(identifier='myplan', primary_language='en', published_at=PUBLISHED_AT)
+        plan.create_default_site()
+        plan.save()
+        settings.HOSTNAME_PLAN_DOMAINS = []
+        settings.DEPLOYMENT_TYPE = 'production'
+        page = StaticPageFactory.create(parent=plan.root_page)
+        assert page.get_url_parts() is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Storing a fixed `site_url` in the database for a plan causes problems at least once for all plans, when that plan is published. Also when other changes happen in infra or URLs. The field was used sometimes as a fallback when generating public URLs for model objects or pages, but it isn't really necessary at all. It did often affect various links in the URL.

## Screenshots/Videos (if applicable)
N/A

## Related issue
N/A

## Requirements, dependencies and related PRs

HOSTNAME_PLAN_DOMAINS has to be set in any environment other than `development` (localhost). This in nowadays enforced in the infra-as-code code.

## Additional Notes

Wagtail also has a Site object and we need to put something there, but we are overriding Wagtail's multi-site setup with our own multitenant plan-based one in our middleware. Hence, the hostname in the Site object is not in fact used anywhere but still needs to be set once.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [-] **Manually tested locally** (functionality verified)

### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [-] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [X] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
