### PR TITLE
Add user_token field to PublicUser

### DIFF
--- a/actions/migrations/0177_add_publicuser_user_token.py
+++ b/actions/migrations/0177_add_publicuser_user_token.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("actions", "0176_rename_pledgecommitment_pledge_user_public_user"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="publicuser",
+            name="user_token",
+            field=models.CharField(
+                blank=True,
+                editable=False,
+                help_text="Opaque secret used as a bearer credential after the user signs up.",
+                max_length=64,
+                null=True,
+                unique=True,
+                verbose_name="user token",
+            ),
+        ),
+    ]

--- a/actions/models/pledge.py
+++ b/actions/models/pledge.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
+import secrets
 import uuid
 from typing import TYPE_CHECKING, ClassVar
 
 import reversion
+from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -338,15 +342,36 @@ class Pledge(
         return (main_panels, i18n_panels)
 
 
-@reversion.register()
+def _generate_user_token() -> str:
+    return secrets.token_urlsafe(48)
+
+
+def _get_user_token_pepper() -> bytes:
+    """
+    Derive a per-app HMAC key from SECRET_KEY.
+
+    Scoping with a label prevents the pepper from being equivalent to keys used
+    elsewhere with SECRET_KEY. Rotating SECRET_KEY rotates all user_token hashes,
+    invalidating outstanding bearer credentials, which is the intended behavior.
+    """
+    return hashlib.sha256(b'kausal-watch:public_user_token_pepper:' + settings.SECRET_KEY.encode()).digest()
+
+
+def hash_user_token(raw_token: str) -> str:
+    """Return the HMAC-SHA256 hex digest of a raw user token."""
+    return hmac.new(_get_user_token_pepper(), raw_token.encode(), hashlib.sha256).hexdigest()
+
+
+@reversion.register(exclude=['user_token'])
 class PublicUser(models.Model):
     """
-    An anonymous public-facing user.
+    A public-facing user identity.
 
     PublicUser represents community members who participate in public-facing
-    features such as pledges without requiring a full user account. The
-    user_data field stores freeform key-value pairs for information like
-    zip_code that can be used for analytics and aggregation purposes.
+    features such as pledges without requiring a full user account. Anonymous
+    users are identified by uuid; user_token is set only after the user
+    verifies an email (i.e., signs up), and is then used as a bearer
+    credential for authenticated requests.
     """
 
     uuid = models.UUIDField(default=uuid.uuid4, unique=True, editable=False)
@@ -355,6 +380,15 @@ class PublicUser(models.Model):
         blank=True,
         verbose_name=_('user data'),
         help_text=_('Freeform key-value data about the user (e.g., zip_code)'),
+    )
+    user_token = models.CharField(
+        max_length=64,
+        unique=True,
+        null=True,
+        blank=True,
+        editable=False,
+        verbose_name=_('user token'),
+        help_text=_('Opaque secret used as a bearer credential after the user signs up.'),
     )
     created_at = models.DateTimeField(
         auto_now_add=True,
@@ -371,6 +405,19 @@ class PublicUser(models.Model):
 
     def __str__(self) -> str:
         return str(self.uuid)
+
+    def regenerate_user_token(self) -> str:
+        """
+        Mint a new raw bearer token, store its HMAC hash on the row, and return the raw value.
+
+        The raw token is returned to the caller exactly once (typically to the
+        client via a mutation payload). The database only ever holds the hash,
+        so a DB leak does not expose live credentials.
+        """
+        raw_token = _generate_user_token()
+        self.user_token = hash_user_token(raw_token)
+        self.save(update_fields=['user_token'])
+        return raw_token
 
 
 @reversion.register()

--- a/actions/models/pledge.py
+++ b/actions/models/pledge.py
@@ -411,8 +411,7 @@ class PublicUser(models.Model):
         Mint a new raw bearer token, store its HMAC hash on the row, and return the raw value.
 
         The raw token is returned to the caller exactly once (typically to the
-        client via a mutation payload). The database only ever holds the hash,
-        so a DB leak does not expose live credentials.
+        client via a mutation payload). The database only ever holds the hash.
         """
         raw_token = _generate_user_token()
         self.user_token = hash_user_token(raw_token)

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -112,6 +112,7 @@ from .models import (
     PledgeCommitment,
     PublicUser,
 )
+from .models.pledge import hash_user_token
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
@@ -2156,7 +2157,19 @@ class Query:
 
     @staticmethod
     def resolve_public_user(_root: Query, info: GQLInfo, uuid: uuid.UUID) -> PublicUser | None:
-        return PublicUser.objects.filter(uuid=uuid).first()
+        """
+        Look up a PublicUser.
+
+        Anonymous users (no user_token) are identified by the UUID argument.
+        Once a user has signed up, the bearer token is the identifier instead.
+        """
+        matched = PublicUser.objects.filter(uuid=uuid).first()
+        if matched is None or matched.user_token is None:
+            return matched
+        bearer_user = _resolve_public_user_from_bearer(info)
+        if bearer_user is None or bearer_user.pk != matched.pk:
+            return None
+        return matched
 
     @staticmethod
     def resolve_workflow_states(_root: Query, info: GQLInfo, plan: str | None = None):
@@ -2419,6 +2432,47 @@ class Query:
         )
 
 
+def _resolve_public_user_from_bearer(info: GQLInfo) -> PublicUser | None:
+    """
+    Look up the PublicUser identified by an `Authorization: Bearer <token>` header.
+
+    The DB stores HMAC hashes of user tokens, so the incoming bearer value is
+    hashed before lookup. Returns None when no Bearer header is present or the
+    token doesn't match any row.
+    """
+    headers = info.context.get_request_headers()
+    auth_header = headers.get('authorization') or headers.get('Authorization')
+    if not auth_header:
+        return None
+    prefix, _, token = auth_header.partition(' ')
+    if prefix.lower() != 'bearer' or not token:
+        return None
+    return PublicUser.objects.filter(user_token=hash_user_token(token)).first()
+
+
+def _resolve_public_user(info: GQLInfo, user_uuid: uuid.UUID | None) -> PublicUser:
+    """
+    Resolve the PublicUser for an authenticated request.
+
+    Prefers the bearer token; falls back to the legacy `userUuid` argument when
+    no bearer is present. Once a user has signed up (has a user_token), the
+    UUID-arg fallback is rejected so the bearer credential can't be bypassed
+    by anyone who knows the UUID.
+    """
+    public_user = _resolve_public_user_from_bearer(info)
+    if public_user is not None:
+        return public_user
+    if user_uuid is None:
+        raise GraphQLError('Authentication required: provide an Authorization: Bearer token or userUuid')
+    try:
+        public_user = PublicUser.objects.get(uuid=user_uuid)
+    except PublicUser.DoesNotExist:
+        raise GraphQLError('PublicUser not found') from None
+    if public_user.user_token is not None:
+        raise GraphQLError('Authentication required: this account requires an Authorization: Bearer header')
+    return public_user
+
+
 class RegisterPublicUserPayload(graphene.ObjectType[Any]):
     """Payload returned after registering a public user."""
 
@@ -2446,18 +2500,25 @@ class CommitToPledgeMutation(graphene.Mutation):
     """Create or remove a commitment to a pledge."""
 
     class Arguments:
-        user_uuid = graphene.UUID(required=True, description='UUID of the PublicUser')
         pledge_id = graphene.ID(required=True, description='ID of the Pledge')
         committed = graphene.Boolean(required=True, description='True to commit, False to uncommit')
+        user_uuid = graphene.UUID(
+            required=False,
+            description='UUID of the PublicUser (legacy; prefer Authorization: Bearer header)',
+        )
 
     Output = CommitToPledgePayload
 
     @classmethod
-    def mutate(cls, _root, _info: GQLInfo, user_uuid: uuid.UUID, pledge_id: str, committed: bool) -> CommitToPledgePayload:
-        try:
-            public_user = PublicUser.objects.get(uuid=user_uuid)
-        except PublicUser.DoesNotExist:
-            raise GraphQLError('PublicUser not found') from None
+    def mutate(
+        cls,
+        _root,
+        info: GQLInfo,
+        pledge_id: str,
+        committed: bool,
+        user_uuid: uuid.UUID | None = None,
+    ) -> CommitToPledgePayload:
+        public_user = _resolve_public_user(info, user_uuid)
 
         try:
             pledge = Pledge.objects.select_related('plan__features').get(id=pledge_id)
@@ -2494,18 +2555,25 @@ class SetUserDataMutation(graphene.Mutation):
     """Set a key-value pair in a PublicUser's user_data."""
 
     class Arguments:
