### PR TITLE
Clean up orphaned data in destructively_trim_db for single-tenant exports

### DIFF
--- a/actions/management/commands/destructively_trim_db.py
+++ b/actions/management/commands/destructively_trim_db.py
@@ -28,6 +28,8 @@ from request_log.models import LoggedRequest
 from users.models import User
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from django.db.models import Field, Model
 
     from orgs.models import OrganizationQuerySet
@@ -61,6 +63,14 @@ class Command(BaseCommand):
             help='Do not ask for confirmation but delete right away',
         )
         parser.add_argument('--thorough', action='store_true', help='Delete more data, including revision history and audit logs')
+        parser.add_argument(
+            '--prune-shared-reference-data',
+            action='store_true',
+            help=(
+                'Also delete shared common-indicator framework data (common indicators, frameworks and their '
+                'relations) that is not linked to any retained plan. Useful for producing a single-tenant export.'
+            ),
+        )
 
     def _validate_exclusions(self, options) -> None:
         # Validate every --exclude-* argument up front, so a typo can't silently fail open and
@@ -100,6 +110,49 @@ class Command(BaseCommand):
             orgs_to_keep |= Organization.objects.filter(uuid__in=exclude_organization)
         return orgs_to_keep
 
+    def _print_orgs_to_delete(self, orgs_to_delete: OrganizationQuerySet) -> None:
+        num_delete_suborgs = {}
+        for org in orgs_to_delete.filter(depth=1):
+            # Unnecessarily inefficient, but what the hell...
+            num_delete_suborgs[org] = orgs_to_delete.filter(id__in=org.get_descendants()).count()
+        if not num_delete_suborgs:
+            return
+        strings = []
+        for org, n in num_delete_suborgs.items():
+            string = org.name
+            if n == 1:
+                string += ' (and 1 suborganization)'
+            elif n > 1:
+                string += f' (and {n} suborganizations)'
+            strings.append(string)
+        self.stdout.write(f'The following organizations will be deleted: {", ".join(strings)}')
+
+    def _print_additional_deletions(self, options) -> None:
+        self.stdout.write('Moreover, the following data will be deleted:')
+        self.stdout.write("- all User instances that don't have a corresponding Person anymore")
+        client_message = "- all Client instances that don't have a corresponding Plan anymore"
+        if options['exclude_client']:
+            client_names = Client.objects.filter(id__in=options['exclude_client']).values_list('name', flat=True)
+            client_message += f' and are not among the following: {", ".join(client_names)}'
+        self.stdout.write(client_message)
+        if options['thorough']:
+            self.stdout.write('- all Reversion Revision instances')
+            self.stdout.write('- all Wagtail Revision instances')
+            self.stdout.write('- all Wagtail ModelLogEntry instances')
+            self.stdout.write('- all plan-scoped model/page log entries')
+            self.stdout.write('- all Wagtail PageLogEntry instances')
+        else:
+            self.stdout.write('- all Wagtail Revision instances whose target object no longer exists')
+            self.stdout.write('- all Wagtail ModelLogEntry instances whose target object no longer exists')
+            self.stdout.write('- all Wagtail PageLogEntry instances whose target page no longer exists')
+        self.stdout.write('- all logged requests')
+        self.stdout.write('- all thumbnails')
+        self.stdout.write('- all sessions')
+        self.stdout.write('- all plan page trees (and their sites) left orphaned by deleted plans')
+        self.stdout.write('- all wagtail_localize translation data whose translated object no longer exists')
+        if options['prune_shared_reference_data']:
+            self.stdout.write('- all common indicators (and their frameworks/relations) not linked to a retained plan')
+
     def handle(self, *args, **options):
         if not settings.DEBUG or settings.DEPLOYMENT_TYPE == 'production':
             raise CommandError(
@@ -120,45 +173,9 @@ class Command(BaseCommand):
         # Determine organizations to delete
         orgs_to_keep = self._organizations_to_keep(plans_to_keep, options.get('exclude_organization'))
         orgs_to_delete = Organization.objects.qs.exclude(id__in=orgs_to_keep)
-        num_delete_suborgs = {}
-        for org in orgs_to_delete.filter(depth=1):
-            # Unnecessarily inefficient, but what the hell...
-            num_delete_suborgs[org] = orgs_to_delete.filter(id__in=org.get_descendants()).count()
-        if num_delete_suborgs:
-            strings = []
-            for org, n in num_delete_suborgs.items():
-                string = org.name
-                if n == 1:
-                    string += ' (and 1 suborganization)'
-                elif n > 1:
-                    string += f' (and {n} suborganizations)'
-                strings.append(string)
-            self.stdout.write(f'The following organizations will be deleted: {", ".join(strings)}')
+        self._print_orgs_to_delete(orgs_to_delete)
 
-        self.stdout.write('Moreover, the following data will be deleted:')
-        self.stdout.write("- all User instances that don't have a corresponding Person anymore")
-        client_message = "- all Client instances that don't have a corresponding Plan anymore"
-        if options['exclude_client']:
-            client_names = Client.objects.filter(id__in=options['exclude_client']).values_list('name', flat=True)
-            client_message += f' and are not among the following: {", ".join(client_names)}'
-        self.stdout.write(client_message)
-        if options['thorough']:
-            self.stdout.write('- all Reversion Revision instances')
-            self.stdout.write('- all Wagtail Revision instances')
-            self.stdout.write('- all Wagtail ModelLogEntry instances')
-            self.stdout.write('- all plan-scoped model/page log entries')
-            self.stdout.write('- all Wagtail PageLogEntry instances')
-        else:
-            self.stdout.write('- all Wagtail Revision instances whose target object no longer exists')
-            self.stdout.write('- all Wagtail ModelLogEntry instances whose target object no longer exists')
-            self.stdout.write('- all Wagtail PageLogEntry instances whose target page no longer exists')
-        self.stdout.write('- all logged requests')
-        # if not options['keep_page_log']:
-        #     self.stdout.write("- all entries of Wagtail's page log")
-        # if not options['keep_model_log']:
-        #     self.stdout.write("- all entries of Wagtail's model log")
-        self.stdout.write('- all thumbnails')
-        self.stdout.write('- all sessions')
+        self._print_additional_deletions(options)
         if not options['no_confirm']:
             confirmation = input('Do you want to proceed? [y/N] ').lower()
             if confirmation != 'y':
@@ -170,6 +187,7 @@ class Command(BaseCommand):
                 orgs_to_delete,
                 clients_to_keep=options['exclude_client'],
                 thorough=options['thorough'],
+                prune_shared_reference_data=options['prune_shared_reference_data'],
             )
         self.stdout.write("Rebuilding Wagtail's reference index...")
         call_command('rebuild_references_index')
