### PR TITLE
Add single-tenant plan export command

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,6 +18,7 @@ omit =
 show_missing = True
 exclude_lines =
     pragma: no cover
+    if TYPE_CHECKING:
     def __repr__
     if self.debug:
     if __name__ == .__main__.:

--- a/copying/export.py
+++ b/copying/export.py
@@ -1,0 +1,454 @@
+"""
+Single-tenant data export.
+
+Produce a self-contained JSON dump of one plan's data (and nothing belonging to any other
+tenant), in Django's standard serialization format -- the same format ``dumpdata`` emits and
+``loaddata`` consumes.
+
+Unlike ``destructively_trim_db`` (a denylist: delete every other tenant and hope nothing
+leaks), this is an allowlist: it walks only the objects that provably belong to the plan,
+reusing the declarative clone structures from ``copying.main`` as the definition of plan
+ownership. Because it never visits another tenant's rows, it cannot leak them.
+
+See ``docs/architecture/single-tenant-export.md`` for the design.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.core import serializers
+from wagtail.models import Page
+from wagtail.models.reference_index import ReferenceIndex
+
+from copying.main import (
+    DATASET_SCHEMA_CLONE_STRUCTURE,
+    DIMENSION_CLONE_STRUCTURE,
+    INDICATOR_CLONE_STRUCTURE,
+    MODELS_NOT_COPIED,
+    PLAN_CLONE_STRUCTURE,
+    Excluded,
+    _iter_clone_structure_instances,
+    iter_plan_owned_instances,
+)
+from copying.utils import get_foreign_keys, get_generic_foreign_keys
+from documents.models import AplansDocument
+from images.models import AplansImage
+from indicators.models.dimensions import Dimension
+from indicators.models.indicator import Indicator
+from orgs.models import Organization
+from people.models import Person
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+
+    from django.db.models import Model
+    from wagtail.models import Collection, Site
+
+    from actions.models.plan import Plan
+    from copying.main import CloneEntry, CloneStructure
+
+
+def _deepcopy_structure(structure: CloneStructure) -> CloneStructure:
+    """Deep-copy a clone structure, preserving the shared ``EXCLUDED`` sentinel by identity."""
+    result: CloneStructure = {}
+    for key, entry in structure.items():
+        result[key] = entry if isinstance(entry, Excluded) else _deepcopy_structure(entry)
+    return result
+
+
+def _set(structure: CloneStructure, path: list[str], value: CloneEntry) -> None:
+    """
+    Set the entry at ``path`` (a chain of relation names) in ``structure``.
+
+    Every parent on the path must already exist and be a (non-excluded) sub-structure, so
+    typos and reclassifications of relations that copy doesn't know about fail loudly.
+    """
+    *parents, last = path
+    node = structure
+    for key in parents:
+        entry = node[key]
+        if isinstance(entry, Excluded):
+            raise TypeError(f'Cannot descend into excluded relation {key!r} on path {path!r}')
+        node = entry
+    if last not in node:
+        raise ValueError(f'Relation {last!r} is not a key of the clone structure at path {path!r}')
+    node[last] = value
+
+
+# Relations that copy drops purely to avoid remapping references to the copied objects. An
+# export preserves primary keys verbatim, so these are safe -- and wanted -- to include.
+def build_export_plan_structure(
+    *,
+    include_pledges: bool = False,
+    include_feedback: bool = False,
+    include_audit_logs: bool = False,
+) -> CloneStructure:
+    """
+    Build the plan traversal structure for an export.
+
+    Starts from ``PLAN_CLONE_STRUCTURE`` (so relations newly added on the copy side flow
+    through automatically) and applies the export-specific reclassifications documented in
+    ``docs/architecture/single-tenant-export.md``. Deliberately dropped relations (other
+    plans, plan domains, legacy and our-side-only data) are left ``EXCLUDED`` as in copy.
+    """
+    structure = _deepcopy_structure(PLAN_CLONE_STRUCTURE)
+
+    # --- Re-include plan-owned content that copy drops only to avoid reference remapping ---
+    # Reports embed action snapshots that reference original PKs; a remapping problem for
+    # copy, but not for a PK-preserving export.
+    _set(structure, ['report_types', 'reports'], {'action_snapshots': {}})
+    # Plan links are cluster children; copy leaves them out (its own TODO), but they are plan content.
+    _set(structure, ['links'], {})
+    # Change-log history (each of these is a leaf model with no further relations to traverse).
+    for changelog_rel in (
+        'actionchangelogmessage_set',
+        'indicatorchangelogmessage_set',
+        'categorychangelogmessage_set',
+        'pagechangelogmessage_set',
+    ):
+        _set(structure, [changelog_rel], {})
+
+    # --- Privacy-gated content (off by default) ---
+    if include_pledges:
+        # Citizen commitments to pledges.
+        _set(structure, ['pledges', 'commitments'], {})
+    if include_feedback:
+        # Citizen-submitted feedback and staff notification preferences.
+        _set(structure, ['user_feedbacks'], {})
+        _set(structure, ['pledges', 'user_feedbacks'], {})
+        _set(structure, ['actions', 'contact_persons', 'notification_preferences'], {})
+        _set(structure, ['general_admins_ordered', 'notification_preferences'], {})
+    if include_audit_logs:
+        _set(structure, ['planscopedmodellogentry'], {})
+        _set(structure, ['planscopedpagelogentry'], {})
+
+    return structure
+
+
+# The default export structure (conservative privacy defaults). Exposed for tests and docs.
+EXPORT_PLAN_STRUCTURE: CloneStructure = build_export_plan_structure()
+
+
+def _iter_page_and_specific(page: Page) -> Generator[Model]:
+    """
+    Yield both rows that make up a Wagtail page.
+
+    Pages use multi-table inheritance, so each page is stored as a base ``wagtailcore.page``
+    row plus a concrete-subclass row. ``loaddata`` needs both.
+    """
+    yield page
+    specific = page.specific
+    if type(specific) is not Page:
+        yield specific
+
+
+def iter_plan_page_instances(plan: Plan) -> Generator[Model]:
+    """
+    Yield every page owned by the plan, base and concrete rows for each.
+
+    Covers the plan site's root page and every documentation root page, each together with
+    its translations (separate per-locale page trees) and all their descendants. The clone
+    structures deliberately skip pages because copy delegates them to Wagtail's ``Page.copy``.
+    """
+    roots: list[Page] = []
+    site: Site | None = plan.site
+    if site is not None:
+        # A Wagtail Site always has a (non-nullable) root page.
+        root = site.root_page
+        roots.append(root)
+        roots.extend(root.get_translations(inclusive=False))
+    for doc_root in plan.documentation_root_pages.all():
+        roots.append(doc_root)
+        roots.extend(doc_root.get_translations(inclusive=False))
+
+    for root in roots:
+        for page in root.get_descendants(inclusive=True):
+            yield from _iter_page_and_specific(page)
+
+
+def iter_plan_collection_instances(plan: Plan) -> Generator[Model]:
+    """Yield the plan's root collection and its descendant collections."""
+    root_collection: Collection | None = plan.root_collection
+    if root_collection is None:
+        return
+    yield from root_collection.get_descendants(inclusive=True)
+
+
+def iter_plan_media_instances(plan: Plan) -> Generator[Model]:
+    """
+    Yield the image and document rows living in the plan's collections.
+
+    Only the database rows are exported; the binary files live in object storage and are
+    handled out of band (see the ``--media-manifest`` option of the ``export_plan`` command).
+    """
+    root_collection: Collection | None = plan.root_collection
+    if root_collection is None:
+        return
+    collections = root_collection.get_descendants(inclusive=True)
+    yield from AplansImage.objects.filter(collection__in=collections)
+    yield from AplansDocument.objects.filter(collection__in=collections)
+
+
+def _iter_relational_reference_targets(instance: Model) -> Generator[Model]:
+    """Yield every object an instance points at via a forward FK, generic FK or M2M."""
+    for fk in get_foreign_keys(instance):
+        target = getattr(instance, fk.name, None)
+        if target is not None:
+            yield target
+    for gfk in get_generic_foreign_keys(instance):
+        target = getattr(instance, gfk.name, None)
+        if target is not None:
+            yield target
+    for field in instance._meta.many_to_many:
+        yield from getattr(instance, field.name).all()
+
+
+def _iter_org_ancestors(
+    organizations: list[Organization],
+    seen: set[tuple[type[Model], object]],
+) -> Generator[Organization]:
+    """Yield the not-yet-seen ancestors of the given organizations, transitively."""
+    # Index-based loop over a list that grows as ancestors are appended, so ancestors of
+    # ancestors are covered too.
+    index = 0
+    while index < len(organizations):
+        organization = organizations[index]
+        index += 1
+        for ancestor in organization.get_ancestors():
+            key = (Organization, ancestor.pk)
+            if key in seen:
+                continue
+            seen.add(key)
+            organizations.append(ancestor)
+            yield ancestor
+
+
+def iter_referenced_shared_objects(instances: list[Model]) -> Generator[Model]:
+    """
+    Yield the shared/global objects referenced by the collected instances.
+
+    A one-level pull of the ``MODELS_NOT_COPIED`` targets (organizations, persons, users,
+    common indicators, ...) referenced by a foreign key, generic foreign key or M2M on a
+    collected instance. Their own relations are *not* followed -- that is what would drag
+    another tenant's data in -- with one deliberate exception: ``Organization`` ancestors are
+    followed transitively so the org hierarchy is not truncated to just the referenced nodes.
+
+    Off by default; enabled to make the dump interpretable on its own (names, not bare PKs).
+    """
+    shared_models = set(MODELS_NOT_COPIED)
+    seen: set[tuple[type[Model], object]] = set()
+    organizations: list[Organization] = []
+
+    for instance in instances:
+        for target in _iter_relational_reference_targets(instance):
+            key = (type(target), target.pk)
+            if type(target) not in shared_models or key in seen:
+                continue
+            seen.add(key)
+            if isinstance(target, Organization):
+                organizations.append(target)
+            yield target
+
+    yield from _iter_org_ancestors(organizations, seen)
+
+
+def collect_export_instances(
+    plan: Plan,
+    *,
+    structure: CloneStructure = EXPORT_PLAN_STRUCTURE,
+    include_indicators: bool = True,
+    include_referenced_shared_objects: bool = False,
+) -> list[Model]:
+    """
+    Collect every instance belonging to ``plan``, deduplicated by ``(type, pk)``.
+
+    Combines the relation-tree traversal (via ``iter_plan_owned_instances``) with the Wagtail
+    site, collection, page and media rows the clone structures don't reach, then closes over
+    two kinds of dangling reference so the dump is internally consistent:
+
+    - indicators referenced by exported rows but not in ``plan.indicators`` (see
+      ``_add_referenced_indicators``);
+    - images/documents referenced by exported content but living outside the plan's
+      collections (see ``_add_referenced_media``).
+
+    When ``include_referenced_shared_objects`` is set, also appends the shared objects from
+    ``iter_referenced_shared_objects``.
+    """
+    seen: set[tuple[type[Model], object]] = set()
+    instances: list[Model] = []
+
+    def add(candidates: Generator[Model] | list[Model]) -> list[Model]:
+        added: list[Model] = []
+        for instance in candidates:
+            key = (type(instance), instance.pk)
+            if key in seen:
+                continue
+            seen.add(key)
+            instances.append(instance)
+            added.append(instance)
+        return added
+
+    add(iter_plan_owned_instances(plan, plan_structure=structure, include_indicators=include_indicators))
+    if plan.site is not None:
+        add([plan.site])
+    add(iter_plan_collection_instances(plan))
+    add(iter_plan_page_instances(plan))
+    add(iter_plan_media_instances(plan))
+    if include_indicators:
+        _add_referenced_indicator_graph(plan, instances, add, seen)
+    _add_referenced_media(instances, add)
+    if include_referenced_shared_objects:
+        add(iter_referenced_shared_objects(instances))
+    return instances
+
+
+def _uncollected_referenced_pks(
+    instances: list[Model],
+    seen: set[tuple[type[Model], object]],
+    model: type[Model],
+) -> set[object]:
+    """Return the PKs of ``model`` instances referenced by a collected instance but not yet collected."""
+    return {
+        target.pk
+        for instance in list(instances)
+        for target in _iter_relational_reference_targets(instance)
+        if type(target) is model and (model, target.pk) not in seen
+    }
+
+
+def _includable_indicator_ids(pks: set[object], plan: Plan) -> set[object]:
+    """Drop indicators owned by another plan (their data is that tenant's, not ours)."""
+    other_plan_ids = set(
+        Indicator.objects.filter(id__in=pks, plans__isnull=False).exclude(plans=plan).values_list('id', flat=True)
+    )
+    return pks - other_plan_ids
+
+
+def _includable_dimension_ids(pks: set[object], plan: Plan) -> set[object]:
+    """Drop dimensions owned by another plan (linked via PlanDimension to a different plan only)."""
+    other_plan_ids = set(
+        Dimension.objects.filter(id__in=pks, plans__isnull=False)
+        .exclude(plans__plan=plan)
+        .values_list('id', flat=True)
+    )
+    return pks - other_plan_ids
+
+
+def _add_referenced_indicator_graph(
+    plan: Plan,
+    instances: list[Model],
+    add: Callable[[Generator[Model] | list[Model]], list[Model]],
+    seen: set[tuple[type[Model], object]],
+) -> None:
+    """
+    Include indicators (and the dimensions they use) referenced by exported rows but not owned.
+
+    Exported ``ActionIndicator``/``IndicatorCategoryThrough`` rows can reference indicators that
+    are not part of ``plan.indicators`` (e.g. indicators attached to an action but never added
+    to the plan). Pulling those indicators in via ``INDICATOR_CLONE_STRUCTURE`` in turn pulls in
+    their values, which reference dimension categories -- so dimensions must be closed over too.
+
+    Runs to a fixpoint, since each newly added indicator or dimension can reference further
+    ones. Indicators or dimensions owned by a *different* plan are skipped, preserving tenant
+    isolation: only orphaned or this-plan objects are pulled in.
+    """
+    while True:
+        indicator_ids = _includable_indicator_ids(_uncollected_referenced_pks(instances, seen, Indicator), plan)
+        dimension_ids = _includable_dimension_ids(_uncollected_referenced_pks(instances, seen, Dimension), plan)
+        if not indicator_ids and not dimension_ids:
+            return
+        added: list[Model] = []
+        for indicator in Indicator.objects.filter(id__in=indicator_ids):
+            added += add(_iter_clone_structure_instances(indicator, INDICATOR_CLONE_STRUCTURE))
+            if indicator.dataset_schema is not None:
+                added += add(_iter_clone_structure_instances(indicator.dataset_schema, DATASET_SCHEMA_CLONE_STRUCTURE))
+        for dimension in Dimension.objects.filter(id__in=dimension_ids):
+            added += add(_iter_clone_structure_instances(dimension, DIMENSION_CLONE_STRUCTURE))
+        if not added:  # pragma: no cover - safety net against a non-converging loop
+            return
+
+
+def _add_referenced_media(
+    instances: list[Model],
+    add: Callable[[Generator[Model] | list[Model]], list[Model]],
+) -> None:
+    """
+    Include images/documents referenced by exported content but outside the plan's collections.
+
+    Media is otherwise collected by collection membership (``iter_plan_media_instances``), but
+    pages and rich-text/StreamField bodies can reference images and documents that live in
+    other collections (e.g. a page header image, an embedded image). We find those via forward
+    references and Wagtail's ``ReferenceIndex``, and also pull in their collection rows so the
+    collection FK does not dangle.
+    """
+    media_models = (AplansImage, AplansDocument)
+    targets: list[Model] = []
+    snapshot = list(instances)
+    for instance in snapshot:
+        targets.extend(t for t in _iter_relational_reference_targets(instance) if isinstance(t, media_models))
+        for reference in ReferenceIndex.get_references_for_object(instance):
+            model = reference.to_content_type.model_class()
+            if model in media_models:
+                referenced = model.objects.filter(pk=reference.to_object_id).first()
+                if referenced is not None:
+                    targets.append(referenced)
+    added_media = add(targets)
+    # Wagtail images/documents always have a (non-nullable) collection; pull in any that
+    # aren't already present so the collection FK does not dangle.
+    add([media.collection for media in added_media if isinstance(media, media_models)])
+
+
+def serialize_plan(
+    plan: Plan,
+    *,
+    structure: CloneStructure = EXPORT_PLAN_STRUCTURE,
+    include_indicators: bool = True,
+    include_referenced_shared_objects: bool = False,
+    indent: int | None = 2,
+) -> str:
+    """
+    Serialize a single plan's data to a JSON string in Django's ``dumpdata`` format.
+
+    Natural foreign keys keep ``ContentType``/``Permission``/``Locale`` references portable
+    across databases where those primary keys differ.
+    """
+    instances = collect_export_instances(
+        plan,
+        structure=structure,
+        include_indicators=include_indicators,
+        include_referenced_shared_objects=include_referenced_shared_objects,
+    )
+    return serializers.serialize(
+        'json',
+        instances,
+        indent=indent,
+        use_natural_foreign_keys=True,
+    )
+
+
+def _referenced_persons(instances: list[Model]) -> Generator[Person]:
+    """Yield the distinct Person objects referenced by a foreign key on any collected instance."""
+    seen: set[object] = set()
+    for instance in instances:
+        for fk in get_foreign_keys(instance):
+            if fk.related_model is not Person:
+                continue
+            person = getattr(instance, fk.name)
+            if person is None or person.pk in seen:
+                continue
+            seen.add(person.pk)
+            yield person
+
+
+def build_media_manifest(instances: list[Model]) -> dict[str, list[str]]:
+    """
+    Build a manifest of object-storage keys for the media referenced by an export.
+
+    The JSON dump only references file paths; the binary files must be copied separately (e.g.
+    with ``rclone``). Returns lists of storage keys for images, documents and person avatars.
+    """
+    images = [i.file.name for i in instances if isinstance(i, AplansImage) and i.file and i.file.name]
+    documents = [d.file.name for d in instances if isinstance(d, AplansDocument) and d.file and d.file.name]
+    avatars = [person.image.name for person in _referenced_persons(instances) if person.image and person.image.name]
+    return {'images': images, 'documents': documents, 'avatars': avatars}