-        user_uuid = graphene.UUID(required=True, description='UUID of the PublicUser')
         key = graphene.String(required=True, description='Key to set in user_data')
         value = graphene.String(required=True, description='Value to set for the key')
+        user_uuid = graphene.UUID(
+            required=False,
+            description='UUID of the PublicUser (legacy; prefer Authorization: Bearer header)',
+        )
 
     Output = SetUserDataPayload
 
     @classmethod
-    def mutate(cls, _root, _info: GQLInfo, user_uuid: uuid.UUID, key: str, value: str) -> SetUserDataPayload:
-        try:
-            public_user = PublicUser.objects.get(uuid=user_uuid)
-        except PublicUser.DoesNotExist:
-            raise GraphQLError('PublicUser not found') from None
+    def mutate(
+        cls,
+        _root,
+        info: GQLInfo,
+        key: str,
+        value: str,
+        user_uuid: uuid.UUID | None = None,
+    ) -> SetUserDataPayload:
+        public_user = _resolve_public_user(info, user_uuid)
 
         public_user.user_data[key] = value
         public_user.save(update_fields=['user_data'])

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -2504,7 +2504,7 @@ class CommitToPledgeMutation(graphene.Mutation):
         committed = graphene.Boolean(required=True, description='True to commit, False to uncommit')
         user_uuid = graphene.UUID(
             required=False,
-            description='UUID of the PublicUser (legacy; prefer Authorization: Bearer header)',
+            description='UUID used to identify an anonymous PublicUser.',
         )
 
     Output = CommitToPledgePayload
