### PR TITLE
Make PlanFeatureGatedStreamBlockMixin more robust

### DIFF
--- a/indicators/blocks/layout.py
+++ b/indicators/blocks/layout.py
@@ -8,6 +8,7 @@ from django.db.models.enums import TextChoices
 from django.utils.translation import gettext_lazy as _
 from wagtail import blocks
 from wagtail.admin.telepath import register as telepath_register
+from wagtail.blocks.stream_block import StreamBlockAdapter
 from wagtail.blocks.struct_block import BlockGroup, StructBlockAdapter, StructBlockValidationError  # type: ignore[attr-defined]
 
 from grapple.helpers import register_streamfield_block
@@ -59,30 +60,53 @@ def _get_plan_features() -> PlanFeatures | None:
 
 class PlanFeatureGatedStreamBlockMixin(_StreamBlockBase):
     """
-    Hides child blocks from the admin "add block" menu based on PlanFeatures flags.
+    Marks child blocks as feature-gated based on PlanFeatures flags.
 
     Subclasses define ``feature_gated_blocks`` as a mapping of block names
-    to the PlanFeatures boolean field that must be ``True`` for the block to appear.
-    When the feature is off (or no admin context exists), the block is hidden.
+    to the PlanFeatures boolean field that must be ``True`` for the block to
+    be addable.
+
+    The gating is applied by ``FeatureGatedStreamBlockAdapter`` at telepath
+    serialization time: ALL block definitions are still sent to the client (so
+    already-saved gated data continues to render), but disabled blocks get a
+    ``blockCounts`` entry with ``max_num: 0`` so no new instances can be added.
+    Removing the definitions entirely would crash the editor JS and corrupt
+    StreamField indice.
     """
 
     feature_gated_blocks: ClassVar[dict[str, str]]
-
-    def sorted_child_blocks(self) -> list[blocks.Block]:
-        sorted_blocks = super().sorted_child_blocks()
-        features = _get_plan_features()
-        if features is None:
-            return sorted_blocks
-        hidden = {name for name, flag in self.feature_gated_blocks.items() if not getattr(features, flag, True)}
-        if not hidden:
-            return sorted_blocks
-        return [b for b in sorted_blocks if b.name not in hidden]
 
 
 class _IndicatorDetailsContentStreamFeatureGateMixin(PlanFeatureGatedStreamBlockMixin):
     feature_gated_blocks = {
         'factor_value_summary': 'enable_indicator_factors',
     }
+
+
+class FeatureGatedStreamBlockAdapter(StreamBlockAdapter):
+    """
+    Telepath adapter that disables (but does not remove) feature-gated child blocks.
+
+    See ``PlanFeatureGatedStreamBlockMixin`` for the rationale.
+    """
+
+    def js_args(self, block) -> list:
+        result = super().js_args(block)
+        if not hasattr(block, 'feature_gated_blocks'):
+            return result
+        features = _get_plan_features()
+        if features is None:
+            return result
+        hidden = {name for name, flag in block.feature_gated_blocks.items() if not getattr(features, flag, True)}
+        if not hidden:
+            return result
+        meta = result[3]
+        block_counts = dict(meta.get('blockCounts') or {})
+        for name in hidden:
+            if name in block.child_blocks:
+                block_counts[name] = {'max_num': 0}
+        meta['blockCounts'] = block_counts
+        return result
 
 
 class IndicatorListColumnInterface(DashboardColumnInterface):
@@ -465,3 +489,7 @@ IndicatorMainContentStream = generate_stream_block(
     field_registry=indicator_registry,
     mixins=(_IndicatorDetailsContentStreamFeatureGateMixin,),
 )
+
+_feature_gated_adapter = FeatureGatedStreamBlockAdapter()
+telepath_register(_feature_gated_adapter, IndicatorAsideContentStream)
+telepath_register(_feature_gated_adapter, IndicatorMainContentStream)