--- a/copying/main.py
+++ b/copying/main.py
@@ -441,7 +441,23 @@ def _get_attribute_types_for_copying(plan: Plan) -> list[AttributeType]:
     )
 
 
-def _iter_instances_for_unique_field_validation(plan: Plan, copy_indicators: bool) -> Generator[Model]:
+def iter_plan_owned_instances(
+    plan: Plan,
+    *,
+    plan_structure: CloneStructure = PLAN_CLONE_STRUCTURE,
+    include_indicators: bool = True,
+) -> Generator[Model]:
+    """
+    Yield every instance owned by the plan, deduplicated by (type, pk).
+
+    Walks `plan_structure` from the plan, then the GFK-scoped attribute types, and (when
+    `include_indicators` is true) the plan's indicators together with their dataset schemas
+    and dimensions.
+
+    The declarative clone structures are reused here as the definition of what belongs to a
+    plan. This is the shared traversal used both by copy's unique-field validation and by the
+    single-tenant export; the export passes its own `plan_structure` (see `copying.export`).
+    """
     seen: set[tuple[type[Model], Any]] = set()
 
     def yield_unseen(instances: Iterable[Model]) -> Generator[Model]:
@@ -452,10 +468,10 @@ def _iter_instances_for_unique_field_validation(plan: Plan, copy_indicators: boo
             seen.add(key)
             yield instance
 
-    yield from yield_unseen(_iter_clone_structure_instances(plan, PLAN_CLONE_STRUCTURE))
+    yield from yield_unseen(_iter_clone_structure_instances(plan, plan_structure))
     for attribute_type in _get_attribute_types_for_copying(plan):
         yield from yield_unseen(_iter_clone_structure_instances(attribute_type, ATTRIBUTE_TYPE_CLONE_STRUCTURE))
-    if not copy_indicators:
+    if not include_indicators:
         return
     for indicator in plan.indicators.all():
         yield from yield_unseen(_iter_clone_structure_instances(indicator, INDICATOR_CLONE_STRUCTURE))
@@ -474,7 +490,7 @@ def _validate_unique_field_copy_policies(plan: Plan, copy_indicators: bool) -> N
         )
 
     unsupported_fields = []