@@ -2559,7 +2559,7 @@ class SetUserDataMutation(graphene.Mutation):
         value = graphene.String(required=True, description='Value to set for the key')
         user_uuid = graphene.UUID(
             required=False,
-            description='UUID of the PublicUser (legacy; prefer Authorization: Bearer header)',
+            description='UUID used to identify an anonymous PublicUser.',
         )
 
     Output = SetUserDataPayload

--- a/actions/tests/test_graphql_pledge.py
+++ b/actions/tests/test_graphql_pledge.py
@@ -1375,7 +1375,7 @@ class TestPublicUserQuery:
         data = response.get('data') or {}
         returned = data.get('publicUser') or {}
         returned_token = returned.get('userToken')
-        assert returned_token is None or returned_token != public_user.user_token
+        assert returned_token is None
 
     def test_public_user_query_returns_null_for_signed_up_user_without_bearer(self, graphql_client_query_data):
         """Once a user has signed up, the UUID query must require a matching bearer header."""

--- a/actions/tests/test_graphql_pledge.py
+++ b/actions/tests/test_graphql_pledge.py
@@ -887,6 +887,98 @@ class TestCommitToPledgeMutation:
         assert 'Community engagement is not enabled for this plan' in response['errors'][0]['message']
         assert PledgeCommitment.objects.count() == 0
 