@@ -201,11 +219,7 @@ class Command(BaseCommand):
         aggregated: dict[str, int] = {}
 
         for content_type_id in content_type_ids:
-            target = (
-                ContentType.objects.get_for_id(content_type_id).model_class()
-                if content_type_id is not None
-                else None
-            )
+            target = ContentType.objects.get_for_id(content_type_id).model_class() if content_type_id is not None else None
             queryset = model._default_manager.filter(content_type_id=content_type_id)
             if target is None:
                 # Stale content type (model removed from the codebase): the object cannot exist.
@@ -215,9 +229,7 @@ class Command(BaseCommand):
                     pk=Cast(OuterRef('object_id'), output_field=self._get_object_id_cast_field(target))
                 )
                 _, by_type = (
-                    queryset.annotate(has_live_object=Exists(existing_object_subquery))
-                    .filter(has_live_object=False)
-                    .delete()
+                    queryset.annotate(has_live_object=Exists(existing_object_subquery)).filter(has_live_object=False).delete()
                 )
             for model_name, n in by_type.items():
                 aggregated[model_name] = aggregated.get(model_name, 0) + n
@@ -230,9 +242,7 @@ class Command(BaseCommand):
         # delete_entries_for_missing_objects: drop entries for pages that no longer exist
         # (regardless of author), keep entries for surviving pages.
         live_pages = Page.objects.filter(pk=OuterRef('page_id'))