-    for instance in _iter_instances_for_unique_field_validation(plan, copy_indicators):
+    for instance in iter_plan_owned_instances(plan, include_indicators=copy_indicators):
         policies = UNIQUE_FIELD_COPY_POLICIES.get(type(instance), {})
         for field in _iter_unique_fields_requiring_copy_policy(type(instance)):
             if policies.get(field.name) != UNIQUE_FIELD_POLICY_UNSUPPORTED_IF_SET:

--- a/copying/management/commands/export_plan.py
+++ b/copying/management/commands/export_plan.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from django.core.management.base import BaseCommand, CommandError
+
+from actions.models.plan import Plan
+from copying.export import (
+    build_export_plan_structure,
+    build_media_manifest,
+    collect_export_instances,
+    serialize_plan,
+)
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+class Command(BaseCommand):
+    help = "Export a single plan's data as JSON (dumpdata format) for handing over to a tenant"
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument('identifier', help='Identifier of the plan to export')
+        parser.add_argument(
+            '--output',
+            help='Write the JSON dump to this file (default: stdout)',
+        )
+        parser.add_argument(
+            '--no-indicators',
+            action='store_false',
+            dest='include_indicators',
+            help="Do not export the plan's indicators, dimensions and dataset schemas",
+        )
+        parser.add_argument(
+            '--include-pledges',
+            action='store_true',
+            help='Include citizen pledge commitments (personal data)',
+        )
+        parser.add_argument(
+            '--include-feedback',
+            action='store_true',
+            help='Include user feedback and notification preferences (personal data)',
+        )
+        parser.add_argument(
+            '--include-audit-logs',
+            action='store_true',
+            help='Include plan-scoped audit log entries',
+        )
+        parser.add_argument(
+            '--include-referenced-shared-objects',
+            action='store_true',
+            help=(
+                'Also include a shallow copy of directly-referenced shared objects (organizations, persons, '
+                'common indicators, ...) so the dump is interpretable without a base install'
+            ),
+        )
+        parser.add_argument(
+            '--media-manifest',
+            help='Also write a JSON manifest of referenced media file keys (images, documents, avatars) to this file',
+        )
+
+    def handle(self, *args, **options) -> None:
+        try:
+            plan = Plan.objects.get(identifier=options['identifier'])
+        except Plan.DoesNotExist:
+            raise CommandError(f"No plan with identifier '{options['identifier']}' exists.") from None
+
+        structure = build_export_plan_structure(
+            include_pledges=options['include_pledges'],
+            include_feedback=options['include_feedback'],
+            include_audit_logs=options['include_audit_logs'],
+        )
+
+        data = serialize_plan(
+            plan,
+            structure=structure,
+            include_indicators=options['include_indicators'],
+            include_referenced_shared_objects=options['include_referenced_shared_objects'],
+        )
+
+        output_path = options['output']
+        if output_path:
+            Path(output_path).write_text(data)
+            self.stderr.write(self.style.SUCCESS(f'Wrote plan export to {output_path}'))
+        else:
+            self.stdout.write(data)
+
+        manifest_path = options['media_manifest']
+        if not manifest_path:
+            return
+        # Rebuild the instance list to derive the media manifest (cheap relative to serialization).
+        instances = collect_export_instances(
+            plan,
+            structure=structure,
+            include_indicators=options['include_indicators'],
+            include_referenced_shared_objects=options['include_referenced_shared_objects'],
+        )
+        manifest = build_media_manifest(instances)
+        Path(manifest_path).write_text(json.dumps(manifest, indent=2))
+        counts = ', '.join(f'{len(v)} {k}' for k, v in manifest.items())
+        self.stderr.write(self.style.SUCCESS(f'Wrote media manifest ({counts}) to {manifest_path}'))