+    def test_commit_with_bearer_token_authenticates(self, graphql_client_query_data):
+        """The commitToPledge mutation should authenticate via Authorization: Bearer header alone."""
+        token = self.public_user.regenerate_user_token()
+
+        data = graphql_client_query_data(
+            """
+            mutation($pledgeId: ID!, $committed: Boolean!) {
+              pledge {
+                commitToPledge(pledgeId: $pledgeId, committed: $committed) {
+                  committed
+                }
+              }
+            }
+            """,
+            variables={'pledgeId': str(self.pledge.id), 'committed': True},
+            headers={'Authorization': f'Bearer {token}'},
+        )
+
+        assert data['pledge']['commitToPledge']['committed'] is True
+        commitment = PledgeCommitment.objects.get()
+        assert commitment.public_user == self.public_user
+
+    def test_commit_bearer_token_takes_precedence_over_user_uuid(self, graphql_client_query_data):
+        """If both bearer and userUuid are given, the bearer-identified user wins."""
+        token = self.public_user.regenerate_user_token()
+        other_user = PublicUser.objects.create()
+
+        graphql_client_query_data(
+            """
+            mutation($userUuid: UUID!, $pledgeId: ID!, $committed: Boolean!) {
+              pledge {
+                commitToPledge(userUuid: $userUuid, pledgeId: $pledgeId, committed: $committed) {
+                  committed
+                }
+              }
+            }
+            """,
+            variables={
+                'userUuid': str(other_user.uuid),
+                'pledgeId': str(self.pledge.id),
+                'committed': True,
+            },
+            headers={'Authorization': f'Bearer {token}'},
+        )
+
+        assert PledgeCommitment.objects.filter(public_user=self.public_user).exists()
+        assert not PledgeCommitment.objects.filter(public_user=other_user).exists()
+
+    def test_commit_with_uuid_rejected_when_user_has_signed_up(self, graphql_client_query):
+        """Once a PublicUser has a user_token, the UUID arg must no longer authenticate."""
+        self.public_user.regenerate_user_token()
+
+        response = graphql_client_query(
+            """
+            mutation($userUuid: UUID!, $pledgeId: ID!, $committed: Boolean!) {
+              pledge {
+                commitToPledge(userUuid: $userUuid, pledgeId: $pledgeId, committed: $committed) {
+                  committed
+                }
+              }
+            }
+            """,
+            variables={
+                'userUuid': str(self.public_user.uuid),
+                'pledgeId': str(self.pledge.id),
+                'committed': True,
+            },
+        )
+
+        assert 'errors' in response
+        assert 'Authorization: Bearer' in response['errors'][0]['message']
+        assert PledgeCommitment.objects.count() == 0
+
+    def test_commit_without_credentials_returns_error(self, graphql_client_query):
+        """Omitting both bearer and userUuid must fail with an auth error."""
+        response = graphql_client_query(
+            """
+            mutation($pledgeId: ID!, $committed: Boolean!) {
+              pledge {
+                commitToPledge(pledgeId: $pledgeId, committed: $committed) {
+                  committed
+                }
+              }
+            }
+            """,
+            variables={'pledgeId': str(self.pledge.id), 'committed': True},
+        )
+
+        assert 'errors' in response
+        assert 'Authentication required' in response['errors'][0]['message']
+        assert PledgeCommitment.objects.count() == 0
+
 
 class TestSetUserDataMutation:
     """Tests for the setUserData GraphQL mutation."""
@@ -990,6 +1082,28 @@ class TestSetUserDataMutation:
 
         assert 'errors' in response
         assert 'PublicUser not found' in response['errors'][0]['message']
+
+    def test_set_user_data_with_bearer_token_authenticates(self, graphql_client_query_data):
+        """The setUserData mutation should authenticate via Authorization: Bearer header alone."""
+        public_user = PublicUser.objects.create()
+        token = public_user.regenerate_user_token()
+
+        graphql_client_query_data(
+            """
+            mutation($key: String!, $value: String!) {
+              pledge {
+                setUserData(key: $key, value: $value) {
+                  uuid
+                }
+              }
+            }
+            """,
+            variables={'key': 'zip_code', 'value': '01234'},
+            headers={'Authorization': f'Bearer {token}'},
+        )
+
+        public_user.refresh_from_db()
+        assert public_user.user_data['zip_code'] == '01234'
 
 
 class TestPledgeBodyField:
@@ -1240,6 +1354,70 @@ class TestPublicUserQuery:
 
         assert data['publicUser'] is not None
         assert json.loads(data['publicUser']['userData']) == {}