-        _, by_type = (
-            PageLogEntry.objects.annotate(has_live_page=Exists(live_pages)).filter(has_live_page=False).delete()
-        )
+        _, by_type = PageLogEntry.objects.annotate(has_live_page=Exists(live_pages)).filter(has_live_page=False).delete()
         self.print_deleted_instances_by_model(by_type)
 
     def delete_thoroughly(self):
@@ -282,6 +292,7 @@ class Command(BaseCommand):
         orgs_to_delete,
         clients_to_keep: list[int] | None = None,
         thorough: bool = False,
+        prune_shared_reference_data: bool = False,
     ):
         if clients_to_keep is None:
             clients_to_keep = []
@@ -292,6 +303,10 @@ class Command(BaseCommand):
         for plan in plans_to_delete:
             plan.delete()
             self.stdout.write(f'Deleted plan {plan.identifier}; information on deleted related rows not available.')
+        # Delete plan page trees left orphaned by deleted plans (e.g. translated locale trees that
+        # Plan.delete()'s bulk page deletion misses). Runs after plans are gone, so the retained set
+        # is accurate, and before the orphan cleanups below, which then handle the cascaded pages.
+        self.delete_orphaned_plan_pages()
         # Delete organizations
         num_orgs = orgs_to_delete.count()
         orgs_to_delete.delete()
@@ -303,6 +318,12 @@ class Command(BaseCommand):
         # Delete clients without plans unless excluded
         _, by_type = Client.objects.filter(plans__isnull=True).exclude(id__in=clients_to_keep).delete()
         self.print_deleted_instances_by_model(by_type)
+        # Prune shared common-indicator framework data not linked to a retained plan. Runs after
+        # plans and organizations (and therefore their indicators) are gone, so the "still in use"
+        # check below sees only retained data. Must run before delete_orphaned_translation_data() so
+        # any translation data left behind by the pruned rows is cleaned up in the same run.
+        if prune_shared_reference_data:
+            self.prune_unused_common_indicators()
         # Reversion cleanup is intentionally omitted here — thorough mode handles it with a full purge.
         # Delete Wagtail revisions for objects that no longer exist (regardless of author), then
         # repair the draft-state invariant on any kept page whose latest_revision was affected.
@@ -311,6 +332,9 @@ class Command(BaseCommand):
         # Delete Wagtail model/page log entries for objects that no longer exist
         self.delete_entries_for_missing_objects(ModelLogEntry)
         self.delete_page_log_entries_for_missing_pages()
+        # Delete wagtail_localize translation data for objects that no longer exist. Its own
+        # post_delete cleanup was muted during deletion (see handle()), so it must be done here.
+        self.delete_orphaned_translation_data()
         # Delete all logged requests
         self.delete_all(LoggedRequest)
         # Delete thumbnails
@@ -325,6 +349,146 @@ class Command(BaseCommand):
 
         if thorough:
             self.delete_thoroughly()