--- a/indicators/tests/test_feature_gated_stream_block.py
+++ b/indicators/tests/test_feature_gated_stream_block.py
@@ -1,0 +1,82 @@
+from wagtail.admin.telepath import JSContext
+
+import pytest
+
+from aplans.cache import PlanSpecificCache
+from aplans.context_vars import ctx_request
+
+from actions.tests.factories import PlanFactory
+from indicators.blocks.layout import (
+    FeatureGatedStreamBlockAdapter,
+    IndicatorAsideContentStream,
+    IndicatorMainContentStream,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _grouped_block_names(js_args) -> set[str]:
+    names: set[str] = set()
+    for _group, child_blocks in js_args[1]:
+        names.update(b.name for b in child_blocks)
+    return names
+
+
+def _block_counts(js_args) -> dict:
+    return js_args[3].get('blockCounts') or {}
+
+
+def _activate_request(rf, plan):
+    request = rf.get('/')
+    request.admin_cache = PlanSpecificCache(plan=plan)
+    return request
+
+
+class TestFeatureGatedStreamBlockAdapter:
+    adapter = FeatureGatedStreamBlockAdapter()
+
+    def test_all_block_defs_present_when_feature_disabled(self, rf):
+        plan = PlanFactory.create(features__enable_indicator_factors=False)
+        block = IndicatorMainContentStream()
+        with ctx_request.activate(_activate_request(rf, plan)):
+            args = self.adapter.js_args(block)
+        assert 'factor_value_summary' in _grouped_block_names(args)
+
+    def test_block_counts_max_zero_when_feature_disabled(self, rf):
+        plan = PlanFactory.create(features__enable_indicator_factors=False)
+        block = IndicatorMainContentStream()
+        with ctx_request.activate(_activate_request(rf, plan)):
+            args = self.adapter.js_args(block)
+        assert _block_counts(args).get('factor_value_summary') == {'max_num': 0}
+
+    def test_no_restriction_when_feature_enabled(self, rf):
+        plan = PlanFactory.create(features__enable_indicator_factors=True)
+        block = IndicatorMainContentStream()
+        with ctx_request.activate(_activate_request(rf, plan)):
+            args = self.adapter.js_args(block)
+        assert 'factor_value_summary' not in _block_counts(args)
+
+    def test_no_restriction_without_admin_context(self):
+        block = IndicatorMainContentStream()
+        args = self.adapter.js_args(block)
+        assert 'factor_value_summary' not in _block_counts(args)
+
+    def test_aside_stream_ignores_missing_gated_block(self, rf):
+        plan = PlanFactory.create(features__enable_indicator_factors=False)
+        block = IndicatorAsideContentStream()
+        with ctx_request.activate(_activate_request(rf, plan)):
+            args = self.adapter.js_args(block)
+        assert 'factor_value_summary' not in _block_counts(args)
+
+    def test_sorted_child_blocks_returns_all_blocks(self, rf):
+        plan = PlanFactory.create(features__enable_indicator_factors=False)
+        block = IndicatorMainContentStream()
+        with ctx_request.activate(_activate_request(rf, plan)):
+            names = {b.name for b in block.sorted_child_blocks()}
+        assert 'factor_value_summary' in names
+
+    def test_telepath_pack_does_not_crash_when_feature_disabled(self, rf):
+        plan = PlanFactory.create(features__enable_indicator_factors=False)
+        block = IndicatorMainContentStream()
+        with ctx_request.activate(_activate_request(rf, plan)):
+            JSContext().pack(block)


### PR DESCRIPTION
PlanFeatureGatedStreamBlockMixin hid feature-gated blocks (e.g. factor_value_summary when enable_indicator_factors is off) by filtering them out of sorted_child_blocks().

Wagtail's telepath layer builds both the "add block" menu and the childBlockDefsByName render registry from that same list, so filtering it removed the block definition the client needs to render already-saved data. When a page held a gated block, the editor JS crashed dereferencing the missing definition, and because the crashed block consumed a counter index without emitting form fields, a subsequent add-and-save hit a MultiValueDictKeyError on the gap index.

This change removes the sorted_child_blocks() override and adds a FeatureGatedStreamBlockAdapter that sends all block definitions and instead sets max_num: 0 on gated blocks via Wagtail's blockCounts mechanism, which prevents adding new instances while leaving existing ones intact. A known limitation: gated blocks still appear in the add menu and produce a "maximum number of items is 0" error when selected.


## Screenshots/Videos (if applicable)
<img width="1350" height="368" alt="image" src="https://github.com/user-attachments/assets/1f401823-5d08-4627-8df7-95d12ae47cc9" />


## Related issue
https://sentry.kausal.tech/organizations/kausal/issues/16819/
https://sentry.kausal.tech/organizations/kausal/issues/16818/

## Requirements, dependencies and related PRs
N/A

## Additional Notes
It's not maybe optimal, we could add some Javascript to hide blocks with max_num 0 but at least this fixes the bugs. We can do that later.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [X] Set the PR's label to match the nature of this change

### Testing
- [X] **Built Unit tests** (unit tests added/updated)
- [-] **Built E2E tests** (if applicable. E2E tests added/updated)
- [-] **Authorization is tested** (permissions and access controls verified)
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Try adding the block to the indicator page, the turning the feature off, going back, removing the block, adding it again won't work.
### Internationalization & Accessibility
- [-] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [-] **Moderation** integration implemented
- [-] **Reporting** integration implemented
- [-] **Copy plan feature** integration implemented
- [-] **Umbrella plan structure** integration implemented

### Dependencies
- [-] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
