### PR TITLE
Fix copy plan revision side effects

### DIFF
--- a/actions/models/category.py
+++ b/actions/models/category.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, Self, cast
 
 import reversion
@@ -56,6 +57,13 @@ if TYPE_CHECKING:
     from ..attributes import AttributeFieldPanel
     from .action import Action, ActionCategoryThrough, ActionQuerySet
     from .attributes import AttributeTypeQuerySet
+
+
+# When set, `Category.save` and `CategoryType.save` skip the `synchronize_pages()` side effect
+# even if the caller doesn't pass `skip_page_synchronization=True`. This is used by plan copying
+# to prevent Wagtail's `save_revision` (which internally calls `self.save(update_fields=[...])`
+# with no way to forward custom kwargs) from minting duplicate page trees.
+skip_page_synchronization_ctx: ContextVar[bool] = ContextVar('skip_page_synchronization_ctx', default=False)
 
 
 class CategoryTypeBase(models.Model):
@@ -277,7 +285,8 @@ class CategoryType(
     @transaction.atomic
     def save(self, *args, skip_page_synchronization=False, **kwargs):
         super().save(*args, **kwargs)
-        if self.synchronize_with_pages and not skip_page_synchronization:
+        skip = skip_page_synchronization or skip_page_synchronization_ctx.get()
+        if self.synchronize_with_pages and not skip:
             self.synchronize_pages()
 
     def clean(self):
@@ -687,7 +696,8 @@ class Category(ModelWithAttributes, CategoryBase, ClusterableModel, PlanRelatedM
     @transaction.atomic()
     def save(self, *args, skip_page_synchronization=False, **kwargs):
         super().save(*args, **kwargs)
-        if self.type.synchronize_with_pages and not skip_page_synchronization:
+        skip = skip_page_synchronization or skip_page_synchronization_ctx.get()
+        if self.type.synchronize_with_pages and not skip:
             # We need to synchronize multiple page trees if there are multiple languages
             if self.parent:
                 parent_pages = self.parent.category_pages.all()

--- a/copying/main.py
+++ b/copying/main.py
@@ -37,7 +37,7 @@ from kausal_common.datasets.models import (
 
 from actions.models.action import Action
 from actions.models.attributes import AttributeType
-from actions.models.category import Category, CategoryType, CommonCategory, CommonCategoryType
+from actions.models.category import Category, CategoryType, CommonCategory, CommonCategoryType, skip_page_synchronization_ctx
 from actions.models.features import PlanFeatures
 from actions.models.plan import Plan
 from actions.models.pledge import Pledge
@@ -1618,6 +1618,25 @@ def _new_site_hostname(old_plan: Plan, new_plan_identifier: str) -> str:
 
 
 @contextmanager
+def _default_skip_page_synchronization() -> Generator[None]:
+    """
+    Make `Category.save` and `CategoryType.save` skip `synchronize_pages()` for this context.
+
+    Wagtail's `save_revision` calls `self.save(update_fields=[...])` internally without any
+    way to forward `skip_page_synchronization=True`, which would otherwise trigger
+    `synchronize_pages()` and grow duplicate CategoryTypePage/CategoryPage trees during
+    plan copy. The two `save` methods consult `skip_page_synchronization_ctx` and treat it
+    as an implicit skip flag; setting it here is safe under concurrency (contextvars are
+    per-async-task / per-thread) and nests correctly.
+    """
+    token = skip_page_synchronization_ctx.set(True)
+    try:
+        yield
+    finally:
+        skip_page_synchronization_ctx.reset(token)
+
+
+@contextmanager
 def _update_reference_index_immediately_ctx() -> Generator[None]:
     """
     Force immediate update of Wagtail's reference index for the duration of this context.
@@ -1891,7 +1910,7 @@ def copy_plan(
         supersede_original_actions=supersede_original_actions,
     )
 
-    with transaction.atomic():
+    with _default_skip_page_synchronization(), transaction.atomic():
         return _clone_plan_objects(plan, clone_visitor, root_page_title_suffix, copy_indicators)
 
 

--- a/copying/main.py
+++ b/copying/main.py
@@ -1222,7 +1222,12 @@ class UpdateReferencesVisitor(AbstractVisitor):
         assert isinstance(manager, Manager)
         # Create `from_object._cluster_related_objects`
         manager.get_object_list()  # type: ignore[attr-defined]
-        referencing_object = manager.get(id=id)
+        try:
+            referencing_object = manager.get(id=id)
+        except source_field.related_model.DoesNotExist:  # type: ignore[attr-defined]
+            # The parent's cluster snapshot (from a stale revision) can lag the current DB.
+            # The reference index is authoritative about which child PK exists right now.
+            referencing_object = source_field.related_model.objects.get(id=id)  # type: ignore[attr-defined]
         # Make sure we only update copies
         assert self.clone_visitor.is_copy(referencing_object)
         child_field_name, *child_content_path = content_path_rest

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -22,6 +22,7 @@ from actions.tests.factories import (
     ActionContactFactory,
     ActionStatusFactory,
     ActionTaskFactory,
+    AttributeChoiceFactory,
     AttributeChoiceWithTextFactory,
     AttributeRichTextFactory,
     AttributeTypeChoiceOptionFactory,
@@ -833,6 +834,19 @@ def test_model_without_revision_is_not_affected(plan_with_pages, action):
     plan_copy = copy_plan(plan_with_pages)
     action_copy = plan_copy.actions.get()
     assert action_copy.latest_revision is None
+
+
+def test_attribute_type_revision_with_stale_snapshot_can_be_copied(plan_with_pages, category, user):
+    attribute_type = AttributeTypeFactory.create(
+        scope=plan_with_pages,
+        object_content_type=ContentType.objects.get_for_model(Category),
+        format=AttributeType.AttributeFormat.ORDERED_CHOICE,
+    )
+    attribute_type.save_revision(user=user)
+    option = AttributeTypeChoiceOptionFactory.create(type=attribute_type)
+    AttributeChoiceFactory.create(type=attribute_type, choice=option, content_object=category)
+
+    copy_plan(plan_with_pages)
 
 
 def test_copying_repairs_impossible_draft_state_without_revision(plan_with_pages, action):

--- a/copying/tests/test_copying.py
+++ b/copying/tests/test_copying.py
@@ -836,6 +836,22 @@ def test_model_without_revision_is_not_affected(plan_with_pages, action):
     assert action_copy.latest_revision is None
 
 
+@pytest.mark.parametrize('category_type__synchronize_with_pages', [True])
+def test_category_type_with_revision_and_page_sync_does_not_duplicate_pages(
+    plan_with_pages, category_type, category, category_level, user
+):
+    category_type.save_revision(user=user)
+    source_ct_page_count = category_type.category_type_pages.count()
+    source_cat_page_count = category.category_pages.count()
+
+    plan_copy = copy_plan(plan_with_pages)
+
+    ct_copy = plan_copy.category_types.get()
+    cat_copy = ct_copy.categories.get()
+    assert ct_copy.category_type_pages.count() == source_ct_page_count
+    assert cat_copy.category_pages.count() == source_cat_page_count
+
+
 def test_attribute_type_revision_with_stale_snapshot_can_be_copied(plan_with_pages, category, user):
     attribute_type = AttributeTypeFactory.create(
         scope=plan_with_pages,


### PR DESCRIPTION
## Description
Fix two side effects of copying models with a latest_revision

Copying a plan re-saves each copied model's latest revision to remap references. Two side effects of that re-save were breaking copies of certain plans:

  1. AttributeChoice.DoesNotExist (Sentry WATCH-BACKEND-BQD): when a revision snapshot lags the current DB (e.g. revision saved before children existed), the deserialized cluster on the parent can't find the child PK the reference index points at. Fall back to a direct DB lookup, which is what the reference index reflects.
  2. Duplicate CategoryTypePage / CategoryPage trees: Wagtail's save_revision internally calls self.save(update_fields=['latest_revision']) with no way to forward skip_page_synchronization=True. On a CategoryType with synchronize_with_pages=True, this triggers synchronize_pages() and mints a whole duplicate page subtree, later failing validate_unique with "This category already has a page". Wrap copy_plan in a context manager that defaults Category.save/CategoryType.save to skip synchronization for the copy's duration.


## Screenshots/Videos (if applicable)
Add screenshots or videos demonstrating the changes if applicable.

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
Any additional information that reviewers should know about this PR.

------

## ✅ Pre-Merge Checklist

### Type of Change
- [x] Set the PR's label to match the nature of this change

### Testing
- [x] **Built Unit tests** (unit tests added/updated)
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Authorization is tested** (permissions and access controls verified)
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Integrations (if applicable)
If there are model changes to models which use any of the features below, verify the new models work together with the features.
For example, when adding a new model, verify the new model instances are copied when copying a plan.
- [ ] **Moderation** integration implemented
- [ ] **Reporting** integration implemented
- [ ] **Copy plan feature** integration implemented
- [ ] **Umbrella plan structure** integration implemented

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
