### PR TITLE
Fix search index crash from invalid from_plan_id FilterField on Plan

### DIFF
--- a/actions/chooser.py
+++ b/actions/chooser.py
@@ -192,7 +192,15 @@ class PlanChooserMixin(WatchModelChooserBase[Plan]):
 
     def get_unfiltered_object_list(self):
         plan = self.request.get_active_admin_plan()
-        return Plan.objects.filter(pk=plan.pk) | plan.related_plans.all()
+        # Filter by primary keys rather than OR-ing in `plan.related_plans.all()`. The latter is a
+        # self-referential M2M, so the combined queryset's WHERE clause references the auto-created
+        # through-table column `from_plan_id`. When this queryset is passed to the search backend's
+        # `autocomplete()`, the compiler would then demand an `index.FilterField('from_plan_id')` on
+        # Plan -- but that column is not a field/attribute on Plan, so indexing it crashes the search
+        # index build (WATCH-BACKEND-5WQ). Filtering by pk keeps the filter on the real `id` field.
+        related_pks = list(plan.related_plans.values_list('pk', flat=True))
+        related_pks.append(plan.pk)
+        return Plan.objects.filter(pk__in=related_pks)
 
     def get_row_data(self, item):
         return {

--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -616,7 +616,6 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
         index.FilterField('organization'),
         index.FilterField('is_active'),
         index.FilterField('id'),
-        index.FilterField('from_plan_id'),
         index.RelatedFields(
             'organization',
             [


### PR DESCRIPTION
FilterField('from_plan_id') was added so the PlanChooser autocomplete search would accept the filter on `plan.related_plans.all()`, whose self-referential M2M leaks the through-table column `from_plan_id` into the queryset's WHERE clause (otherwise the search backend raises FilterFieldError).

But `from_plan_id` is a column on the auto-created M2M through table, not a field/attribute/callable on Plan. So when the Elasticsearch mapping is built, get_definition_model() returns None and the build crashes with "AttributeError: 'NoneType' object has no attribute '_meta'", breaking the nightly update_index Celery task on every run.

Fix the root cause instead of indexing the through-column: build the PlanChooser queryset with pk__in so its WHERE clause only references the real `id` field (already indexed via FilterField('id')), and drop the invalid FilterField('from_plan_id'). This avoids both the FilterFieldError and the index-build crash.

Fixes WATCH-BACKEND-5WQ

## Related issue
[Sentry issue](https://sentry.kausal.tech/organizations/kausal/issues/16915/events/fa850d7f759249e587cd54e0a3d60ed2/)
[PR introducing the bug (note the Codex review comment)](https://github.com/kausaltech/kausal-watch/pull/610)

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    ```
    python manage.py shell_plus --quiet-load -c "
    from modelsearch.backends.elasticsearch8 import Elasticsearch8Mapping
    from actions.models.plan import Plan
    Elasticsearch8Mapping(Plan).get_mapping()
    "
    ```