+
+    def delete_orphaned_plan_pages(self) -> None:
+        """
+        Delete Wagtail page trees of plans that no longer exist.
+
+        Plan.delete() removes a plan's own-locale page tree, but a deleted plan can leave orphaned
+        PlanRootPage subtrees behind — most notably its translated locale trees — together with
+        their Sites. These carry the deleted plan's (translated) content, so retaining them would
+        leak it into an export. Delete every plan root page, in any locale, that does not belong to
+        a retained plan; the instance-level delete() cascades the descendant subtree and the root
+        page's Site (unlike the bulk queryset delete in Plan.delete()).
+        """
+        from pages.models import PlanRootPage
+
+        keep_root_ids: set[int] = set()
+        for plan in Plan.objects.qs.all():
+            if plan.site_id is None:
+                continue
+            keep_root_ids.update(plan.root_page.get_translations(inclusive=True).values_list('id', flat=True))
+            keep_root_ids.update(plan.documentation_root_pages.values_list('id', flat=True))
+
+        orphan_roots = PlanRootPage.objects.exclude(id__in=keep_root_ids)
+        count = 0
+        for root in orphan_roots:
+            root.delete()
+            count += 1
+        if not count:
+            self.stdout.write('No orphaned plan pages found.')
+            return
+        self.stdout.write(f'Deleted {count} orphaned plan root page(s), including their page subtrees and sites.')
+
+    def delete_orphaned_translation_data(self) -> None:
+        """
+        Delete wagtail_localize translation data whose translated object no longer exists.
+
+        wagtail_localize normally garbage-collects this data via a `post_delete` handler
+        (`cleanup_translation_on_delete`), but the whole trim runs inside
+        `factory.django.mute_signals(post_delete, post_save)`, so that handler never fires and the
+        translation metadata for deleted pages/snippets is left behind. Since it carries the source
+        text of the deleted objects, retaining it would leak other plans' content into any export.
+        This mirrors that handler's cleanup, applied to every orphaned TranslatableObject at once.
+        """
+        try:
+            from wagtail_localize.models import (
+                OverridableSegment,
+                RelatedObjectSegment,
+                SegmentOverride,
+                String,
+                StringSegment,
+                StringTranslation,
+                Template,
+                TemplateSegment,
+                TranslatableObject,
+            )
+        except ImportError:
+            return
+
+        # A TranslatableObject is orphaned when no live instance shares its translation_key for the
+        # object's content type. Collect the orphaned translation_keys per content type.
+        orphan_keys: list[UUID] = []
+        content_type_ids = list(TranslatableObject.objects.values_list('content_type_id', flat=True).distinct())
+        for content_type_id in content_type_ids:
+            model = ContentType.objects.get_for_id(content_type_id).model_class()
+            keys = TranslatableObject.objects.filter(content_type_id=content_type_id).values_list(
+                'translation_key',
+                flat=True,
+            )
+            if model is None:
+                # Stale content type (model removed from the codebase): the object cannot exist.
+                orphan_keys.extend(keys)
+                continue
+            live_keys = set(model._default_manager.values_list('translation_key', flat=True))
+            orphan_keys.extend(key for key in keys if key not in live_keys)
+
+        aggregated: dict[str, int] = {}
+
+        def accumulate(by_type: dict[str, int]) -> None:
+            for model_name, n in by_type.items():
+                aggregated[model_name] = aggregated.get(model_name, 0) + n
+
+        if orphan_keys:
+            # Segments must be deleted before their TranslatableObject because BaseSegment.context is
+            # on_delete=PROTECT (same ordering as wagtail_localize's own cleanup_translation_on_delete).
+            for model in (OverridableSegment, RelatedObjectSegment, StringSegment, TemplateSegment):
+                _, by_type = model.objects.filter(context__object_id__in=orphan_keys).delete()
+                accumulate(by_type)
+            for model in (SegmentOverride, StringTranslation):
+                _, by_type = model.objects.filter(context__object_id__in=orphan_keys).delete()
+                accumulate(by_type)
+            # Cascades to TranslationSource, Translation, TranslationLog and TranslationContext.
+            _, by_type = TranslatableObject.objects.filter(translation_key__in=orphan_keys).delete()
+            accumulate(by_type)
+
+        # Source strings and templates are deduplicated globally, so deleting orphaned sources leaves
+        # them behind once no surviving segment references them. Dropping a String cascades to its
+        # StringTranslations, so this also removes orphaned translated text.
+        _, by_type = String.objects.filter(segments__isnull=True).delete()
+        accumulate(by_type)
+        _, by_type = Template.objects.filter(segments__isnull=True).delete()
+        accumulate(by_type)
+        # Overrides/translations whose context was SET_NULL by an earlier deletion are orphans too.
+        _, by_type = SegmentOverride.objects.filter(context__isnull=True).delete()
+        accumulate(by_type)
+        _, by_type = StringTranslation.objects.filter(context__isnull=True).delete()
+        accumulate(by_type)
+
+        if not aggregated:
+            self.stdout.write('No orphaned translation data found.')
+            return
+        self.print_deleted_instances_by_model(aggregated)
+
+    def prune_unused_common_indicators(self) -> None:
+        """
+        Delete shared common-indicator framework data not linked to any retained plan.
+
+        Common indicators, their frameworks and relations are shared reference data that is not
+        scoped to a plan, so a plan trim leaves the whole library behind. Keep only common
+        indicators still linked to a retained plan (via PlanCommonIndicator) or referenced by a
+        surviving Indicator (Indicator.common is on_delete=PROTECT, so those must be kept), delete
+        the rest, then drop frameworks that end up with no common indicators.
+        """
+        from django.db.models import Q
+
+        from indicators.models.common_indicator import CommonIndicator
+        from indicators.models.metadata import Framework
+
+        keep_ids = set(
+            CommonIndicator.objects
+            .filter(Q(plans__isnull=False) | Q(indicators__isnull=False))
+            .values_list('id', flat=True)
+            .distinct()
+        )
+        # Deleting a CommonIndicator cascades to FrameworkIndicator, PlanCommonIndicator,
+        # RelatedCommonIndicator, CommonIndicatorNormalizator and CommonIndicatorDimension.
+        _, by_type = CommonIndicator.objects.exclude(id__in=keep_ids).delete()
+        self.print_deleted_instances_by_model(by_type)
+        # Frameworks are only referenced through FrameworkIndicator (no plan FK), so any framework
+        # left without common indicators is now unreferenced.
+        _, by_type = Framework.objects.filter(common_indicators__isnull=True).delete()
+        self.print_deleted_instances_by_model(by_type)
 
     def print_deleted_instances_by_model(self, by_type):
         for model_name, n in by_type.items():