+
+    def test_public_user_query_does_not_expose_user_token(self, graphql_client_query):
+        """The user_token must never be queryable via the publicUser node."""
+        public_user = PublicUser.objects.create()
+        public_user.regenerate_user_token()
+        query = """
+            query($uuid: UUID!) {
+                publicUser(uuid: $uuid) {
+                    uuid
+                    userToken
+                }
+            }
+        """
+
+        response = graphql_client_query(query, variables={'uuid': str(public_user.uuid)})
+
+        assert 'errors' in response
+        assert any('userToken' in error['message'] for error in response['errors'])
+        data = response.get('data') or {}
+        returned = data.get('publicUser') or {}
+        returned_token = returned.get('userToken')
+        assert returned_token is None or returned_token != public_user.user_token
+
+    def test_public_user_query_returns_null_for_signed_up_user_without_bearer(self, graphql_client_query_data):
+        """Once a user has signed up, the UUID query must require a matching bearer header."""
+        public_user = PublicUser.objects.create()
+        public_user.regenerate_user_token()
+
+        data = graphql_client_query_data(
+            self.PLEDGE_USER_QUERY,
+            variables={'uuid': str(public_user.uuid)},
+        )
+
+        assert data['publicUser'] is None
+
+    def test_public_user_query_returns_null_when_bearer_belongs_to_other_user(self, graphql_client_query_data):
+        """A signed-up user's data is hidden when the bearer header is for someone else."""
+        public_user = PublicUser.objects.create()
+        public_user.regenerate_user_token()
+
+        other_user = PublicUser.objects.create()
+        other_token = other_user.regenerate_user_token()
+
+        data = graphql_client_query_data(
+            self.PLEDGE_USER_QUERY,
+            variables={'uuid': str(public_user.uuid)},
+            headers={'Authorization': f'Bearer {other_token}'},
+        )
+
+        assert data['publicUser'] is None
+
+    def test_public_user_query_returns_signed_up_user_when_bearer_resolves_to_them(self, graphql_client_query_data):
+        """A signed-up user can read their own data by presenting their own bearer token."""
+        public_user = PublicUser.objects.create()
+        token = public_user.regenerate_user_token()
+
+        data = graphql_client_query_data(
+            self.PLEDGE_USER_QUERY,
+            variables={'uuid': str(public_user.uuid)},
+            headers={'Authorization': f'Bearer {token}'},
+        )
+
+        assert data['publicUser'] is not None
+        assert data['publicUser']['uuid'] == str(public_user.uuid)
 
 
 class TestPledgeCommitmentCountAnnotation:

--- a/actions/tests/test_pledge.py
+++ b/actions/tests/test_pledge.py
@@ -373,6 +373,45 @@ class TestPublicUser:
 
         assert str(public_user) == str(public_user.uuid)
 
+    def test_public_user_token_defaults_to_none(self):
+        """A freshly created PublicUser has no token until they sign up."""
+        public_user = PublicUser.objects.create()
+
+        assert public_user.user_token is None
+
+    def test_regenerate_user_token_returns_raw_and_stores_hash(self):
+        """regenerate_user_token() returns the raw token and stores only the hash."""
+        from actions.models.pledge import hash_user_token
+
+        user1 = PublicUser.objects.create()
+        user2 = PublicUser.objects.create()
+
+        token1 = user1.regenerate_user_token()
+        token2 = user2.regenerate_user_token()
+
+        assert token1
+        assert token2
+        assert token1 != token2
+
+        user1.refresh_from_db()
+        assert user1.user_token != token1
+        assert user1.user_token == hash_user_token(token1)
+
+    def test_regenerate_user_token_rotates_existing_token(self):
+        """Calling regenerate_user_token() again replaces the previous hash."""
+        from actions.models.pledge import hash_user_token
+
+        public_user = PublicUser.objects.create()
+        first_token = public_user.regenerate_user_token()
+        first_hash = public_user.user_token
+
+        second_token = public_user.regenerate_user_token()
+
+        assert second_token != first_token
+        public_user.refresh_from_db()
+        assert public_user.user_token != first_hash
+        assert public_user.user_token == hash_user_token(second_token)
+
 
 class TestPledgeCommitment:
     """Tests for the PledgeCommitment model."""

--- a/aplans/schema_context.py
+++ b/aplans/schema_context.py
@@ -323,6 +323,16 @@ class WatchExecutionCacheExtension(ExecutionCacheExtension[WatchGraphQLContext])
             self.set_reason('no plan')
             return None
 
+        headers = exec_ctx.get_request_headers()
+        auth = headers.get('authorization') or headers.get('Authorization', '')
+        if auth.lower().startswith('bearer '):
+            self.set_reason('public-user bearer auth present')
+            return None
+
+        if 'publicUser' in (self.execution_context.query or ''):
+            self.set_reason('publicUser query is identity-sensitive and not cached')
+            return None
+
         parts = [str(plan.identifier), plan.cache_invalidated_at.isoformat()]
         return parts
 


### PR DESCRIPTION
## Description
Adds a nullable, unique user_token field on PublicUser and a generate_user_token() helper. The field stays NULL for anonymous users; future VerifyPin/SignIn flows will call generate_user_token() on first successful email verification to issue the bearer credential.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1215599133155551/task/1215599132655936

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [ ] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
