### PR TITLE
Add Photovoltaik-Zubau Kloten to embed allowlist

### DIFF
--- a/aplans/settings.py
+++ b/aplans/settings.py
@@ -708,7 +708,7 @@ WAGTAILEMBEDS_FINDERS = [
     {
         'class': f'{PROJECT_NAME}.wagtail_embed_finders.GenericFinder',
         # If we leave the provider out, the "default" provider will be used
-        'domain_whitelist': ('public.tableau.com', 'tableau.minneapolismn.gov','tableaupub.kingcounty.gov'),
+        'domain_whitelist': ('public.tableau.com', 'tableau.minneapolismn.gov', 'tableaupub.kingcounty.gov'),
         'title': 'Chart',
     },
     {
@@ -752,6 +752,12 @@ WAGTAILEMBEDS_FINDERS = [
         # If we leave the provider out, the "default" provider will be used
         'domain_whitelist': ('kraftwerk-unterland.ch',),
         'title': 'Kraftwerk-Unterland',
+    },
+    {
+        'class': f'{PROJECT_NAME}.wagtail_embed_finders.GenericFinder',
+        # If we leave the provider out, the "default" provider will be used
+        'domain_whitelist': ('pv-kloten-zeitreise.pplx.app',),
+        'title': 'Photovoltaik-Zubau Kloten',
     },
 ]
 WAGTAIL_SITE_NAME = 'Kausal Watch'


### PR DESCRIPTION
## Description
Add Photovoltaik-Zubau Kloten to embed allowlist

## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://app.asana.com/1/1201243246741462/inbox/1206692847418444/item/1216767460985906/story/1217107149936729

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [ ] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    Tested, but ran into: "Framing 'https://pv-kloten-zeitreise.pplx.app/' violates the following Content Security Policy directive: "frame-ancestors 'none'". The request has been blocked.". The client will have to allowlist the final url where this embed will be shown.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