--- a/actions/tests/test_destructively_trim_db.py
+++ b/actions/tests/test_destructively_trim_db.py
@@ -1,12 +1,20 @@
 from unittest.mock import call, patch
 
+from django.db.models.signals import post_delete, post_save
 from reversion.models import Revision as ReversionRevision
-from wagtail.models import Revision
+from wagtail.models import Revision, Site
 
+import factory
 import pytest
+from wagtail_localize.models import String, TranslatableObject, TranslationSource
 
 from actions.management.commands.destructively_trim_db import Command
-from actions.tests.factories import ActionFactory
+from actions.models import Plan
+from actions.tests.factories import ActionFactory, PlanFactory
+from indicators.models.common_indicator import CommonIndicator, FrameworkIndicator, PlanCommonIndicator
+from indicators.models.metadata import Framework
+from indicators.tests.factories import CommonIndicatorFactory, IndicatorFactory
+from pages.models import PlanRootPage
 from pages.tests.factories import CategoryTypePageFactory, StaticPageFactory
 
 pytestmark = pytest.mark.django_db
@@ -61,6 +69,91 @@ def test_delete_missing_object_wagtail_revisions_handles_multi_table_page_subcla
     page.refresh_from_db()
     assert page.latest_revision_id == revision.id
     assert Revision.objects.filter(id=revision.id).exists()