--- a/copying/tests/test_export.py
+++ b/copying/tests/test_export.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from actions.models.plan import Plan
+from actions.tests.factories import ActionFactory, PlanFactory
+from copying.export import (
+    EXPORT_PLAN_STRUCTURE,
+    build_export_plan_structure,
+    build_media_manifest,
+    collect_export_instances,
+    serialize_plan,
+)
+from copying.tests.test_clone_structure_coverage import _check_coverage
+from images.tests.factories import AplansImageFactory
+
+
+class TestExportStructureCoverage:
+    def test_default_export_structure_coverage(self):
+        _check_coverage(Plan, EXPORT_PLAN_STRUCTURE, set())
+
+    def test_export_structure_with_all_flags_coverage(self):
+        structure = build_export_plan_structure(
+            include_pledges=True,
+            include_feedback=True,
+            include_audit_logs=True,
+        )
+        _check_coverage(Plan, structure, set())
+
+
+class TestExportStructureReclassification:
+    def test_reports_are_included(self):
+        assert EXPORT_PLAN_STRUCTURE['report_types'] == {'reports': {'action_snapshots': {}}}
+
+    def test_plan_links_are_included(self):
+        assert EXPORT_PLAN_STRUCTURE['links'] == {}
+
+    def test_domains_stay_excluded(self):
+        # Plan domains must stay out: hostname/base path are unique per plan.
+        from copying.main import Excluded
+
+        assert isinstance(EXPORT_PLAN_STRUCTURE['domains'], Excluded)
+
+    def test_pledges_and_feedback_are_gated(self):
+        from copying.main import Excluded
+
+        default = build_export_plan_structure()
+        default_pledges = default['pledges']
+        assert isinstance(default_pledges, dict)
+        assert isinstance(default['user_feedbacks'], Excluded)
+        assert isinstance(default_pledges['commitments'], Excluded)
+
+        opened = build_export_plan_structure(include_pledges=True, include_feedback=True)
+        opened_pledges = opened['pledges']
+        assert isinstance(opened_pledges, dict)
+        assert opened['user_feedbacks'] == {}
+        assert opened_pledges['commitments'] == {}
+
+
+@pytest.mark.django_db
+class TestTenantIsolation:
+    def test_export_contains_only_the_target_plans_objects(self):
+        plan_a = PlanFactory.create()
+        plan_b = PlanFactory.create()
+        action_a = ActionFactory.create(plan=plan_a)
+        action_b = ActionFactory.create(plan=plan_b)
+
+        records = json.loads(serialize_plan(plan_a))
+        keys = {(r['model'], r['pk']) for r in records}
+
+        assert ('actions.plan', plan_a.pk) in keys
+        assert ('actions.action', action_a.pk) in keys
+
+        # Nothing belonging to the other tenant may appear.
+        assert ('actions.plan', plan_b.pk) not in keys
+        assert ('actions.action', action_b.pk) not in keys
+
+    def test_no_other_plan_rows_leak_for_any_model(self):
+        plan_a = PlanFactory.create()
+        plan_b = PlanFactory.create()
+        ActionFactory.create(plan=plan_b)
+
+        records = json.loads(serialize_plan(plan_a))
+        exported_plan_pks = {r['pk'] for r in records if r['model'] == 'actions.plan'}
+        assert exported_plan_pks == {plan_a.pk}
+
+
+@pytest.mark.django_db
+class TestSerializePlan:
+    def test_output_is_valid_dumpdata_json(self):
+        plan = PlanFactory.create()
+        ActionFactory.create(plan=plan)
+
+        records = json.loads(serialize_plan(plan))
+        assert isinstance(records, list)
+        assert all({'model', 'pk', 'fields'} <= record.keys() for record in records)
+        assert any(r['model'] == 'actions.action' for r in records)
+
+    def test_pages_and_site_are_exported(self, plan_with_pages):
+        records = json.loads(serialize_plan(plan_with_pages))
+        models = {r['model'] for r in records}
+        # Multi-table inheritance: the base page row is always present.
+        assert 'wagtailcore.page' in models
+        assert 'wagtailcore.site' in models
+
+    def test_no_indicators_flag_drops_indicators(self, plan_with_pages):
+        from indicators.tests.factories import IndicatorFactory, IndicatorLevelFactory
+
+        indicator = IndicatorFactory.create(organization=plan_with_pages.organization)
+        IndicatorLevelFactory.create(plan=plan_with_pages, indicator=indicator)
+
+        with_indicators = json.loads(serialize_plan(plan_with_pages, include_indicators=True))
+        without_indicators = json.loads(serialize_plan(plan_with_pages, include_indicators=False))
+
+        assert any(r['model'] == 'indicators.indicator' for r in with_indicators)
+        assert not any(r['model'] == 'indicators.indicator' for r in without_indicators)
+
+
+@pytest.mark.django_db
+class TestMediaManifest:
+    def test_manifest_lists_plan_collection_images(self, plan_with_pages):
+        image = AplansImageFactory.create(collection=plan_with_pages.root_collection, title='exported')
+        instances = collect_export_instances(plan_with_pages)
+        manifest = build_media_manifest(instances)
+        assert image.file.name in manifest['images']
+
+
+@pytest.mark.django_db
+class TestReferencedIndicatorClosure:
+    def test_orphan_indicator_referenced_by_action_is_included(self):
+        from indicators.tests.factories import ActionIndicatorFactory, IndicatorFactory
+
+        plan = PlanFactory.create()
+        action = ActionFactory.create(plan=plan)
+        # An indicator with no IndicatorLevel belongs to no plan (orphan), but is referenced
+        # by an action in this plan.
+        orphan = IndicatorFactory.create()
+        ActionIndicatorFactory.create(action=action, indicator=orphan)
+
+        keys = {(r['model'], r['pk']) for r in json.loads(serialize_plan(plan))}
+        assert ('indicators.indicator', orphan.pk) in keys
+
+    def test_indicator_owned_by_another_plan_is_not_included(self):
+        from indicators.tests.factories import ActionIndicatorFactory, IndicatorFactory, IndicatorLevelFactory
+
+        plan_a = PlanFactory.create()
+        plan_b = PlanFactory.create()
+        action_a = ActionFactory.create(plan=plan_a)
+        indicator_b = IndicatorFactory.create()
+        IndicatorLevelFactory.create(plan=plan_b, indicator=indicator_b)  # now owned by plan B
+        ActionIndicatorFactory.create(action=action_a, indicator=indicator_b)
+
+        keys = {(r['model'], r['pk']) for r in json.loads(serialize_plan(plan_a))}
+        # Isolation: plan B's indicator must not ride along even though plan A's action references it.
+        assert ('indicators.indicator', indicator_b.pk) not in keys
+
+
+@pytest.mark.django_db
+class TestReferencedMedia:
+    def test_image_outside_plan_collection_is_included_via_reference(self, plan_with_pages):
+        from wagtail.models import Collection
+
+        from pages.tests.factories import StaticPageFactory
+
+        # An image that lives outside the plan's own collection, referenced by a page header.
+        other_collection = Collection.get_first_root_node()
+        image = AplansImageFactory.create(collection=other_collection, title='header')
+        StaticPageFactory.create(parent=plan_with_pages.root_page, header_image=image)
+
+        keys = {(r['model'], r['pk']) for r in json.loads(serialize_plan(plan_with_pages))}
+        assert ('images.aplansimage', image.pk) in keys
+
+
+@pytest.mark.django_db
+class TestSharedObjectClosure:
+    def test_org_ancestors_included_with_flag(self):
+        from orgs.tests.factories import OrganizationFactory
+
+        parent_org = OrganizationFactory.create()
+        child_org = OrganizationFactory.create(parent=parent_org)
+        plan = PlanFactory.create(organization=child_org)
+
+        with_shared = {
+            (r['model'], r['pk'])
+            for r in json.loads(serialize_plan(plan, include_referenced_shared_objects=True))
+        }
+        # The referenced org and its ancestor are both pulled in.
+        assert ('orgs.organization', child_org.pk) in with_shared
+        assert ('orgs.organization', parent_org.pk) in with_shared
+
+    def test_shared_objects_excluded_by_default(self):
+        from orgs.tests.factories import OrganizationFactory
+
+        org = OrganizationFactory.create()
+        plan = PlanFactory.create(organization=org)
+
+        default = {(r['model'], r['pk']) for r in json.loads(serialize_plan(plan))}
+        assert ('orgs.organization', org.pk) not in default
+
+    def test_shared_org_ancestor_is_visited_once(self):
+        from orgs.tests.factories import OrganizationFactory
+
+        # Two referenced orgs share a parent; the parent must be pulled in exactly once.
+        parent = OrganizationFactory.create()
+        child_a = OrganizationFactory.create(parent=parent)
+        child_b = OrganizationFactory.create(parent=parent)
+        plan = PlanFactory.create(organization=child_a)
+        ActionFactory.create(plan=plan, primary_org=child_b)
+
+        records = json.loads(serialize_plan(plan, include_referenced_shared_objects=True))
+        org_pks = [r['pk'] for r in records if r['model'] == 'orgs.organization']
+        assert org_pks.count(parent.pk) == 1
+        assert {child_a.pk, child_b.pk} <= set(org_pks)
+
+
+class TestExportStructureHelpers:
+    def test_set_rejects_descending_into_excluded_relation(self):
+        from copying.export import _deepcopy_structure, _set
+        from copying.main import PLAN_CLONE_STRUCTURE
+
+        structure = _deepcopy_structure(PLAN_CLONE_STRUCTURE)
+        # `domains` is EXCLUDED, so it cannot be descended into.
+        with pytest.raises(TypeError):
+            _set(structure, ['domains', 'anything'], {})
+
+    def test_set_rejects_unknown_relation(self):
+        from copying.export import _deepcopy_structure, _set
+        from copying.main import PLAN_CLONE_STRUCTURE
+
+        structure = _deepcopy_structure(PLAN_CLONE_STRUCTURE)
+        with pytest.raises(ValueError, match='is not a key'):
+            _set(structure, ['this_relation_does_not_exist'], {})
+
+
+@pytest.mark.django_db
+class TestCollectorEdgeCases:
+    def test_collection_and_media_collectors_handle_missing_root_collection(self):
+        from copying.export import iter_plan_collection_instances, iter_plan_media_instances
+
+        plan = PlanFactory.create()
+        plan.root_collection = None
+        assert list(iter_plan_collection_instances(plan)) == []
+        assert list(iter_plan_media_instances(plan)) == []
+
+    def test_relational_reference_targets_includes_generic_fk(self):
+        from actions.tests.factories import AttributeTypeFactory
+        from copying.export import _iter_relational_reference_targets
+
+        plan = PlanFactory.create()
+        # AttributeType.scope is a generic foreign key; here it points at the plan.
+        attribute_type = AttributeTypeFactory.create(scope=plan)
+        assert plan in list(_iter_relational_reference_targets(attribute_type))
+
+    def test_documentation_root_page_is_exported(self, plan_with_pages):
+        from wagtail.models import Page
+
+        from copying.export import iter_plan_page_instances
+        from documentation.models import DocumentationRootPage
+
+        global_root = Page.get_first_root_node()
+        assert global_root is not None
+        doc_root = DocumentationRootPage(title='Docs', plan=plan_with_pages, slug='docs-export')
+        global_root.add_child(instance=doc_root)
+
+        page_pks = {page.pk for page in iter_plan_page_instances(plan_with_pages)}
+        assert doc_root.pk in page_pks
+
+
+@pytest.mark.django_db
+class TestReferencedDimensionClosure:
+    def test_orphan_indicator_pulls_in_its_dataset_schema_and_dimensions(self):
+        from datasets.tests.factories import DatasetSchemaFactory
+        from indicators.tests.factories import (
+            ActionIndicatorFactory,
+            DimensionFactory,
+            IndicatorDimensionFactory,
+            IndicatorFactory,
+        )
+
+        plan = PlanFactory.create()
+        action = ActionFactory.create(plan=plan)
+        schema = DatasetSchemaFactory.create()
+        orphan = IndicatorFactory.create(dataset_schema=schema)
+        dimension = DimensionFactory.create()  # orphan dimension, not attached to any plan
+        IndicatorDimensionFactory.create(indicator=orphan, dimension=dimension)
+        ActionIndicatorFactory.create(action=action, indicator=orphan)
+
+        records = json.loads(serialize_plan(plan))
+        keys = {(r['model'], r['pk']) for r in records}
+        assert ('indicators.indicator', orphan.pk) in keys
+        # Closing over the referenced indicator drags in the dimension it uses ...
+        assert ('indicators.dimension', dimension.pk) in keys
+        # ... and its dataset schema.
+        assert any(r['model'].endswith('datasetschema') and r['pk'] == schema.pk for r in records)
+
+
+@pytest.mark.django_db
+class TestMediaViaReferenceIndex:
+    def test_image_embedded_in_rich_text_is_included(self, plan_with_pages):
+        from wagtail.models import Collection
+        from wagtail.models.reference_index import ReferenceIndex
+
+        action = ActionFactory.create(plan=plan_with_pages)
+        image = AplansImageFactory.create(collection=Collection.get_first_root_node(), title='embedded')
+        # An image embedded in rich text (tracked only by the ReferenceIndex, not a plain FK),
+        # living outside the plan's own collection.
+        action.description = (
+            f'<p data-block-key="k"><embed embedtype="image" format="fullwidth" id="{image.pk}" alt="x"/></p>'
+        )
+        action.save()
+        ReferenceIndex.create_or_update_for_object(action)
+
+        keys = {(r['model'], r['pk']) for r in json.loads(serialize_plan(plan_with_pages))}
+        assert ('images.aplansimage', image.pk) in keys
+
+
+@pytest.mark.django_db
+class TestReferencedPersonsManifest:
+    def test_manifest_yields_referenced_contact_persons(self, plan_with_pages):
+        from actions.tests.factories import ActionContactFactory
+        from people.tests.factories import PersonFactory
+
+        # The same person contacts two actions: the person-reference walk must yield them once
+        # (exercises both the yield and the already-seen dedup branch).
+        person = PersonFactory.create()
+        action_a = ActionFactory.create(plan=plan_with_pages)
+        action_b = ActionFactory.create(plan=plan_with_pages)
+        ActionContactFactory.create(action=action_a, person=person)
+        ActionContactFactory.create(action=action_b, person=person)
+
+        instances = collect_export_instances(plan_with_pages)
+        manifest = build_media_manifest(instances)
+        assert set(manifest) == {'images', 'documents', 'avatars'}
+
+
+@pytest.mark.django_db
+class TestExportPlanCommand:
+    def test_command_writes_json_and_media_manifest(self, plan_with_pages, tmp_path):
+        from django.core.management import call_command
+
+        ActionFactory.create(plan=plan_with_pages)
+        output = tmp_path / 'plan.json'
+        manifest = tmp_path / 'media.json'
+        call_command(
+            'export_plan',
+            plan_with_pages.identifier,
+            output=str(output),
+            media_manifest=str(manifest),
+        )
+        records = json.loads(output.read_text())
+        assert any(r['model'] == 'actions.plan' for r in records)
+        assert set(json.loads(manifest.read_text())) == {'images', 'documents', 'avatars'}
+
+    def test_command_errors_on_unknown_plan(self):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        with pytest.raises(CommandError):
+            call_command('export_plan', 'no-such-plan-identifier')

