### PR TITLE
Fix unpublished plan visibility resolution

### DIFF
--- a/actions/models/plan.py
+++ b/actions/models/plan.py
@@ -1093,8 +1093,6 @@ class Plan(ClusterableModel, ModelWithPrimaryLanguage, PermissionedModel, Search
 
     def is_visible_for_user(self, user: UserOrAnon | None) -> bool:
         """Use permission policy to check visibility."""
-        if self.features.expose_unpublished_plan_only_to_authenticated_user is False:
-            return True
         if user is None:  # TODO: remove this once all places where None is used are fixed
             user = AnonymousUser()
         return self.permission_policy().user_has_permission_for_instance(user, 'view', self)

--- a/actions/permission_policy.py
+++ b/actions/permission_policy.py
@@ -5,10 +5,10 @@ import typing
 from django.db.models import Q
 from django.utils import timezone
 
-from kausal_common.models.permission_policy import ModelPermissionPolicy
+from kausal_common.models.permission_policy import ModelPermissionPolicy, PermissionBlock
 
 if typing.TYPE_CHECKING:
-    from kausal_common.models.permission_policy import ObjectSpecificAction
+    from kausal_common.models.permission_policy import BaseObjectAction, ObjectSpecificAction
 
     from actions.models import Plan
     from actions.models.plan import PlanQuerySet  # noqa: F401
@@ -16,18 +16,33 @@ if typing.TYPE_CHECKING:
 
 
 class PlanPermissionPolicy(ModelPermissionPolicy['Plan', None, 'PlanQuerySet']):
+    def get_permission_block(
+        self,
+        action: BaseObjectAction,
+        *,
+        obj: Plan | None = None,
+        context: None = None,
+    ) -> PermissionBlock | None:
+        if action == 'view' and obj is not None and not obj.is_active:
+            return PermissionBlock('Inactive plans are not visible', code='plan_inactive')
+        return super().get_permission_block(action, obj=obj, context=context)
+
+    def construct_state_perm_q(self, action: ObjectSpecificAction) -> Q:
+        if action == 'view':
+            return Q(is_active=True)
+        return Q()
+
     def construct_perm_q_anon(self, action: ObjectSpecificAction) -> Q | None:
         """
         Construct permission query for anonymous users.
 
         Allow viewing of plans if the expose_unpublished_plan_only_to_authenticated_user flag is False.
         If the expose_unpublished_plan_only_to_authenticated_user flag is True, only allow viewing of published plans.
-        Inactive plans are never visible to anonymous users.
         """
         if action == 'view':
-            return Q(is_active=True) & (
-                Q(features__expose_unpublished_plan_only_to_authenticated_user=False)
-                | Q(published_at__isnull=False, published_at__lte=timezone.now())
+            return Q(features__expose_unpublished_plan_only_to_authenticated_user=False) | Q(
+                published_at__isnull=False,
+                published_at__lte=timezone.now(),
             )
         return None
 
@@ -35,19 +50,16 @@ class PlanPermissionPolicy(ModelPermissionPolicy['Plan', None, 'PlanQuerySet']):
         """
         Construct permission query for authenticated users.
 
-        Only superusers can see inactive plans. For non-superusers, inactive plans
-        are excluded from both admin and public-facing access.
+        Inactive plans are excluded by the state-level permission filter.
         """
         if action == 'view':
             # get_adminable_plans() already filters out inactive plans for non-superusers,
             # and get_viewable_plans() also excludes inactive plans.
             viewable_plans = user.get_adminable_plans().union(user.get_viewable_plans()).values_list('id', flat=True)
-            return Q(id__in=viewable_plans) | (
-                Q(is_active=True)
-                & (
-                    Q(published_at__isnull=False, published_at__lte=timezone.now())
-                    | Q(features__expose_unpublished_plan_only_to_authenticated_user=False)
-                )
+            return (
+                Q(id__in=viewable_plans)
+                | Q(published_at__isnull=False, published_at__lte=timezone.now())
+                | Q(features__expose_unpublished_plan_only_to_authenticated_user=False)
             )
         return None
 
@@ -55,7 +67,7 @@ class PlanPermissionPolicy(ModelPermissionPolicy['Plan', None, 'PlanQuerySet']):
         """Check permissions for a specific plan instance."""
         if action == 'view':
             if not obj.is_active:
-                return user.is_superuser
+                return False
             if user.can_access_public_site(obj):
                 return True
             if obj.features.expose_unpublished_plan_only_to_authenticated_user:

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -298,6 +298,7 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
         only=('features__expose_unpublished_plan_only_to_authenticated_user',),
     )
     def resolve_login_enabled(root: Plan, _info: GQLInfo) -> bool:
+        # This indicates whether signing in may grant access to a restricted plan.
         return root.features.expose_unpublished_plan_only_to_authenticated_user
 
     @staticmethod
@@ -317,15 +318,9 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
         context_hostname = getattr(info.context, '_plan_hostname', None)
         if context_hostname is None:
             return RestrictedPlanNode
-        domains = instance.domains.filter(plan=instance, hostname=context_hostname)
-        first_domain = domains.first()
 
-        if instance.features.expose_unpublished_plan_only_to_authenticated_user is False:
-            if first_domain is None or first_domain.status == PublicationStatus.PUBLISHED:
-                return PlanNode
-            return RestrictedPlanNode
-
-        if first_domain:
+        first_domain = instance.domains.filter(plan=instance, hostname=context_hostname).first()
+        if first_domain is not None:
             override = first_domain.publication_status_override
             if override is not None:
                 if override == PublicationStatus.PUBLISHED:
@@ -2174,6 +2169,8 @@ class Query:
         user = user_or_none(info.context.user)
         result = []
         plan_obj = Plan.objects.get(identifier=plan)
+        if not plan_obj.is_active:
+            return []
         if plan_obj.features.moderation_workflow is None:
             return []
         tasks = plan_obj.get_workflow_tasks()
@@ -2219,9 +2216,14 @@ class Query:
     @staticmethod
     def resolve_plans_for_hostname(_root: Query, info: GQLInfo, hostname: str) -> list[Plan]:
         info.context._plan_hostname = hostname.lower()  # type: ignore
-        plans = Plan.objects.get_queryset().for_hostname(
-            info.context._plan_hostname,
-            request=info.context,  # type: ignore
+        plans = (
+            Plan.objects
+            .get_queryset()
+            .for_hostname(
+                info.context._plan_hostname,
+                request=info.context,  # type: ignore
+            )
+            .filter(is_active=True)
         )
         ret = list(gql_optimizer.query(plans, info))
         req = info.context
@@ -2243,7 +2245,7 @@ class Query:
         user = user_or_none(info.context.user)
         if user is None:
             return []
-        plans = Plan.objects.get_queryset().user_has_staff_role_for(user)
+        plans = Plan.objects.get_queryset().user_has_staff_role_for(user).visible_for_user(user)
         return gql_optimizer.query(plans, info)
 
     @staticmethod

--- a/actions/schema.py
+++ b/actions/schema.py
@@ -259,6 +259,16 @@ def _annotate_shared_pledge_commitment_count(queryset: QuerySet[Pledge]) -> Quer
 T = TypeVar('T', bound=Plan)
 
 
+def _get_plan_domains_for_hostname(plan: Plan, hostname: str) -> list[PlanDomain]:
+    domains_by_hostname: dict[str, list[PlanDomain]] | None = getattr(plan, '_domains_by_hostname', None)
+    if domains_by_hostname is None:
+        domains_by_hostname = {}
+        for domain in plan.domains.all():
+            domains_by_hostname.setdefault(domain.hostname, []).append(domain)
+        plan.__dict__['_domains_by_hostname'] = domains_by_hostname
+    return domains_by_hostname.get(hostname, [])
+
+
 class PlanInterface(graphene.Interface[T], Generic[T]):
     primary_language = graphene.String(required=True)
     published_at = graphene.DateTime()
@@ -279,9 +289,9 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
             hostname = context_hostname
         if not hostname:
             return None
-        explicit_domains = root.domains.filter(plan=root, hostname=hostname).first()
+        explicit_domains = _get_plan_domains_for_hostname(root, hostname)
         if explicit_domains:
-            return explicit_domains
+            return explicit_domains[0]
 
         implicit_domain = PlanDomain(
             plan=root,
@@ -305,13 +315,13 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
     @gql_optimizer.resolver_hints(
         model_field='domains',
     )
-    def resolve_domains(root: Plan, info, hostname=None) -> None | QuerySet[PlanDomain, PlanDomain]:
+    def resolve_domains(root: Plan, info, hostname=None) -> list[PlanDomain] | None:
         context_hostname = getattr(info.context, '_plan_hostname', None)
         if not hostname:
             hostname = context_hostname
             if not hostname:
                 return None
-        return root.domains.filter(plan=root, hostname=hostname)
+        return _get_plan_domains_for_hostname(root, hostname)
 
     @classmethod
     def resolve_type(cls, instance: Plan, info: GQLInfo) -> type[RestrictedPlanNode | PlanNode]:
@@ -319,8 +329,9 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
         if context_hostname is None:
             return RestrictedPlanNode
 
-        first_domain = instance.domains.filter(plan=instance, hostname=context_hostname).first()
-        if first_domain is not None:
+        domains = _get_plan_domains_for_hostname(instance, context_hostname)
+        if domains:
+            first_domain = domains[0]
             override = first_domain.publication_status_override
             if override is not None:
                 if override == PublicationStatus.PUBLISHED:
@@ -338,9 +349,9 @@ class PlanInterface(graphene.Interface[T], Generic[T]):
             hostname = context_hostname
             if not hostname:
                 return None
-        domain = root.domains.filter(plan=root, hostname=hostname).first()
-        if domain is not None:
-            return domain.status_message
+        domains = _get_plan_domains_for_hostname(root, hostname)
+        if domains:
+            return domains[0].status_message
         if root.is_live():
             return None
         with override(root.primary_language):

--- a/actions/tests/test_graphql_plan_is_active.py
+++ b/actions/tests/test_graphql_plan_is_active.py
@@ -13,6 +13,8 @@ from django.utils import timezone
 
 import pytest
 
+from actions.models.plan import PublicationStatus
+
 pytestmark = pytest.mark.django_db
 
 
@@ -40,11 +42,31 @@ PLAN_WITH_IS_ACTIVE_QUERY = """
 PLANS_FOR_HOSTNAME_QUERY = """
     query GetPlansForHostname($hostname: String) {
         plansForHostname(hostname: $hostname) {
+            __typename
             ... on Plan {
                 id
                 identifier
                 name
             }
+        }
+    }
+"""
+
+WORKFLOW_STATES_QUERY = """
+    query GetWorkflowStates($plan: ID!) {
+        workflowStates(plan: $plan) {
+            id
+        }
+    }
+"""
+
+PUBLIC_PLAN_WORKFLOW_STATES_QUERY = """
+    query GetPublicPlanWorkflowStates($hostname: String, $plan: ID!) {
+        plansForHostname(hostname: $hostname) {
+            __typename
+        }
+        workflowStates(plan: $plan) {
+            id
         }
     }
 """
@@ -68,6 +90,60 @@ class TestPlanGraphQLIsActive:
         # Should return None for inactive plan
         assert data['plan'] is None
 
+    def test_superuser_cannot_query_inactive_plan_by_id(self, client, graphql_client_query_data, plan_factory, user_factory):
+        inactive_plan = plan_factory(
+            is_active=False,
+            published_at=timezone.now() - timedelta(days=1),
+        )
+        client.force_login(user_factory(is_superuser=True))
+
+        data = graphql_client_query_data(
+            PLAN_QUERY,
+            variables={'id': inactive_plan.identifier},
+        )
+
+        assert data['plan'] is None
+
+    def test_superuser_cannot_query_inactive_plan_workflow_states(
+        self, client, graphql_client_query_data, plan_factory, user_factory
+    ):
+        inactive_plan = plan_factory(is_active=False)
+        client.force_login(user_factory(is_superuser=True))
+
+        data = graphql_client_query_data(
+            WORKFLOW_STATES_QUERY,
+            variables={'plan': inactive_plan.identifier},
+        )
+
+        assert data['workflowStates'] == []
+
+    def test_anonymous_can_query_workflow_states_for_plan_published_by_domain_override(
+        self,
+        graphql_client_query_data,
+        plan_domain_factory,
+        plan_factory,
+        workflow_factory,
+        workflow_task_factory,
+    ):
+        plan = plan_factory(published_at=None)
+        plan.features.expose_unpublished_plan_only_to_authenticated_user = True
+        workflow = workflow_factory()
+        workflow_task_factory(workflow=workflow)
+        plan.features.moderation_workflow = workflow
+        plan.features.save()
+        domain = plan_domain_factory(
+            plan=plan,
+            publication_status_override=PublicationStatus.PUBLISHED,
+        )
+
+        data = graphql_client_query_data(
+            PUBLIC_PLAN_WORKFLOW_STATES_QUERY,
+            variables={'hostname': domain.hostname, 'plan': plan.identifier},
+        )
+
+        assert data['plansForHostname'][0]['__typename'] == 'Plan'
+        assert data['workflowStates'] == [{'id': 'PUBLISHED'}]
+
     def test_anonymous_can_query_active_plan_by_id(self, graphql_client_query_data, plan_factory):
         """Test that anonymous users can query active published plans by ID."""
         active_plan = plan_factory(
@@ -86,64 +162,57 @@ class TestPlanGraphQLIsActive:
         assert data['plan'] is not None
         assert data['plan']['identifier'] == active_plan.identifier
 
-    # Note: Testing authenticated GraphQL queries requires a more complex setup
-    # with the request context. The permission filtering is tested in the
-    # permission policy tests above.
-
 
 class TestPlansForHostnameGraphQL:
     """Test plansForHostname GraphQL query respects is_active field."""
 
-    def test_plans_for_hostname_excludes_inactive_for_anon(self, graphql_client_query_data, plan_factory, plan_domain_factory):
-        """Test that plansForHostname excludes inactive plans for anonymous users."""
-        active_plan = plan_factory(
-            is_active=True,
-            published_at=timezone.now() - timedelta(days=1),
-        )
+    @pytest.mark.parametrize('user_kind', ['anonymous', 'superuser'])
+    @pytest.mark.parametrize('publication_override', [None, 'PUBLISHED'])
+    def test_plans_for_hostname_excludes_inactive_plan(
+        self,
+        client,
+        graphql_client_query_data,
+        plan_factory,
+        plan_domain_factory,
+        user_factory,
+        user_kind,
+        publication_override,
+    ):
         inactive_plan = plan_factory(
             is_active=False,
             published_at=timezone.now() - timedelta(days=1),
         )
-
-        # Create domains for both plans
-        active_domain = plan_domain_factory(
-            plan=active_plan,
-            hostname='active.example.com',
-        )
         inactive_domain = plan_domain_factory(
             plan=inactive_plan,
             hostname='inactive.example.com',
+            publication_status_override=publication_override,
         )
-
-        # Ensure expose flag allows viewing when active
-        active_plan.features.expose_unpublished_plan_only_to_authenticated_user = False
-        active_plan.features.save()
         inactive_plan.features.expose_unpublished_plan_only_to_authenticated_user = False
         inactive_plan.features.save()
 
-        # Query for active plan
-        active_data = graphql_client_query_data(
-            PLANS_FOR_HOSTNAME_QUERY,
-            variables={'hostname': active_domain.hostname},
-        )
+        if user_kind == 'superuser':
+            client.force_login(user_factory(is_superuser=True))
 
-        assert len(active_data['plansForHostname']) == 1
-        assert active_data['plansForHostname'][0]['identifier'] == active_plan.identifier
-
-        # Query for inactive plan - should return empty or without identifier
-        graphql_client_query_data(
+        data = graphql_client_query_data(
             PLANS_FOR_HOSTNAME_QUERY,
             variables={'hostname': inactive_domain.hostname},
         )
 
-        # NOTE: The actual behavior of plansForHostname with inactive plans
-        # depends on publication_status_override and other factors.
-        # For this test, we just verify that active plans are returned correctly.
-        # The filtering of inactive plans is tested in the permission policy tests.
+        assert data['plansForHostname'] == []
 
-    # Note: Testing authenticated GraphQL queries for plansForHostname requires
-    # a more complex setup. The permission filtering is tested in the permission
-    # policy tests.
+    def test_plans_for_hostname_returns_active_plan(self, graphql_client_query_data, plan_factory, plan_domain_factory):
+        active_plan = plan_factory(
+            is_active=True,
+            published_at=timezone.now() - timedelta(days=1),
+        )
+        active_domain = plan_domain_factory(plan=active_plan, hostname='active.example.com')
+
+        data = graphql_client_query_data(
+            PLANS_FOR_HOSTNAME_QUERY,
+            variables={'hostname': active_domain.hostname},
+        )
+
+        assert data['plansForHostname'][0]['identifier'] == active_plan.identifier
 
 
 class TestPlanIsActiveFieldInSchema:

--- a/actions/tests/test_graphql_plans_for_hostname.py
+++ b/actions/tests/test_graphql_plans_for_hostname.py
@@ -53,6 +53,14 @@ GET_PLANS_BY_HOSTNAME_QUERY_STATUSMESSAGE = """
   }
 """
 
+GET_PLANS_BY_HOSTNAME_QUERY_TYPENAME = """
+  query GetPlansByHostname($hostname: String) {
+    plansForHostname(hostname: $hostname) {
+      __typename
+    }
+  }
+"""
+
 
 @pytest.mark.parametrize(
     ('publication_status_override', 'delta_minutes', 'expected_publication_status', 'redirect_to'),
@@ -112,10 +120,76 @@ def test_get_plans_by_hostname(
             'publishedAt': published_at.isoformat() if published_at else None,
         },
     ]
-    if expected_publication_status == PublicationStatus.PUBLISHED:
+    publication_status_gates_visibility = expose_flag or publication_status_override is not None
+    if expected_publication_status == PublicationStatus.PUBLISHED or not publication_status_gates_visibility:
         expected[0]['identifier'] = plan.identifier
         expected[0]['id'] = plan.identifier
     assert plans == expected
+
+
+@pytest.mark.parametrize(
+    'domain_kind',
+    ['implicit', 'explicit', 'published_override', 'unpublished_override'],
+)
+@pytest.mark.parametrize('publication_state', ['published', 'scheduled', 'unpublished'])
+@pytest.mark.parametrize('user_kind', ['anonymous', 'plan_admin', 'superuser'])
+@pytest.mark.parametrize('expose_flag', [True, False])
+def test_plan_type_respects_publication_visibility(
+    client,
+    graphql_client_query_data,
+    person_factory,
+    plan_domain_factory,
+    plan_factory,
+    settings,
+    user_factory,
+    domain_kind,
+    publication_state,
+    user_kind,
+    expose_flag,
+):
+    published_at = {
+        'published': timezone.now() - timedelta(minutes=5),
+        'scheduled': timezone.now() + timedelta(minutes=5),
+        'unpublished': None,
+    }[publication_state]
+    plan = plan_factory(published_at=published_at)
+    plan.features.expose_unpublished_plan_only_to_authenticated_user = expose_flag
+    plan.features.save()
+
+    override = None
+    if domain_kind == 'implicit':
+        settings.HOSTNAME_PLAN_DOMAINS = ['dummy.io']
+        hostname = f'{plan.identifier}.dummy.io'
+    else:
+        if domain_kind == 'published_override':
+            override = PublicationStatus.PUBLISHED
+        elif domain_kind == 'unpublished_override':
+            override = PublicationStatus.UNPUBLISHED
+        domain = plan_domain_factory(plan=plan, publication_status_override=override)
+        hostname = domain.hostname
+
+    if user_kind == 'plan_admin':
+        person = person_factory(general_admin_plans=[plan])
+        client.force_login(person.user)
+    elif user_kind == 'superuser':
+        client.force_login(user_factory(is_superuser=True))
+
+    data = graphql_client_query_data(
+        GET_PLANS_BY_HOSTNAME_QUERY_TYPENAME,
+        variables={'hostname': hostname},
+    )
+
+    if domain_kind == 'published_override':
+        is_visible = True
+    elif domain_kind == 'unpublished_override':
+        is_visible = False
+    elif not expose_flag or publication_state == 'published':
+        is_visible = True
+    else:
+        is_visible = user_kind in ('plan_admin', 'superuser')
+
+    expected_type = 'Plan' if is_visible else 'RestrictedPlanNode'
+    assert data['plansForHostname'][0]['__typename'] == expected_type
 
 
 @pytest.mark.parametrize(

--- a/actions/tests/test_graphql_plans_for_hostname.py
+++ b/actions/tests/test_graphql_plans_for_hostname.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 import pytest
@@ -125,6 +127,27 @@ def test_get_plans_by_hostname(
         expected[0]['identifier'] = plan.identifier
         expected[0]['id'] = plan.identifier
     assert plans == expected
+
+
+def test_plans_for_hostname_reuses_prefetched_domains(
+    graphql_client_query_data,
+    plan_domain_factory,
+    plan_factory,
+):
+    hostname = 'multi-plan.example.org'
+    plans = [plan_factory() for _ in range(8)]
+    for index, plan in enumerate(plans):
+        plan_domain_factory(plan=plan, hostname=hostname, base_path=f'/plan-{index}')
+
+    with CaptureQueriesContext(connection) as queries:
+        data = graphql_client_query_data(
+            GET_PLANS_BY_HOSTNAME_QUERY,
+            variables={'hostname': hostname},
+        )
+
+    assert len(data['plansForHostname']) == len(plans)
+    plan_domain_queries = [query for query in queries if 'FROM "actions_plandomain"' in query['sql']]
+    assert len(plan_domain_queries) == 2
 
 
 @pytest.mark.parametrize(

--- a/actions/tests/test_plan_is_active.py
+++ b/actions/tests/test_plan_is_active.py
@@ -94,9 +94,22 @@ class TestPlanPermissionPolicy:
         inactive_plan = plan_factory(is_active=False, published_at=timezone.now())
         policy = PlanPermissionPolicy(Plan)
 
-        has_perm = policy.anon_has_perm('view', inactive_plan)
+        has_perm = policy.user_has_permission_for_instance(AnonymousUser(), 'view', inactive_plan)
 
         assert has_perm is False
+
+    def test_inactive_plan_with_publication_gate_disabled_is_not_visible(self, plan_factory):
+        inactive_plan = plan_factory(is_active=False)
+        inactive_plan.features.expose_unpublished_plan_only_to_authenticated_user = False
+        inactive_plan.features.save()
+
+        assert inactive_plan.is_visible_for_user(AnonymousUser()) is False
+
+    def test_inactive_plan_is_not_publicly_visible_to_superuser(self, plan_factory, user_factory):
+        inactive_plan = plan_factory(is_active=False)
+        superuser = user_factory(is_superuser=True)
+
+        assert inactive_plan.is_visible_for_user(superuser) is False
 
     def test_anonymous_can_view_active_plan(self, plan_factory):
         """Test that anonymous users can view active published plans."""
@@ -120,24 +133,21 @@ class TestPlanPermissionPolicy:
         inactive_plan = plan_factory(is_active=False, published_at=timezone.now())
 
         policy = PlanPermissionPolicy(Plan)
-        q = policy.construct_perm_q_anon('view')
-
-        assert q is not None
-        filtered_plans = Plan.objects.filter(q)
+        filtered_plans = policy.filter_by_perm(Plan.objects.all(), AnonymousUser(), 'view')
 
         assert active_plan in filtered_plans or not active_plan.features.expose_unpublished_plan_only_to_authenticated_user
         assert inactive_plan not in filtered_plans
 
-    def test_superuser_can_view_inactive_plan(self, plan_factory, user_factory):
-        """Test that superusers can view inactive plans."""
+    def test_permission_policy_blocks_inactive_plan_for_superuser(self, plan_factory, user_factory):
+        """State-level permission blocks apply before the superuser shortcut."""
         inactive_plan = plan_factory(is_active=False, published_at=timezone.now())
         superuser = user_factory(is_superuser=True)
 
         policy = PlanPermissionPolicy(Plan)
 
-        has_perm = policy.user_has_perm(superuser, 'view', inactive_plan)
+        has_perm = policy.user_has_permission_for_instance(superuser, 'view', inactive_plan)
 
-        assert has_perm is True
+        assert has_perm is False
 
     def test_non_superuser_cannot_view_inactive_plan(self, plan_factory, user_factory):
         """Test that non-superusers cannot view inactive plans they don't admin."""
@@ -146,7 +156,7 @@ class TestPlanPermissionPolicy:
 
         policy = PlanPermissionPolicy(Plan)
 
-        has_perm = policy.user_has_perm(regular_user, 'view', inactive_plan)
+        has_perm = policy.user_has_permission_for_instance(regular_user, 'view', inactive_plan)
 
         assert has_perm is False
 
@@ -184,8 +194,8 @@ class TestPlanPermissionPolicy:
         # Regular user should not see inactive plan
         assert inactive_plan not in visible_plans
 
-    def test_filter_by_perm_includes_inactive_for_superuser(self, plan_factory, user_factory):
-        """Test that visible_for_user() includes inactive plans for superusers."""
+    def test_visible_for_user_excludes_inactive_for_superuser(self, plan_factory, user_factory):
+        """Public visibility excludes inactive plans even for superusers."""
         active_plan = plan_factory(is_active=True, published_at=timezone.now())
         inactive_plan = plan_factory(is_active=False, published_at=timezone.now())
 
@@ -194,4 +204,4 @@ class TestPlanPermissionPolicy:
         visible_plans = Plan.objects.qs.visible_for_user(superuser)
 
         assert active_plan in visible_plans
-        assert inactive_plan in visible_plans
+        assert inactive_plan not in visible_plans


### PR DESCRIPTION
Disabling expose_unpublished_plan_only_to_authenticated_user did not make an unpublished plan public when its hostname had an explicit PlanDomain. PlanInterface returned RestrictedPlanNode from the domain status branch before consulting the plan permission policy, so the disabled flag was effectively ignored.

Let explicit publication status overrides retain precedence, then delegate ordinary publication visibility to Plan.is_visible_for_user. Keep loginEnabled tied to whether authentication may grant access to a restricted plan.

Centralize inactive-plan view restrictions in PlanPermissionPolicy. Apply the restriction as both an instance permission block and a queryset state filter so it precedes superuser shortcuts, while Wagtail's separate administrative queryset can still expose inactive plans to superusers. Filter inactive plans out of hostname and staff-plan GraphQL queries and guard the workflow-state resolver.

Add a visibility matrix covering implicit and explicit domains, publication states, authentication roles, feature-flag values, and domain overrides. Add regression coverage ensuring inactive plans are absent from GraphQL even for superusers or with a published domain override.