+
+
+def test_delete_orphaned_translation_data_keeps_live_objects(plan_with_pages):
+    page = StaticPageFactory.create(parent=plan_with_pages.root_page)
+    TranslationSource.update_or_create_from_instance(page)
+    assert TranslatableObject.objects.filter(translation_key=page.translation_key).exists()
+
+    Command().delete_orphaned_translation_data()
+
+    assert TranslatableObject.objects.filter(translation_key=page.translation_key).exists()
+    assert TranslationSource.objects.filter(object_id=page.translation_key).exists()
+
+
+def test_delete_orphaned_translation_data_deletes_orphans(plan_with_pages):
+    page = StaticPageFactory.create(parent=plan_with_pages.root_page)
+    TranslationSource.update_or_create_from_instance(page)
+    translation_key = page.translation_key
+    string_count = String.objects.count()
+    assert string_count > 0
+
+    # Delete the page with signals muted, exactly as the trim command does. This suppresses
+    # wagtail_localize's own post_delete cleanup, leaving the translation data orphaned.
+    with factory.django.mute_signals(post_delete):
+        page.delete()
+    assert TranslatableObject.objects.filter(translation_key=translation_key).exists()
+
+    Command().delete_orphaned_translation_data()
+
+    assert not TranslatableObject.objects.filter(translation_key=translation_key).exists()
+    assert not TranslationSource.objects.filter(object_id=translation_key).exists()
+    # The deleted page's strings are gone (count dropped), and no orphaned strings are left behind;
+    # strings still referenced by other, live pages are kept.
+    assert String.objects.count() < string_count
+    assert not String.objects.filter(segments__isnull=True).exists()
+
+
+def test_delete_orphaned_plan_pages(plan_with_pages):
+    from audit_logging.models import PlanScopedModelLogEntry, PlanScopedPageLogEntry
+
+    kept_root_id = plan_with_pages.root_page.id
+
+    orphan_plan = PlanFactory.create()
+    with factory.django.mute_signals(post_save):
+        orphan_plan.create_default_site()
+        orphan_plan.save()
+    orphan_root_id = orphan_plan.root_page.id
+    orphan_site_id = orphan_plan.site_id
+    assert orphan_site_id is not None
+
+    # Simulate a plan whose page tree was left behind. Clear the PROTECT-ed log entries first (as
+    # Plan.delete() itself does), then bulk-delete the Plan row so its override's page cleanup is
+    # bypassed and the PlanRootPage subtree and Site survive, as translated locale trees do in
+    # practice.
+    PlanScopedPageLogEntry.objects.filter(plan=orphan_plan).delete()
+    PlanScopedModelLogEntry.objects.filter(plan=orphan_plan).delete()
+    Plan.objects.filter(pk=orphan_plan.pk).delete()
+    assert PlanRootPage.objects.filter(id=orphan_root_id).exists()
+
+    Command().delete_orphaned_plan_pages()
+
+    assert not PlanRootPage.objects.filter(id=orphan_root_id).exists()
+    assert not Site.objects.filter(id=orphan_site_id).exists()
+    assert PlanRootPage.objects.filter(id=kept_root_id).exists()
+
+
+def test_prune_unused_common_indicators():
+    # Kept: referenced by a surviving indicator (Indicator.common is on_delete=PROTECT).
+    indicator = IndicatorFactory.create()
+    assert indicator.common is not None
+    used_by_indicator = indicator.common
+    # Kept: linked to a retained plan.
+    plan = PlanFactory.create()
+    used_by_plan = CommonIndicatorFactory.create()
+    PlanCommonIndicator.objects.create(common_indicator=used_by_plan, plan=plan)
+    # Deleted: not linked to any plan or indicator; leaves its framework empty.
+    framework = Framework.objects.create(identifier='fw', name='Framework')
+    unused = CommonIndicatorFactory.create()
+    FrameworkIndicator.objects.create(common_indicator=unused, framework=framework, identifier='fi')
+
+    Command().prune_unused_common_indicators()
+
+    assert CommonIndicator.objects.filter(pk=used_by_indicator.pk).exists()
+    assert CommonIndicator.objects.filter(pk=used_by_plan.pk).exists()
+    assert not CommonIndicator.objects.filter(pk=unused.pk).exists()
+    assert not Framework.objects.filter(pk=framework.pk).exists()
 
 
 def test_delete_thoroughly_deletes_all_revision_history():


### PR DESCRIPTION
Trimming the DB to a single plan and running dumpdata left behind data that is not scoped to the retained plan, leaking other clients' content into the export. Add three cleanups to the trim command:

- delete_orphaned_translation_data() (always): sweep wagtail_localize rows whose translated object no longer exists. The trim deletes inside mute_signals(post_delete), which suppresses wagtail_localize's own cleanup_translation_on_delete handler, so this mirrors it after the fact.
- delete_orphaned_plan_pages() (always): delete PlanRootPage trees (any locale) and their Sites not belonging to a retained plan. Plan.delete() uses a bulk PageQuerySet.delete() that leaves a deleted plan's translated locale-tree pages (and Site) behind as live orphans.
- prune_unused_common_indicators() (behind --prune-shared-reference-data): delete common indicators not linked to a retained plan or a surviving indicator, then empty frameworks.

Extract the deletion-summary printing into helpers to keep handle() under the complexity limits.

While this removes some data that should not be in single-tenant exports, it is not sufficient. When I tested this with a churned client's data, there were still several records included that belonged to some other tenant for one reason or another. For cases like this, where we hand off data to customers, we need to be extra sure that we do not include data from other customers. A destructively_trim_db -> dumpdata approach seems to risky to me. Therefore, for data hand-off cases like this, I decided to go with a constructive approach that reuses some code from the copying app in order to only export data that is in fact reachable from the tenant's plan. There is a different PR for this: https://github.com/kausaltech/kausal-watch/pull/632

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [x] **Manually tested locally** (functionality verified)