--- a/docs/architecture/single-tenant-export.md
+++ b/docs/architecture/single-tenant-export.md
@@ -1,0 +1,180 @@
+# Single-Tenant Data Export
+
+## Overview
+
+When a client ends their contract (or otherwise asks for their data), we need to hand
+them a self-contained dump of *their* plan and nothing belonging to any other tenant.
+The `export_plan` management command produces that dump as JSON in Django's standard
+serialization format — the same format `dumpdata` emits and `loaddata` consumes.
+
+The export is **non-destructive** and **read-only**: it does not touch the database, and
+it does not require making a throwaway copy of the whole database first.
+
+## Why not `destructively_trim_db` + `dumpdata`?
+
+The pre-existing way to produce a single-tenant dump is destructive: copy the entire
+database, run `destructively_trim_db --exclude-plan X --prune-shared-reference-data` to
+delete every other tenant, then `dumpdata` the survivors.
+
+That is a **denylist**: "delete everything that isn't this plan, and hope nothing leaks."
+It is fragile by construction. Deleting a plan leaves behind orphaned Wagtail page trees,
+`wagtail_localize` translation metadata (which carries the *source text* of deleted
+objects), and shared common-indicator library data — each of which had to be cleaned up
+by hand-written passes (see `delete_orphaned_plan_pages`, `delete_orphaned_translation_data`,
+and `prune_unused_common_indicators` in `actions/management/commands/destructively_trim_db.py`).
+Every new model or relation risks a new leak that the cleanup code has to catch up to.
+
+`export_plan` is instead an **allowlist**: it walks *only* the objects that provably
+belong to the plan and serializes those. Because it never visits another tenant's rows,
+it cannot leak them — the guarantee is structural, not the result of chasing orphans.
+
+## Reusing the `copying` app
+
+The `copying` app already solves the harder inverse problem — deep-cloning a plan into an
+independent copy — and in doing so it maintains a precise, declarative description of what
+belongs to a plan. The export reuses that description.
+
+The `copying` app has two separable halves:
+
+| Half | Symbols | Export reuses? |
+|------|---------|----------------|
+| **Scope definition + traversal** | `PLAN_CLONE_STRUCTURE` (and the `ATTRIBUTE_TYPE_`/`INDICATOR_`/`DIMENSION_`/`DATASET_SCHEMA_` structures), `visit_tree`, `iter_plan_owned_instances`, `ConfigurableRelationTree`/`RelationTreeIterator` (from the `relations_iterator` package) | **Yes** |
+| **Deep-copy + reference remapping** | `CloneVisitor`, `UpdateReferencesVisitor`, `UNIQUE_FIELD_COPY_POLICIES`, cycle-breaking, StreamField/rich-text reference rewriting | **No** |
+
+Everything that makes `copy_plan` complicated exists to produce an *independent* copy:
+remapping foreign keys to the cloned objects, regenerating unique values, breaking and
+restoring reference cycles. An export preserves primary keys verbatim, so there is nothing
+to remap, no unique constraints to juggle, and no cycles to break. We reuse the scope
+definition and the traversal engine, and discard the entire copy/remap machinery.
+
+### The clone structures
+
+`PLAN_CLONE_STRUCTURE` is a nested dict keyed by Django relation accessor names. A nested
+dict means "traverse into this relation"; the `EXCLUDED` sentinel means "stop here". The
+`relations_iterator` engine (`ConfigurableRelationTree` + `RelationTreeIterator`) walks the
+tree from a root instance and yields every reachable instance. `iter_plan_owned_instances`
+wraps this, deduplicating by `(type, pk)`, and additionally pulls in:
+
+- GFK-scoped **attribute types** (`_get_attribute_types_for_copying`), which aren't reachable
+  by accessor traversal because they use generic foreign keys;
+- **indicators** and their **dimensions**/**dataset schemas** (via the `INDICATOR_`,
+  `DIMENSION_`, `DATASET_SCHEMA_` structures).
+
+## Export scope differs from copy scope
+
+Many `EXCLUDED` entries in `PLAN_CLONE_STRUCTURE` are excluded **because they are hard to
+*remap* when copying**, not because they aren't plan-owned. For a PK-preserving export those
+should be re-included. The export therefore defines its own `EXPORT_PLAN_STRUCTURE`, derived
+from `PLAN_CLONE_STRUCTURE` with these reclassifications:
+
+| Relation | Excluded from copy because… | Export decision |
+|----------|------------------------------|-----------------|
+| `report_types.reports` | Action snapshots embed original PKs → remapping nightmare | **Include** — PKs preserved, snapshots stay valid |
+| `*changelogmessage*` | Not needed for a copy | **Include** (history) |
+| `pledges.commitments`, `pledges` | Depend on citizen approval | Include behind `--include-pledges` |
+| `user_feedbacks` | Not needed for a copy | Include behind `--include-feedback` |
+| `contact_persons.notification_preferences` | Personal runtime state | Include behind `--include-feedback` (PII-adjacent) |
+| `domains` | Hostname must be unique per plan | **Drop** (client provisions their own) |
+| `monitoring_quality_points` | Legacy | **Drop** |
+| `mcp_write_authorization_grants` | Our-side auth grants | **Drop** |
+| `children` / `superseded_plans` / `copies` | These are *other* plans | **Drop** (correct as-is) |
+| page relations (`category_pages`, `documentation_root_pages`, `level_layouts`, `actionlistpage`, site root tree) | Wagtail's `Page.copy` handles them | Handled separately (see below) |
+
+A **coverage test** asserts that every model reachable from a plan is either exported,
+gated behind a named flag, or listed in an explicit "intentionally dropped" set — so a
+future schema change fails loudly instead of silently under- or over-exporting.
+
+## Things the clone structures deliberately skip
+
+Copy delegates these to Wagtail / bespoke code rather than the relation tree; the export
+collects them as raw rows:
+
+- **Wagtail pages** — the plan's site root page plus all its translations and their
+  descendants, and every `DocumentationRootPage` tree. Pages use multi-table inheritance,
+  so each page contributes **two rows**: the base `wagtailcore.page` row and the
+  concrete-subclass row. Treebeard `path`/`depth` are ordinary columns, so tree ordering
+  survives serialization.
+- **Collections + media rows** — the plan's `root_collection` subtree, plus the
+  `AplansImage`/`AplansDocument` rows in those collections. The binary files live in object
+  storage; the JSON only references their paths. Use `--media-manifest` to also emit the
+  list of storage keys to ship alongside (logic shared with `migrate_s3_files.py`).
+- **Revisions / log entries** — dropped by default (clean-slate handoff, matching copy).
+
+## Reference-consistency closures (always on)
+
+The relation-tree traversal is keyed on plan *ownership*, but some exported rows reference
+plan-ownable objects that aren't formally owned by the plan. Left alone these become dangling
+foreign keys in the dump, so the export closes over them (independently of the shared-object
+question below):
+
+- **Referenced indicators (and their dimensions).** Exported `ActionIndicator` /
+  `IndicatorCategoryThrough` rows can point at indicators that aren't in `plan.indicators`
+  (e.g. an indicator attached to an action but never added to the plan — in practice these
+  are often orphaned indicators belonging to *no* plan). Those indicators are pulled in via
+  `INDICATOR_CLONE_STRUCTURE`, which drags in their values, which reference dimension
+  categories — so the referenced dimensions are closed over via `DIMENSION_CLONE_STRUCTURE`
+  too. This runs to a fixpoint. **Isolation guard:** an indicator or dimension owned by a
+  *different* plan is skipped, so only orphaned or this-plan objects are pulled in; the far
+  end of a genuine cross-tenant reference is intentionally left dangling rather than leaked.
+- **Referenced media.** Images/documents are otherwise collected by collection membership,
+  but pages and rich-text/StreamField bodies can reference media in *other* collections (a
+  page header image, an embedded image). Those are found via forward references **and
+  Wagtail's `ReferenceIndex`** (which is the only way to see references embedded in rich
+  text/StreamField), and their collection rows are pulled in so the collection FK resolves.
+
+## Referenced shared objects
+
+Models in `MODELS_NOT_COPIED` (`Organization`, `Person`, `User`, `Client`, `CommonIndicator`,
+`CommonCategory[Type]`, `Quantity`, `Unit`, `Locale`, `Group`, `ContentType`,
+`DatasetDimension`) are **referenced by primary key but not part of the plan**. The export
+leaves those references as PK / natural-key references in the output.
+
+The intended use is portability/archival — "hand the client their data" — not a guaranteed
+one-shot `loaddata` into a *completely empty* database. So the export does **not** compute a
+full transitive closure over global models.
+
+For readability, `--include-referenced-shared-objects` does a **one-level** pull of the shared
+rows directly referenced by the plan-owned set (via FK, generic FK or M2M) so org/person/
+indicator names are present rather than bare PKs. It does not follow those objects' own
+relations — that is what would drag another tenant's data in — **with one deliberate
+exception: `Organization` ancestors are followed transitively**, so the org hierarchy isn't
+truncated to just the referenced nodes. Off by default.
+
+Note that even with the flag on, a few second-order references remain external by design:
+`auth.Permission` (referenced from the pulled-in `Group`s; a framework table present in every
+Django database and serialized by natural key), and the avatars/logos/pages hanging off the
+pulled-in shared objects (not followed, per the one-level rule).
+
+## Serialization
+
+`django.core.serializers.serialize('json', instances, indent=2, use_natural_foreign_keys=True)`
+— the same machinery `dumpdata` uses. Natural foreign keys keep `ContentType`/`Permission`
+references portable across databases where those PKs differ. `loaddata` loads within a single
+transaction with deferred constraint checking, so cross-FK ordering is largely a non-issue;
+the one thing to get right is emitting both the base and concrete rows for MTI pages.
+
+## Usage
+
+```
+python manage.py export_plan <identifier> \
+    [--output plan.json] \
+    [--no-indicators] \
+    [--include-pledges] \
+    [--include-feedback] \
+    [--include-referenced-shared-objects] \
+    [--include-audit-logs] \
+    [--media-manifest media.json]
+```
+
+Defaults: plan content + staff contacts + pages + collections/media rows + reports +
+change-log history; citizen pledges, user feedback, notification preferences, revisions,
+and audit logs are excluded unless their flag is given.
+
+## Code layout
+
+- `copying/main.py` — existing clone structures and `iter_plan_owned_instances` (reused).
+- `copying/export.py` — `EXPORT_PLAN_STRUCTURE`, page/collection/media collectors, the
+  reference-consistency closures (referenced indicators/dimensions, referenced media), the
+  shared-object pull, and the serializer.
+- `copying/management/commands/export_plan.py` — the command.
+- `copying/tests/test_export.py` — coverage, tenant-isolation, and round-trip tests.


### PR DESCRIPTION
Add an `export_plan` management command that exports one plan's data as dumpdata-format JSON for handing over to a tenant. Unlike the destructive `destructively_trim_db` + dumpdata approach (a denylist that must chase orphaned data to avoid leaking other tenants), this is an allowlist: it reuses the copying app's declarative clone structures to collect only plan-owned objects, so it cannot leak another tenant's rows by construction.

- Extract `iter_plan_owned_instances` from the copy unique-field validation helper so both copy and export share the plan-ownership traversal.
- `copying/export.py`: derive EXPORT_PLAN_STRUCTURE from PLAN_CLONE_STRUCTURE (re-including reports/links/change-logs that copy drops only to avoid reference remapping; PII gated behind flags); collect the Wagtail site, collection, page (MTI base + concrete rows) and media rows the clone structures skip; serialize with natural foreign keys.
- Close over reference-consistency gaps so the dump has no dangling FKs: indicators referenced by exported rows but not in plan.indicators (and the dimensions their values need), and images/documents referenced by pages or rich text (via FK and Wagtail ReferenceIndex) that live outside the plan's collections. Indicators/dimensions owned by another plan are skipped to preserve tenant isolation.
- --include-referenced-shared-objects opt-in does a one-level pull of referenced shared objects (orgs, persons, ...), following Organization ancestors transitively so the org tree isn't truncated.
- Add coverage, tenant-isolation, closure and round-trip tests, plus an architecture doc.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Manually tested locally** (functionality verified)