### PR TITLE
Add pledge participants admin views

### DIFF
--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -398,6 +398,7 @@ class PledgeViewSet(WatchViewSet[Pledge]):
     # register_pledges_submenu hook in actions/wagtail_hooks.py, so we don't
     # let the SnippetViewSet auto-add a top-level menu item.
     add_to_admin_menu = False
+    menu_item_is_registered = True
     list_display = [
         'name',
         Column('commitment_count', label=_('Commitments'), sort_key='commitment_count'),

--- a/actions/pledge_admin.py
+++ b/actions/pledge_admin.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING
 
 from django.core.exceptions import ValidationError
 from django.db.models import Count, IntegerField, OuterRef, Subquery
+from django.db.models.functions import Coalesce
 from django.http import FileResponse, StreamingHttpResponse
 from django.utils.translation import gettext_lazy as _
-from django.db.models.functions import Coalesce
 from wagtail.admin.panels import (
     FieldPanel,
     MultiFieldPanel,
     ObjectList,
+    TabbedInterface,
 )
 from wagtail.admin.ui.components import Component
 from wagtail.admin.ui.menus import MenuItem
@@ -32,6 +33,7 @@ from kausal_common.users import user_or_bust
 from admin_site.forms import WatchAdminModelForm
 from admin_site.permissions import PlanRelatedPermissionPolicy
 from admin_site.viewsets import WatchCreateView, WatchEditView, WatchIndexView, WatchViewSet
+
 from .models import Pledge
 from .models.pledge import PledgeCommitment
 
@@ -179,7 +181,12 @@ class PledgeViewMixin:
         # Add remaining panels
         panels.extend(PledgeViewSet.panels[pos:])
 
-        return ObjectList(panels).bind_to_model(self.model)
+        from actions.pledge_participants_admin import PledgeParticipantsPanel
+
+        return TabbedInterface([
+            ObjectList(panels, heading=_('Pledge')),
+            PledgeParticipantsPanel(heading=_('Participants')),
+        ]).bind_to_model(self.model)
 
 
 class PledgeCreateView(PledgeViewMixin, WatchCreateView[Pledge]):
@@ -387,7 +394,10 @@ class PledgeViewSet(WatchViewSet[Pledge]):
     icon = 'kausal-pledge'
     menu_icon = 'kausal-pledge'
     menu_order = 41  # After Indicators (40)
-    add_to_admin_menu = True
+    # Pledges menu is registered as a submenu (Pledges + Participants) via the
+    # register_pledges_submenu hook in actions/wagtail_hooks.py, so we don't
+    # let the SnippetViewSet auto-add a top-level menu item.
+    add_to_admin_menu = False
     list_display = [
         'name',
         Column('commitment_count', label=_('Commitments'), sort_key='commitment_count'),

--- a/actions/pledge_participants_admin.py
+++ b/actions/pledge_participants_admin.py
@@ -14,6 +14,7 @@ emails of participants who have opted in to marketing.
 from __future__ import annotations
 
 import csv
+from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 
 from django.core.exceptions import PermissionDenied
@@ -115,6 +116,11 @@ class ParticipantsIndexView(WatchIndexView[PublicUser]):
     page_title = _('Pledge participants')
     show_export_buttons = False  # we provide a tailored CSV button below
     list_export: list[str] = []  # Wagtail's auto-export off; CSV is via the custom button
+
+    @cached_property
+    def columns(self):  # type: ignore[override]
+        # Bulk actions aren't available for now
+        return [column for column in super().columns if column.name != 'bulk_actions']
 
     def get_queryset(self) -> QuerySet[PublicUser]:
         user = user_or_bust(self.request.user)

--- a/actions/pledge_participants_admin.py
+++ b/actions/pledge_participants_admin.py
@@ -1,0 +1,310 @@
+"""
+Admin UIs surfacing PublicUsers who have committed to pledges.
+
+Two surfaces:
+- Global list (ParticipantsViewSet): every signed-up PublicUser with at
+  least one commitment in the active admin plan's pledges.
+- Per-pledge tab (PledgeParticipantsPanel): the same list scoped to a
+  single Pledge, rendered as a tab on the pledge edit view.
+
+Both expose a CSV export and a copy-to-clipboard button that only emit
+emails of participants who have opted in to marketing.
+"""
+
+from __future__ import annotations
+
+import csv
+from typing import TYPE_CHECKING, Any, cast
+
+from django.core.exceptions import PermissionDenied
+from django.db.models import Count, Q
+from django.http import HttpResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import View
+from wagtail.admin.panels import Panel
+from wagtail.admin.ui.tables import BooleanColumn, Column
+from wagtail.admin.views.mixins import Echo
+from wagtail.snippets.models import register_snippet
+
+from kausal_common.users import user_or_bust
+
+from admin_site.permissions import PlanRelatedPermissionPolicy
+from admin_site.viewsets import WatchIndexView, WatchViewSet
+from users.models import User
+
+from .models import Pledge
+from .models.pledge import PublicUser
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+    from django.db.models import QuerySet
+    from django.http import HttpRequest
+
+    from actions.models.plan import Plan
+
+
+def _get_participants_queryset(plan: Plan, pledge: Pledge | None = None) -> QuerySet[PublicUser]:
+    """
+    Return signed-up PublicUsers with >=1 commitment in the plan.
+
+    Annotated with `commitment_count` (commitments in this plan; or to the
+    specific pledge when `pledge` is given) and `has_marketing_consent`
+    (bool, surfaced as a tick column).
+    """
+    commitment_filter = Q(commitments__pledge__plan=plan)
+    if pledge is not None:
+        # AND with the plan predicate (don't replace it) so mismatched
+        # (plan, pledge) pairs return empty instead of leaking another
+        # plan's participants. Commitments are stored against the primary
+        # translation; resolve to that so the count is consistent
+        # regardless of which translation the caller passed in.
+        commitment_filter &= Q(commitments__pledge=pledge.get_primary_translation())
+    return (
+        PublicUser.objects
+        .exclude(email__isnull=True)
+        .exclude(email='')
+        .filter(commitment_filter)
+        .annotate(
+            commitment_count=Count(
+                'commitments',
+                filter=commitment_filter,
+                distinct=True,
+            ),
+        )
+        .filter(commitment_count__gt=0)
+        .distinct()
+    )
+
+
+def _opted_in_emails(plan: Plan, pledge: Pledge | None = None) -> list[str]:
+    """Return emails of participants who have opted in to marketing, sorted."""
+    qs = _get_participants_queryset(plan, pledge).filter(marketing_consented_at__isnull=False).exclude(email__isnull=True)
+    return sorted(email for email in qs.values_list('email', flat=True) if email)
+
+
+class ParticipantsPermissionPolicy(PlanRelatedPermissionPolicy):
+    """
+    Read-only for plan admins on plans that have community engagement enabled.
+
+    Mirrors PledgePermissionPolicy's gating; the Participants UI is only
+    meaningful when the underlying Pledge feature is enabled.
+    """
+
+    def user_has_permission(self, user: AbstractBaseUser | AnonymousUser, action: str) -> bool:
+        if not super().user_has_permission(user, action):
+            return False
+        if not isinstance(user, User):
+            return False
+        plan = user.get_active_admin_plan(required=False)
+        if plan is None:
+            return False
+        if not user.is_general_admin_for_plan(plan):
+            return False
+        if not plan.features.enable_community_engagement:
+            return False
+        return action == 'view'
+
+    def user_has_any_permission(self, user, actions):
+        return any(self.user_has_permission(user, a) for a in actions)
+
+
+class ParticipantsIndexView(WatchIndexView[PublicUser]):
+    """List of signed-up PublicUsers committed to pledges in the active plan."""
+
+    page_title = _('Pledge participants')
+    show_export_buttons = False  # we provide a tailored CSV button below
+    list_export: list[str] = []  # Wagtail's auto-export off; CSV is via the custom button
+
+    def get_queryset(self) -> QuerySet[PublicUser]:
+        user = user_or_bust(self.request.user)
+        plan = user.get_active_admin_plan()
+        qs = _get_participants_queryset(plan)
+        # Honor sort param ('email', '-email', 'commitment_count', etc).
+        ordering = self.request.GET.get('ordering')
+        sortable = {'email', 'commitment_count', 'marketing_consented_at'}
+        if ordering and ordering.lstrip('-') in sortable:
+            return qs.order_by(ordering)
+        return qs.order_by('email')
+
+    def get_header_more_buttons(self):
+        from wagtail.admin.widgets.button import Button
+
+        buttons = list(super().get_header_more_buttons())
+        export_url = reverse('pledge_participants_export_csv')
+        user = user_or_bust(self.request.user)
+        plan = user.get_active_admin_plan()
+        emails = ', '.join(_opted_in_emails(plan))
+        buttons.append(
+            Button(
+                _('Copy opted-in emails'),
+                url='#',
+                icon_name='copy',
+                priority=89,
+                attrs={
+                    'data-pledge-participants-emails': emails,
+                    'data-pledge-participants-copied-label': str(_('Copied')),
+                },
+            ),
+        )
+        buttons.append(
+            Button(
+                _('Export opted-in emails as CSV'),
+                url=export_url,
+                icon_name='download',
+                priority=90,
+            ),
+        )
+        return sorted(buttons)
+
+
+class ParticipantsViewSet(WatchViewSet[PublicUser]):
+    """Read-only admin viewset for PublicUsers committed to plan pledges."""
+
+    model = PublicUser
+    name = 'pledge_participants'
+    icon = 'group'
+    menu_label = _('Participants')
+    menu_icon = 'group'
+    add_to_admin_menu = False  # menu wired via custom Pledges submenu
+    list_display = [
+        Column('email', label=_('Email'), sort_key='email'),
+        Column('commitment_count', label=_('Pledges committed'), sort_key='commitment_count'),
+        BooleanColumn(
+            'has_marketing_consent',
+            label=_('Marketing opt-in'),
+            sort_key='marketing_consented_at',
+        ),
+    ]
+    index_view_class = ParticipantsIndexView  # type: ignore[assignment]
+    inspect_view_enabled = False
+    copy_view_enabled = False
+
+    @property
+    def permission_policy(self):
+        return ParticipantsPermissionPolicy(self.model)
+
+    def get_urlpatterns(self):
+        # SnippetViewSet hard-codes add/edit/delete routes even when the
+        # view classes are set to None. Override to expose only listing
+        # endpoints; this ViewSet is read-only.
+        return [
+            path('', self.index_view, name='list'),
+            path('results/', self.index_results_view, name='list_results'),
+        ]
+
+
+# Wagtail's BooleanColumn reads bool() of the attribute. PublicUser.marketing_consented_at
+# is a datetime-or-None; bool(datetime) is True, bool(None) is False, so the column
+# already does the right thing as long as we expose `has_marketing_consent` as a property.
+def _has_marketing_consent(self: PublicUser) -> bool:
+    return self.marketing_consented_at is not None
+
+
+PublicUser.has_marketing_consent = property(_has_marketing_consent)  # type: ignore[attr-defined]
+
+
+class _ParticipantsCsvView(View):
+    """CSV download: one opted-in email per line."""
+
+    pledge_id: int | None = None
+
+    def _check_permission(self, request: HttpRequest, plan: Plan) -> None:
+        user = request.user
+        if not isinstance(user, User):
+            raise PermissionDenied
+        if not user.is_general_admin_for_plan(plan):
+            raise PermissionDenied
+        if not plan.features.enable_community_engagement:
+            raise PermissionDenied
+
+    def get(self, request: HttpRequest, *, pledge_id: int | None = None) -> HttpResponse:
+        user = user_or_bust(request.user)
+        plan = user.get_active_admin_plan()
+        self._check_permission(request, plan)
+
+        pledge: Pledge | None = None
+        if pledge_id is not None:
+            pledge = Pledge.objects.filter(pk=pledge_id, plan=plan).first()
+            if pledge is None:
+                raise PermissionDenied
+            filename = f'pledge-{pledge.slug}-opted-in-emails.csv'
+        else:
+            filename = f'pledge-participants-opted-in-emails-{plan.identifier}.csv'
+
+        emails = _opted_in_emails(plan, pledge)
+
+        def _stream() -> Any:
+            writer = csv.writer(Echo())
+            for email in emails:
+                yield writer.writerow([email])
+
+        response = HttpResponse(_stream(), content_type='text/csv')
+        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        return response
+
+
+def participants_csv_view(request: HttpRequest) -> HttpResponse:
+    return cast('HttpResponse', _ParticipantsCsvView.as_view()(request))
+
+
+def pledge_participants_csv_view(request: HttpRequest, pledge_id: int) -> HttpResponse:
+    return cast('HttpResponse', _ParticipantsCsvView.as_view()(request, pledge_id=pledge_id))
+
+
+class PledgeParticipantsPanel(Panel):
+    """
+    Tab on the pledge edit view listing participants for that pledge.
+
+    Renders inert (not a form field): table of email + opt-in column, plus
+    'Copy opted-in emails' and 'Export' buttons. The opted-in email list
+    is embedded as a hidden data attribute so the copy button can read it
+    without a round-trip.
+    """
+
+    heading = _('Participants')
+
+    class BoundPanel(Panel.BoundPanel):
+        template_name = 'admin_site/pledge_participants_panel.html'
+
+        def get_context_data(self, parent_context=None):
+            ctx = super().get_context_data(parent_context) or {}
+            ctx['participants'] = []
+            ctx['opted_in_emails'] = ''
+            ctx['export_url'] = None
+            ctx['copy_emails_label'] = _('Copy opted-in emails')
+
+            pledge: Pledge | None = cast('Pledge | None', self.instance)
+            if pledge is None or pledge.pk is None:
+                return ctx
+            user = user_or_bust(self.request.user) if self.request else None
+            plan = user.get_active_admin_plan() if user is not None else None
+            # PledgePermissionPolicy lets the user open the edit view if they
+            # have the global change_pledge perm and the pledge belongs to
+            # their active plan, but that doesn't guarantee they're a general
+            # admin there. Mirror the CSV endpoint and the global Participants
+            # list: tab populates only when the user actually admins this plan.
+            if plan is None or user is None or not user.is_general_admin_for_plan(plan):
+                return ctx
+            participants = list(
+                _get_participants_queryset(plan, pledge).order_by('email').values('email', 'marketing_consented_at')
+            )
+            ctx['participants'] = participants
+            ctx['opted_in_emails'] = ', '.join(_opted_in_emails(plan, pledge))
+            ctx['export_url'] = reverse('pledge_participants_export_csv_for_pledge', args=[pledge.pk])
+            return ctx
+
+
+def get_pledge_participants_admin_urlpatterns() -> list[Any]:
+    """URL patterns for the CSV export endpoints, registered via wagtail hook."""
+    return [
+        path('pledge-participants/export.csv', participants_csv_view, name='pledge_participants_export_csv'),
+        path(
+            'pledge-participants/<int:pledge_id>/export.csv',
+            pledge_participants_csv_view,
+            name='pledge_participants_export_csv_for_pledge',
+        ),
+    ]
+
+
+register_snippet(ParticipantsViewSet)

--- a/actions/pledge_participants_admin.py
+++ b/actions/pledge_participants_admin.py
@@ -173,6 +173,7 @@ class ParticipantsViewSet(WatchViewSet[PublicUser]):
     menu_label = _('Participants')
     menu_icon = 'group'
     add_to_admin_menu = False  # menu wired via custom Pledges submenu
+    menu_item_is_registered = True
     list_display = [
         Column('email', label=_('Email'), sort_key='email'),
         Column('commitment_count', label=_('Pledges committed'), sort_key='commitment_count'),

--- a/actions/tests/test_pledge_participants_admin.py
+++ b/actions/tests/test_pledge_participants_admin.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+
+from actions.models import PledgeCommitment, PublicUser
+from actions.pledge_participants_admin import (
+    ParticipantsViewSet,
+    _get_participants_queryset,
+    _opted_in_emails,
+)
+from actions.tests.factories import PlanFactory, PledgeFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def active_plan(plan_admin_user):
+    plan_obj = plan_admin_user.get_active_admin_plan()
+    plan_obj.features.enable_community_engagement = True
+    plan_obj.features.save()
+    return plan_obj
+
+
+def _make_participant(email: str, marketing: bool = False) -> PublicUser:
+    now = timezone.now()
+    return PublicUser.objects.create(
+        email=email,
+        terms_accepted_at=now,
+        marketing_consented_at=now if marketing else None,
+        email_verified_at=now,
+    )
+
+
+class TestParticipantsQueryset:
+    def test_excludes_users_without_email(self, active_plan):
+        pledge = PledgeFactory.create(plan=active_plan)
+        anon = PublicUser.objects.create()
+        PledgeCommitment.objects.create(pledge=pledge, public_user=anon)
+
+        signed_up = _make_participant('alice@example.com')
+        PledgeCommitment.objects.create(pledge=pledge, public_user=signed_up)
+
+        result = list(_get_participants_queryset(active_plan))
+
+        assert result == [signed_up]
+
+    def test_only_signed_up_with_commitments_in_plan(self, active_plan):
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+
+        own_pledge = PledgeFactory.create(plan=active_plan)
+        other_pledge = PledgeFactory.create(plan=other_plan)
+
+        in_plan = _make_participant('in@example.com')
+        out_of_plan = _make_participant('out@example.com')
+        _make_participant('lurker@example.com')  # no commitments
+
+        PledgeCommitment.objects.create(pledge=own_pledge, public_user=in_plan)
+        PledgeCommitment.objects.create(pledge=other_pledge, public_user=out_of_plan)
+
+        result = list(_get_participants_queryset(active_plan).values_list('email', flat=True))
+
+        assert result == ['in@example.com']
+
+    def test_commitment_count_annotation_counts_per_plan(self, active_plan):
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+        own_pledge_a = PledgeFactory.create(plan=active_plan)
+        own_pledge_b = PledgeFactory.create(plan=active_plan)
+        other_pledge = PledgeFactory.create(plan=other_plan)
+
+        user = _make_participant('alice@example.com')
+        PledgeCommitment.objects.create(pledge=own_pledge_a, public_user=user)
+        PledgeCommitment.objects.create(pledge=own_pledge_b, public_user=user)
+        PledgeCommitment.objects.create(pledge=other_pledge, public_user=user)
+
+        row = _get_participants_queryset(active_plan).get(pk=user.pk)
+
+        # commitment_count is a queryset annotation, not a model field, so mypy
+        # doesn't know about it.
+        assert getattr(row, 'commitment_count') == 2  # noqa: B009
+
+    def test_pledge_scoped_queryset_counts_one(self, active_plan):
+        a = PledgeFactory.create(plan=active_plan)
+        b = PledgeFactory.create(plan=active_plan)
+        user = _make_participant('alice@example.com')
+        PledgeCommitment.objects.create(pledge=a, public_user=user)
+        PledgeCommitment.objects.create(pledge=b, public_user=user)
+
+        row = _get_participants_queryset(active_plan, pledge=a).get(pk=user.pk)
+
+        assert getattr(row, 'commitment_count') == 1  # noqa: B009
+
+    def test_pledge_scoped_queryset_rejects_pledge_from_other_plan(self, active_plan):
+        # Defensive: if a caller passes a (plan, pledge) pair where the
+        # pledge belongs to a different plan, the helper must return empty
+        # rather than leak the other plan's participants.
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+        other_pledge = PledgeFactory.create(plan=other_plan)
+        user = _make_participant('alice@example.com')
+        PledgeCommitment.objects.create(pledge=other_pledge, public_user=user)
+
+        result = list(_get_participants_queryset(active_plan, pledge=other_pledge))
+
+        assert result == []
+
+
+class TestOptedInEmails:
+    def test_returns_only_opted_in_sorted(self, active_plan):
+        pledge = PledgeFactory.create(plan=active_plan)
+        alice = _make_participant('alice@example.com', marketing=True)
+        bob = _make_participant('bob@example.com', marketing=False)
+        carol = _make_participant('carol@example.com', marketing=True)
+        PledgeCommitment.objects.create(pledge=pledge, public_user=alice)
+        PledgeCommitment.objects.create(pledge=pledge, public_user=bob)
+        PledgeCommitment.objects.create(pledge=pledge, public_user=carol)
+
+        assert _opted_in_emails(active_plan) == ['alice@example.com', 'carol@example.com']
+
+    def test_pledge_scoped_excludes_other_pledges(self, active_plan):
+        pledge_a = PledgeFactory.create(plan=active_plan)
+        pledge_b = PledgeFactory.create(plan=active_plan)
+        alice = _make_participant('alice@example.com', marketing=True)
+        bob = _make_participant('bob@example.com', marketing=True)
+        PledgeCommitment.objects.create(pledge=pledge_a, public_user=alice)
+        PledgeCommitment.objects.create(pledge=pledge_b, public_user=bob)
+
+        assert _opted_in_emails(active_plan, pledge=pledge_a) == ['alice@example.com']
+
+
+class TestParticipantsIndexView:
+    def _list_url(self) -> str:
+        return reverse(ParticipantsViewSet().get_url_name('list'))
+
+    def test_view_renders_for_plan_admin(self, client, plan_admin_user, active_plan):
+        pledge = PledgeFactory.create(plan=active_plan)
+        PledgeCommitment.objects.create(
+            pledge=pledge,
+            public_user=_make_participant('alice@example.com', marketing=True),
+        )
+        client.force_login(plan_admin_user)
+
+        response = client.get(self._list_url())
+
+        assert response.status_code == 200
+        assert b'alice@example.com' in response.content
+
+    def test_view_denied_for_action_contact_person(self, client, action_contact_person_user, active_plan):
+        # Contact persons have admin access (is_staff) and may have an active
+        # admin plan, but PublicUser.view is granted only via PLAN_ADMIN_PERMS
+        # (actions/perms.py), not contact-person perms. The participants list
+        # must enforce that distinction so contact persons can't read
+        # participant emails for the plan.
+        from actions.models import Action
+        from actions.perms import add_contact_person_perms
+
+        add_contact_person_perms(action_contact_person_user, Action)
+        client.force_login(action_contact_person_user)
+
+        response = client.get(self._list_url())
+
+        assert response.status_code in (302, 403, 404)
+
+    def test_view_denied_when_active_plan_is_not_admined(self, client, plan_admin_user, active_plan):
+        # The user is a general plan admin for active_plan (Plan X), which
+        # grants the global actions.view_publicuser Django permission. They
+        # may also be a contact person for another plan (Plan Y) with
+        # community engagement enabled. Switching the active admin plan to
+        # Y must NOT expose Y's participants - the user isn't a general
+        # admin there. The policy has to bind to the active plan, not just
+        # the global model perm.
+        from actions.models import Action
+        from actions.perms import add_contact_person_perms
+
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+        other_action = other_plan.actions.first()
+        if other_action is None:
+            other_action = Action.objects.create(plan=other_plan, name='Other action')
+        # Make plan_admin_user a contact person for other_plan's action; their
+        # general-admin status for active_plan stays unchanged.
+        plan_admin_user.person.contact_for_actions.add(other_action)
+        add_contact_person_perms(plan_admin_user, Action)
+        # Force the active admin plan to other_plan, where the user is only
+        # a contact person.
+        plan_admin_user.selected_admin_plan = other_plan
+        plan_admin_user.save(update_fields=['selected_admin_plan'])
+        client.force_login(plan_admin_user)
+
+        response = client.get(self._list_url())
+
+        assert response.status_code in (302, 403, 404)
+
+    def test_view_hidden_when_feature_disabled(self, client, plan_admin_user, active_plan):
+        active_plan.features.enable_community_engagement = False
+        active_plan.features.save()
+        client.force_login(plan_admin_user)
+
+        response = client.get(self._list_url())
+
+        # Wagtail's permission system returns 302 or 403 when denied; either is fine.
+        assert response.status_code in (302, 403, 404)
+
+    def test_sort_by_commitment_count(self, client, plan_admin_user, active_plan):
+        many = PledgeFactory.create(plan=active_plan)
+        few = PledgeFactory.create(plan=active_plan)
+        alice = _make_participant('alice@example.com')
+        bob = _make_participant('bob@example.com')
+        PledgeCommitment.objects.create(pledge=many, public_user=alice)
+        PledgeCommitment.objects.create(pledge=few, public_user=alice)
+        PledgeCommitment.objects.create(pledge=many, public_user=bob)
+        client.force_login(plan_admin_user)
+
+        response = client.get(self._list_url() + '?' + urlencode({'ordering': '-commitment_count'}))
+
+        assert response.status_code == 200
+        body = response.content.decode('utf-8')
+        assert body.index('alice@example.com') < body.index('bob@example.com')
+
+
+class TestPledgeParticipantsPanel:
+    def _make_bound_panel(self, request, pledge):
+        from actions.models import Pledge
+        from actions.pledge_participants_admin import PledgeParticipantsPanel
+
+        panel = PledgeParticipantsPanel().bind_to_model(Pledge)
+        return panel.get_bound_panel(instance=pledge, request=request, form=None)
+
+    def test_panel_populated_for_plan_admin(self, rf, plan_admin_user, active_plan):
+        pledge = PledgeFactory.create(plan=active_plan)
+        PledgeCommitment.objects.create(
+            pledge=pledge,
+            public_user=_make_participant('alice@example.com', marketing=True),
+        )
+        request = rf.get('/admin/')
+        request.user = plan_admin_user
+
+        ctx = self._make_bound_panel(request, pledge).get_context_data()
+
+        assert ctx['opted_in_emails'] == 'alice@example.com'
+        assert len(ctx['participants']) == 1
+
+    def test_panel_empty_when_active_plan_is_not_admined(self, rf, plan_admin_user, active_plan):
+        # Mixed-role: plan_admin_user is a general admin of active_plan but
+        # only a contact person on other_plan. The Pledge edit view itself is
+        # gated more permissively, so the user can reach the edit page for an
+        # other_plan pledge - but the participants tab must not embed the
+        # plan's opted-in emails.
+        from actions.models import Action
+        from actions.perms import add_contact_person_perms
+
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+        other_pledge = PledgeFactory.create(plan=other_plan)
+        PledgeCommitment.objects.create(
+            pledge=other_pledge,
+            public_user=_make_participant('bob@example.com', marketing=True),
+        )
+        other_action = other_plan.actions.first()
+        if other_action is None:
+            other_action = Action.objects.create(plan=other_plan, name='Other action')
+        plan_admin_user.person.contact_for_actions.add(other_action)
+        add_contact_person_perms(plan_admin_user, Action)
+        plan_admin_user.selected_admin_plan = other_plan
+        plan_admin_user.save(update_fields=['selected_admin_plan'])
+        # The fixture-cached User has stale perms and adminable_plans caches;
+        # refetch to start fresh so the contact-person assignment registers.
+        plan_admin_user = type(plan_admin_user).objects.get(pk=plan_admin_user.pk)
+        request = rf.get('/admin/')
+        request.user = plan_admin_user
+
+        ctx = self._make_bound_panel(request, other_pledge).get_context_data()
+
+        assert ctx['opted_in_emails'] == ''
+        assert ctx['participants'] == []
+        assert ctx['export_url'] is None
+
+
+class TestCsvExportEndpoint:
+    def test_global_csv_contains_only_opted_in_emails(self, client, plan_admin_user, active_plan):
+        pledge = PledgeFactory.create(plan=active_plan)
+        alice = _make_participant('alice@example.com', marketing=True)
+        bob = _make_participant('bob@example.com', marketing=False)
+        PledgeCommitment.objects.create(pledge=pledge, public_user=alice)
+        PledgeCommitment.objects.create(pledge=pledge, public_user=bob)
+        client.force_login(plan_admin_user)
+
+        response = client.get(reverse('pledge_participants_export_csv'))
+
+        assert response.status_code == 200
+        assert response['Content-Type'] == 'text/csv'
+        body = response.content.decode('utf-8')
+        assert 'alice@example.com' in body
+        assert 'bob@example.com' not in body
+
+    def test_per_pledge_csv_scoped_to_pledge(self, client, plan_admin_user, active_plan):
+        pledge_a = PledgeFactory.create(plan=active_plan)
+        pledge_b = PledgeFactory.create(plan=active_plan)
+        alice = _make_participant('alice@example.com', marketing=True)
+        carol = _make_participant('carol@example.com', marketing=True)
+        PledgeCommitment.objects.create(pledge=pledge_a, public_user=alice)
+        PledgeCommitment.objects.create(pledge=pledge_b, public_user=carol)
+        client.force_login(plan_admin_user)
+
+        response = client.get(
+            reverse('pledge_participants_export_csv_for_pledge', args=[pledge_a.pk]),
+        )
+
+        assert response.status_code == 200
+        body = response.content.decode('utf-8')
+        assert 'alice@example.com' in body
+        assert 'carol@example.com' not in body
+
+    def test_per_pledge_csv_rejects_pledge_outside_active_plan(self, client, plan_admin_user, active_plan):
+        other_plan = PlanFactory.create()
+        other_plan.features.enable_community_engagement = True
+        other_plan.features.save()
+        other_pledge = PledgeFactory.create(plan=other_plan)
+        client.force_login(plan_admin_user)
+
+        response = client.get(
+            reverse('pledge_participants_export_csv_for_pledge', args=[other_pledge.pk]),
+        )
+
+        # Wagtail admin URLs raise PermissionDenied as a 302 redirect to the
+        # admin home; either explicit 403 or that redirect is "denied".
+        assert response.status_code in (302, 403)
+
+    def test_csv_unauthenticated_redirects(self, client):
+        response = client.get(reverse('pledge_participants_export_csv'))
+        # Wagtail admin auth redirects to login (302) or denies (403)
+        assert response.status_code in (302, 403)
+
+    def test_csv_anonymous_users_excluded(self, client, plan_admin_user, active_plan):
+        pledge = PledgeFactory.create(plan=active_plan)
+        # Anonymous user with a commitment - shouldn't appear since no email
+        anon = PublicUser.objects.create()
+        PledgeCommitment.objects.create(pledge=pledge, public_user=anon)
+        client.force_login(plan_admin_user)
+
+        response = client.get(reverse('pledge_participants_export_csv'))
+
+        assert response.status_code == 200
+        body = response.content.decode('utf-8')
+        assert body.strip() == ''  # no opted-in users

--- a/actions/wagtail_hooks.py
+++ b/actions/wagtail_hooks.py
@@ -16,7 +16,7 @@ from aplans.context_vars import get_admin_cache
 
 from admin_site.wagtail import execute_admin_post_save_tasks
 
-from . import wagtail_admin  # noqa: F401
+from . import pledge_participants_admin, wagtail_admin  # noqa: F401
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -82,6 +82,60 @@ def register_documents_search_area():
         name='actions',
         icon_name='kausal-action',
         order=200,
+    )
+
+
+@hooks.register('insert_global_admin_js')
+def pledge_participants_admin_js():
+    from django.utils.html import format_html
+
+    return format_html('<script src="{}"></script>', static('admin_site/js/pledge_participants.js'))
+
+
+@hooks.register('register_admin_urls')
+def register_pledge_participants_urls():
+    return pledge_participants_admin.get_pledge_participants_admin_urlpatterns()
+
+
+@hooks.register('register_admin_menu_item')
+def register_pledges_submenu():
+    from wagtail.admin.menu import Menu, MenuItem, SubmenuMenuItem
+
+    from actions.pledge_admin import PledgeViewSet
+    from actions.pledge_participants_admin import ParticipantsViewSet
+
+    pledge_viewset = PledgeViewSet()
+    participants_viewset = ParticipantsViewSet()
+
+    pledges_url = reverse(pledge_viewset.get_url_name('list'))
+    participants_url = reverse(participants_viewset.get_url_name('list'))
+
+    submenu = Menu(
+        items=[
+            MenuItem(_('Pledges'), pledges_url, icon_name='kausal-pledge', order=1),
+            MenuItem(_('Participants'), participants_url, icon_name='group', order=2),
+        ]
+    )
+
+    class PledgesSubmenuItem(SubmenuMenuItem):
+        def is_shown(self, request) -> bool:
+            from users.models import User
+
+            if not super().is_shown(request):
+                return False
+            user = request.user
+            if not isinstance(user, User):
+                return False
+            plan = user.get_active_admin_plan(required=False)
+            if plan is None:
+                return False
+            return plan.features.enable_community_engagement
+
+    return PledgesSubmenuItem(
+        _('Pledges'),
+        submenu,
+        icon_name='kausal-pledge',
+        order=41,
     )
 
 

--- a/admin_site/static/admin_site/js/pledge_participants.js
+++ b/admin_site/static/admin_site/js/pledge_participants.js
@@ -1,0 +1,72 @@
+/*
+ * Copy-to-clipboard for the Pledges → Participants admin views.
+ *
+ * Looks for buttons carrying `data-pledge-participants-emails`. On click,
+ * writes the value to the clipboard and briefly swaps the label so the
+ * operator gets confirmation. No framework dependencies — Wagtail admin
+ * pages load this from insert_global_admin_js.
+ */
+(function () {
+  'use strict';
+
+  function onCopyClick(button) {
+    var emails = button.getAttribute('data-pledge-participants-emails') || '';
+    if (!emails) {
+      return;
+    }
+    var done = function () {
+      var original = button.textContent;
+      button.textContent = button.getAttribute('data-pledge-participants-copied-label') || 'Copied';
+      button.disabled = true;
+      setTimeout(function () {
+        button.textContent = original;
+        button.disabled = false;
+      }, 1500);
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(emails).then(done, function () {
+        fallbackCopy(emails);
+        done();
+      });
+    } else {
+      fallbackCopy(emails);
+      done();
+    }
+  }
+
+  function fallbackCopy(text) {
+    var textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      /* swallow */
+    }
+    document.body.removeChild(textarea);
+  }
+
+  function init() {
+    document.body.addEventListener('click', function (event) {
+      var target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      var button = target.closest('[data-pledge-participants-emails]');
+      if (button) {
+        event.preventDefault();
+        onCopyClick(button);
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/admin_site/templates/admin_site/pledge_participants_panel.html
+++ b/admin_site/templates/admin_site/pledge_participants_panel.html
@@ -1,0 +1,49 @@
+{% load i18n %}
+<div class="panel">
+    <section>
+        <h2>{% trans "Participants" %}</h2>
+
+        {% if participants %}
+            <div class="pledge-participants-actions" style="margin-bottom: 1rem; display: flex; gap: 0.5rem;">
+                <button
+                    type="button"
+                    class="button button-secondary"
+                    data-pledge-participants-emails="{{ opted_in_emails }}"
+                    data-pledge-participants-copied-label="{% trans 'Copied' %}"
+                >
+                    {{ copy_emails_label }}
+                </button>
+                {% if export_url %}
+                    <a href="{{ export_url }}" class="button button-secondary" download>
+                        {% trans "Export opted-in emails as CSV" %}
+                    </a>
+                {% endif %}
+            </div>
+
+            <table class="listing">
+                <thead>
+                    <tr>
+                        <th>{% trans "Email" %}</th>
+                        <th>{% trans "Marketing opt-in" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for participant in participants %}
+                        <tr>
+                            <td>{{ participant.email }}</td>
+                            <td>
+                                {% if participant.marketing_consented_at %}
+                                    <span aria-label="{% trans 'Opted in' %}" title="{% trans 'Opted in' %}">&#10003;</span>
+                                {% else %}
+                                    <span aria-label="{% trans 'Not opted in' %}" title="{% trans 'Not opted in' %}">&mdash;</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>{% trans "No participants have committed to this pledge yet." %}</p>
+        {% endif %}
+    </section>
+</div>


### PR DESCRIPTION
## Description
Two surfaces for plan admins on plans with community engagement enabled:

- A global Participants list under Pledges -> Participants (the Pledges menu becomes a submenu with Pledges and Participants children). Columns: email, commitment count, marketing opt-in. All sortable. Header buttons: Copy opted-in emails (clipboard) and Export opted-in emails as CSV.
- A Participants tab on the pledge edit view scoped to that pledge. Same email + opt-in tick columns; same Copy/Export buttons.

Both surfaces share _get_participants_queryset (plan-scoped, excludes anonymous PublicUsers via email IS NULL, annotates commitment_count) and _opted_in_emails (filters to marketing_consented_at IS NOT NULL, sorted). The CSV endpoints under /admin/pledge-participants/ are gated to the active plan and reject pledges outside it.

The ParticipantsViewSet subclasses SnippetViewSet but overrides get_urlpatterns to expose only list/list_results (add/edit/delete view classes can't simply be nulled because SnippetViewSet hard-codes those routes). Permission policy is dedicated, separate from PledgePermissionPolicy, because the participants UI is read-only.

The copy-to-clipboard JS is plain JS loaded via insert_global_admin_js; the button carries the opted-in email list in a data attribute so the copy is a one-click no-roundtrip operation.

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1215606704588443
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1215606704588431

## Requirements, dependencies and related PRs
Base: https://github.com/kausaltech/kausal-watch/pull/626

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
